### PR TITLE
Add canonical test entry points

### DIFF
--- a/UnitTests/README.md
+++ b/UnitTests/README.md
@@ -8,8 +8,30 @@
 - `EtaTrueOperationToolboxUnavailable.m` is a test double used to exercise the no-Optimization-Toolbox path.
 - `IsSameSolutionAs.m` provides a custom test constraint.
 - `private/` contains functions shared by formal tests without placing them on the public test path.
-- `RunAllUnitTests.m` is the existing compatibility runner. Canonical test categories and entry points will be added separately.
+- `RunAllUnitTests.m` is a compatibility wrapper for the canonical full test task.
 
 Interactive investigations, scratch scripts, plots, and historical comparisons belong in [DeveloperExperiments](../DeveloperExperiments/). Profiling and timing scripts belong in [Benchmarks](../Benchmarks/). Those authoring folders are not part of automated discovery or the runtime package path.
 
 Do not place section-based scripts with test-like filenames in this folder because MATLAB may discover their sections as automated tests.
+
+## Running tests
+
+Run test categories from the repository root with MATLAB's build tool:
+
+```matlab
+buildtool test:smoke
+buildtool test:full
+buildtool test:exhaustive
+buildtool test:optional
+```
+
+Running `buildtool` without a task runs the smoke category. `RunAllUnitTests` delegates to `buildtool test:full` and may be invoked from any working directory.
+
+Every formal test method declares exactly one primary tag:
+
+- `smoke` provides fast, representative development feedback. Smoke tests are also included in full execution.
+- `full` contains the remaining deterministic tests that do not require optional dependencies or exhaustive parameter sweeps.
+- `exhaustive` contains large numerical parameter matrices, including spectral differentiation combinations.
+- `optional` requires a declared optional dependency. The current optional category exercises the supported Optimization Toolbox path; unavailable dependencies produce an incomplete, unsuccessful run.
+
+Any failed or incomplete test makes its build task unsuccessful. Full and exhaustive discovery also check declared test metadata so a class or method cannot be silently omitted.

--- a/UnitTests/RunAllUnitTests.m
+++ b/UnitTests/RunAllUnitTests.m
@@ -1,27 +1,2 @@
-import matlab.unittest.plugins.CodeCoveragePlugin
-import matlab.unittest.plugins.codecoverage.CoverageResult
-
-runner = testrunner("textoutput");
-% format = CoverageResult();
-% plugin = CodeCoveragePlugin.forFile("../FlowComponents/WVGeostrophicMethods.m",Producing=format);
-% runner.addPlugin(plugin)
-
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestSpectralDifferentiationXY);
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestSpectralDifferentiationZ);
-diffTest = matlab.unittest.TestSuite.fromClass(?TestOrthogonalSolutionGroups);
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestRadialTransformation);
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestWVTransformInitialization);
-% 
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestNonlinearFlux);
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestInertialOscillationMethods);
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestGeostrophicMethods);
-% diffTest = matlab.unittest.TestSuite.fromClass(?TestInternalGravityWaveMethods);
-result = runner.run(diffTest);
-
-% generateHTMLReport(result);
-% generateHTMLReport(format.Result);
-rt = table(result)
-
-% suite = matlab.unittest.TestSuite.fromFile('TestSpectralDifferentiation.m');
-% {suite.Name}'
-% suite.run
+repositoryRoot = fileparts(fileparts(mfilename("fullpath")));
+buildtool("test:full","-buildFile",fullfile(repositoryRoot,"buildfile.m"));

--- a/UnitTests/TestDivergence.m
+++ b/UnitTests/TestDivergence.m
@@ -1,6 +1,6 @@
 classdef TestDivergence < matlab.unittest.TestCase
 
-    methods (Test)
+    methods (Test, TestTags = "smoke")
         function testDivergence(self)
             Lxyz = [1000, 500, 500];
             Nxyz = [16 8 9];

--- a/UnitTests/TestEtaTrueOperation.m
+++ b/UnitTests/TestEtaTrueOperation.m
@@ -1,6 +1,6 @@
 classdef TestEtaTrueOperation < matlab.unittest.TestCase
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testTransformsRegisterRhoNmWithoutPersistingFlag(testCase)
             testCase.verifyTrue(ismember('rho_nm',WVTransformConstantStratification.namesOfTransformVariables()));
             testCase.verifyTrue(ismember('rho_nm',WVTransformHydrostatic.namesOfTransformVariables()));
@@ -45,8 +45,12 @@ classdef TestEtaTrueOperation < matlab.unittest.TestCase
             expectedEtaTrue = TestEtaTrueOperation.etaTrueForProfile(wvt,wvt.rho_nm0);
             testCase.verifyEqual(eta_true,expectedEtaTrue,AbsTol=1e-12);
         end
+    end
 
+    methods (Test, TestTags = ["optional","optimization-toolbox"])
         function testEtaTrueUsesRegisteredRhoNmWhenRequested(testCase)
+            testCase.assumeTrue(WVNoMotionProfileOperation.hasOptimizationToolboxSupport(),"Optimization Toolbox is required for this optional test.");
+
             wvt = TestEtaTrueOperation.hydrostaticTransform();
             wvt.shouldUseTrueNoMotionProfile = true;
             rho_nm = TestEtaTrueOperation.testRhoNmProfile(wvt);
@@ -62,7 +66,9 @@ classdef TestEtaTrueOperation < matlab.unittest.TestCase
             testCase.verifyEqual(eta_true,expectedEtaTrue,AbsTol=1e-12);
             testCase.verifyGreaterThan(max(abs(eta_true(:) - defaultEtaTrue(:))),1e-8);
         end
+    end
 
+    methods (Test, TestTags = "full")
         function testEtaTrueDoesNotWarnWhenUsingRhoNm0(testCase)
             wvt = TestEtaTrueOperation.hydrostaticTransform();
             wvt.addOperation(EtaTrueOperationToolboxUnavailable(wvt), ...

--- a/UnitTests/TestFlowComponentSurfaceDiagnostics.m
+++ b/UnitTests/TestFlowComponentSurfaceDiagnostics.m
@@ -41,7 +41,7 @@ classdef TestFlowComponentSurfaceDiagnostics < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "smoke")
         function testRegistrationAddsStandardVariables(testCase)
             testCase.verifyTrue(ismember("balanced",testCase.wvt.flowComponentNames));
             expectedNames = ["u_balanced","v_balanced","w_balanced","eta_balanced","p_balanced","ssh_balanced","ssu_balanced","ssv_balanced"];

--- a/UnitTests/TestFourierTransformXY.m
+++ b/UnitTests/TestFourierTransformXY.m
@@ -4,12 +4,8 @@ classdef TestFourierTransformXY < matlab.unittest.TestCase
     end
 
     properties (ClassSetupParameter)
-        %transform = {'constant','hydrostatic','boussinesq'};
-        % Lxyz = struct('Lxyz',[1 10 4]);
         Nxyz = struct('Nx16Ny16Nz9',[16 16 9]);
-        % transform = {'hydrostatic'};
         Lxyz = struct('Lxyz',[1000, 500, 500]);
-        % Nxyz = struct('Nx32N16Nz17',[32 16 17]);
         transform = {'hydrostatic'};
     end
 
@@ -44,7 +40,7 @@ classdef TestFourierTransformXY < matlab.unittest.TestCase
         l_n
     end
 
-    methods (Test)
+    methods (Test, TestTags = "smoke")
         function testForwardBackwardTransform(testCase,k_n,l_n)
             [X,Y,Z] = testCase.wvt.xyzGrid;
             Lx = testCase.wvt.Lx;

--- a/UnitTests/TestGeostrophicMethods.m
+++ b/UnitTests/TestGeostrophicMethods.m
@@ -7,8 +7,6 @@ classdef TestGeostrophicMethods < matlab.unittest.TestCase
     properties (ClassSetupParameter)
         Lxyz = struct('Lxyz',[750e3, 750e3, 1300]);
         Nxyz = struct('Nx64Ny64Nz30',[64 64 40]);
-        % Nxyz = struct('Nx16Ny16Nz5',[16 16 5]);
-        % transform = {'constant','hydrostatic','boussinesq'};
         transform = {'hydrostatic'};
     end
 
@@ -27,7 +25,7 @@ classdef TestGeostrophicMethods < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testRemoveAllGeostrophicMotions(self)
             % In this test we intialize with a random flow state, confirm
             % that both total energy and geostrophic energy are present,

--- a/UnitTests/TestInertialOscillationMethods.m
+++ b/UnitTests/TestInertialOscillationMethods.m
@@ -7,8 +7,6 @@ classdef TestInertialOscillationMethods < matlab.unittest.TestCase
     properties (ClassSetupParameter)
         Lxyz = struct('Lxyz',[15e3, 15e3, 1300]);
         Nxyz = struct('Nx8Ny8Nz5',[8 8 30]);
-        % Nxyz = struct('Nx16Ny16Nz5',[16 16 5]);
-        % transform = {'constant','hydrostatic','boussinesq'};
         transform = {'hydrostatic'};
     end
 
@@ -27,7 +25,7 @@ classdef TestInertialOscillationMethods < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testRemoveAllInertialMotions(self)
             % In this test we intialize with a random flow state, confirm
             % that both total energy and inertial energy are present,

--- a/UnitTests/TestInternalGravityWaveMethods.m
+++ b/UnitTests/TestInternalGravityWaveMethods.m
@@ -5,12 +5,8 @@ classdef TestInternalGravityWaveMethods < matlab.unittest.TestCase
     end
 
     properties (ClassSetupParameter)
-        % Lxyz = struct('Lxyz',[750e0, 750e0, 375]);
         Lxyz = struct('Lxyz',[750e2, 750e2, 1300]);
-        %Nxyz = struct('Nx64Ny64Nz30',[64 64 32]);
-        % Nxyz = struct('Nx16Ny16Nz5',[16 16 5]);
         Nxyz = struct('Nx32Ny32Nz10',2*[16 16 5]);
-        %transform = {'constant','hydrostatic','boussinesq'};
         transform = {'hydrostatic'};
     end
 
@@ -28,7 +24,7 @@ classdef TestInternalGravityWaveMethods < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testRemoveAllWaves(self)
             % In this test we intialize with a random flow state, confirm
             % that both total energy and geostrophic energy are present,

--- a/UnitTests/TestInterpolatedFieldAtPosition.m
+++ b/UnitTests/TestInterpolatedFieldAtPosition.m
@@ -31,7 +31,7 @@ classdef TestInterpolatedFieldAtPosition < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "smoke")
         function testTwoDimensionalLinearInterpolation(testCase)
             [x,y] = testCase.horizontalQueryPoints();
 

--- a/UnitTests/TestNetCDF.m
+++ b/UnitTests/TestNetCDF.m
@@ -22,7 +22,7 @@ classdef TestNetCDF < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testAddDimension(testCase)
             testCase.verifyWarningFree(@() testCase.ncfile.addDimension('x',testCase.x) );
         end

--- a/UnitTests/TestNetCDFHandleOwnership.m
+++ b/UnitTests/TestNetCDFHandleOwnership.m
@@ -26,7 +26,7 @@ classdef TestNetCDFHandleOwnership < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function oneOutputRestorationClosesFile(testCase)
             wvt = WVTransform.waveVortexTransformFromFile(char(testCase.transformPath));
             testCase.verifyClass(wvt,"WVTransformConstantStratification")

--- a/UnitTests/TestNonlinearFlux.m
+++ b/UnitTests/TestNonlinearFlux.m
@@ -5,13 +5,7 @@ classdef TestNonlinearFlux < matlab.unittest.TestCase
 
     properties (ClassSetupParameter)
         Lxyz = struct('Lxyz',[4e3, 4e3, 2e3]);
-        % Nxyz = struct('Nx8Ny8Nz5',[8 8 5]);
         Nxyz = struct('Nx16Ny16Nz9',[16 16 9]);
-        %transform = {'constant','hydrostatic','boussinesq'};
-        % transform = {'constant-hydrostatic','constant-boussinesq','hydrostatic','boussinesq'};
-        % transform = {'constant-hydrostatic','constant-boussinesq'};
-        % transform = {'boussinesq'};
-        % transform = {'hydrostatic'};
         transform = {'hydrostatic-exp'};
     end
 
@@ -35,7 +29,7 @@ classdef TestNonlinearFlux < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         % function testNonlinearFlux(self)
         %     wvt = self.wvt_;
         %     wvt.initWithRandomFlow();

--- a/UnitTests/TestOrthogonalSolutionGroups.m
+++ b/UnitTests/TestOrthogonalSolutionGroups.m
@@ -5,19 +5,10 @@ classdef TestOrthogonalSolutionGroups < matlab.unittest.TestCase
     end
 
     properties (ClassSetupParameter)
-        % Lxyz = struct('Lxyz',[15e3, 15e3, 1300]);
         Nxyz = struct('Nx8Ny8Nz5',[8 8 5]);
-        % Nxyz = struct('Nx16Ny16Nz5',[16 16 5]);
-        % Nxyz = struct('Nx16Ny16Nz16',[16 16 16]);
-        % transform = {'constant','hydrostatic','boussinesq'};
         Lxyz = struct('Lxyz',[1000, 500, 500]);
-        % Nxyz = struct('Nx16Ny8Nz9',[16 8 9]);
-        % Nxyz = struct('Nx32N16Nz17',[32 16 17]);
-        % transform = {'hydrostatic','constant'};
-        % transform = {'hydrostatic','constant-hydrostatic','constant-boussinesq'};
         transform = {'boussinesq'};
         orthogonalSolutionGroup = {'WVInertialOscillationComponent','WVMeanDensityAnomalyComponent','WVInternalGravityWaveComponent','WVGeostrophicComponent'}
-        % orthogonalSolutionGroup = {'WVInternalGravityWaveComponent'}
     end
 
     methods (TestClassSetup)
@@ -81,7 +72,7 @@ classdef TestOrthogonalSolutionGroups < matlab.unittest.TestCase
         solutionIndex
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testSolution(self,solutionIndex)
             self.wvt.t=0;
             args = {self.wvt.X,self.wvt.Y,self.wvt.Z,self.wvt.t};

--- a/UnitTests/TestRadialTransformation.m
+++ b/UnitTests/TestRadialTransformation.m
@@ -29,7 +29,7 @@ classdef TestRadialTransformation < matlab.unittest.TestCase
         flowComponent = {'geostrophic','mda','wave','inertial'}
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testRadialWavenumberVariance(self,flowComponent)
             self.wvt.initWithRandomFlow(flowComponent);
             varianceMatrix = abs(self.wvt.Ap).^2 + abs(self.wvt.Am).^2 + abs(self.wvt.A0).^2;

--- a/UnitTests/TestRandomFlow.m
+++ b/UnitTests/TestRandomFlow.m
@@ -5,16 +5,9 @@ classdef TestRandomFlow < matlab.unittest.TestCase
     end
 
     properties (ClassSetupParameter)
-        % Lxyz = struct('Lxyz',[15e3, 15e3, 1300]);
-        % Nxyz = struct('Nx8Ny8Nz5',[8 8 5]);
-        % Nxyz = struct('Nx16Ny16Nz5',[16 16 5]);
-        % transform = {'constant','hydrostatic','boussinesq'};
         Lxyz = struct('Lxyz',[1000, 500, 500]);
         Nxyz = struct('Nx16Ny8Nz9',[16 8 9]);
-        % Nxyz = struct('Nx32N16Nz17',[32 16 17]);
         transform = {'constant'};
-        % orthogonalSolutionGroup = {'WVInertialOscillationComponent','WVMeanDensityAnomalyComponent','WVInternalGravityWaveComponent','WVGeostrophicComponent'}
-        % flowComponent = {'WVMeanDensityAnomalyComponent'}
     end
 
     methods (TestClassSetup)
@@ -51,7 +44,7 @@ classdef TestRandomFlow < matlab.unittest.TestCase
         flowComponent
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testSolution(self,flowComponent)
             self.wvt.initWithRandomFlow(flowComponent,uvMax=0.1);
             self.verifyEqual(self.wvt.totalEnergy,self.wvt.totalEnergySpatiallyIntegrated, "AbsTol",1e-7,"RelTol",1e-7);

--- a/UnitTests/TestSpectralDifferentiationXY.m
+++ b/UnitTests/TestSpectralDifferentiationXY.m
@@ -4,12 +4,8 @@ classdef TestSpectralDifferentiationXY < matlab.unittest.TestCase
     end
 
     properties (ClassSetupParameter)
-        %transform = {'constant','hydrostatic','boussinesq'};
-        % Lxyz = struct('Lxyz',[1 10 4]);
         Nxyz = struct('Nx16Ny16Nz9',[16 16 9]);
-        % transform = {'hydrostatic'};
         Lxyz = struct('Lxyz',[1000, 500, 500]);
-        % Nxyz = struct('Nx32N16Nz17',[32 16 17]);
         transform = {'hydrostatic'};
     end
 
@@ -41,12 +37,11 @@ classdef TestSpectralDifferentiationXY < matlab.unittest.TestCase
 
     properties (TestParameter)
         derivative = struct('first',1,'second',2,'third',3,'fourth',4);
-        % derivative = struct('second',2,'third',3,'fourth',4);
         k_n
         l_n
     end
 
-    methods (Test)
+    methods (Test, TestTags = "exhaustive")
         function testDiffX(testCase,derivative,k_n,l_n)
             [X,Y,Z] = testCase.wvt.xyzGrid;
             Lx = testCase.wvt.Lx;

--- a/UnitTests/TestSpectralDifferentiationZ.m
+++ b/UnitTests/TestSpectralDifferentiationZ.m
@@ -4,10 +4,6 @@ classdef TestSpectralDifferentiationZ < matlab.unittest.TestCase
     end
 
     properties (ClassSetupParameter)
-        % transform = {'constant','hydrostatic','boussinesq'};
-        % Lxyz = struct('Lxyz',[1 10 4]);
-        % Nxyz = struct('Nx16Ny16Nz9',[16 16 9]);
-        % transform = {'constant','hydrostatic','boussinesq'};
         Lxyz = struct('Lxyz',[1000, 500, 500]);
         Nxyz = struct('Nx32N16Nz17',[32 16 17]);
         transform = {'hydrostatic'};
@@ -44,13 +40,12 @@ classdef TestSpectralDifferentiationZ < matlab.unittest.TestCase
 
     properties (TestParameter)
         derivative = struct('first',1,'second',2,'third',3,'fourth',4);
-        %derivative = struct('first',1);
         k_n
         l_n
         m_n
     end
 
-    methods (Test)
+    methods (Test, TestTags = "exhaustive")
         function testDiffZF(self,derivative,k_n,m_n)
             [X,Y,Z] = self.wvt.xyzGrid;
 

--- a/UnitTests/TestTraditionalDamping.m
+++ b/UnitTests/TestTraditionalDamping.m
@@ -18,7 +18,7 @@ classdef TestTraditionalDamping < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "smoke")
         function verticalDampingSupportsConstantStratification(testCase)
             for isHydrostatic = [true false]
                 wvt = TestTraditionalDamping.constantTransform(isHydrostatic=isHydrostatic,shouldAntialias=false);

--- a/UnitTests/TestWVPseudoTopographicWaveGeneration.m
+++ b/UnitTests/TestWVPseudoTopographicWaveGeneration.m
@@ -8,7 +8,7 @@ classdef TestWVPseudoTopographicWaveGeneration < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function darwinSymbolsSelectFrequency(testCase)
             wvt = TestWVPseudoTopographicWaveGeneration.createTransform(false);
             terrain = TestWVPseudoTopographicWaveGeneration.sinusoidalTopography(wvt,50);

--- a/UnitTests/TestWVPseudoTopographicWaveGenerationProduction.m
+++ b/UnitTests/TestWVPseudoTopographicWaveGenerationProduction.m
@@ -8,7 +8,7 @@ classdef TestWVPseudoTopographicWaveGenerationProduction < matlab.unittest.TestC
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function variableStratificationMatchesOracleAndIdentities(testCase)
             previousRandomState = rng;
             randomStateCleanup = onCleanup(@()rng(previousRandomState));

--- a/UnitTests/TestWVTransformInitialization.m
+++ b/UnitTests/TestWVTransformInitialization.m
@@ -4,7 +4,7 @@ classdef TestWVTransformInitialization < matlab.unittest.TestCase
         latitude = {0,5,10,90}
     end
 
-    methods (Test)
+    methods (Test, TestTags = "full")
         function testInitWithLatitude(testCase,latitude)
             if latitude < 5
             testCase.verifyError(@() WVTransformConstantStratification([15e3, 15e3, 5000], [8 8 5],latitude=latitude),'MATLAB:validators:mustBeGreaterThanOrEqual' );

--- a/UnitTests/TestWVTransformVersion.m
+++ b/UnitTests/TestWVTransformVersion.m
@@ -1,6 +1,6 @@
 classdef TestWVTransformVersion < matlab.unittest.TestCase
 
-    methods (Test)
+    methods (Test, TestTags = "smoke")
         function testVersionMatchesPackageManifest(testCase)
             wvt = TestWVTransformVersion.barotropicTransform();
             expectedVersion = TestWVTransformVersion.packageVersionFromManifest();

--- a/UnitTests/TestWaveModeVerticalStructureAtIndex.m
+++ b/UnitTests/TestWaveModeVerticalStructureAtIndex.m
@@ -31,7 +31,7 @@ classdef TestWaveModeVerticalStructureAtIndex < matlab.unittest.TestCase
         end
     end
 
-    methods (Test)
+    methods (Test, TestTags = "smoke")
         function factorsMatchNativeTransforms(testCase)
             previousRandomState = rng;
             randomStateCleanup = onCleanup(@()rng(previousRandomState));

--- a/buildfile.m
+++ b/buildfile.m
@@ -1,0 +1,139 @@
+function plan = buildfile
+import matlab.buildtool.Task
+import matlab.buildtool.TaskGroup
+
+tasks = [
+    Task(Actions=@testSmokeTask,Description="Run the fast smoke test category.",DisableIncremental=true)
+    Task(Actions=@testFullTask,Description="Run all non-optional, non-exhaustive tests.",DisableIncremental=true)
+    Task(Actions=@testExhaustiveTask,Description="Run exhaustive numerical test matrices.",DisableIncremental=true)
+    Task(Actions=@testOptionalTask,Description="Run tests that require optional dependencies.",DisableIncremental=true)
+    ];
+
+plan = buildplan;
+plan("test") = TaskGroup(tasks,TaskNames=["smoke"; "full"; "exhaustive"; "optional"],Description="Run WaveVortexModel test categories.");
+plan.DefaultTasks = "test:smoke";
+end
+
+function testSmokeTask(~)
+runTestCategory("smoke","smoke");
+end
+
+function testFullTask(~)
+runTestCategory("full",["smoke" "full"]);
+end
+
+function testExhaustiveTask(~)
+runTestCategory("exhaustive","exhaustive");
+end
+
+function testOptionalTask(~)
+runTestCategory("optional","optional");
+end
+
+function runTestCategory(categoryName,selectedTags)
+repositoryRoot = fileparts(mfilename("fullpath"));
+testFolder = fullfile(repositoryRoot,"UnitTests");
+originalPath = path;
+pathCleanup = onCleanup(@()path(originalPath));
+addpath(testFolder);
+
+suite = matlab.unittest.TestSuite.fromFolder(testFolder,IncludingSubfolders=true);
+[expectedPairs,discoveredPairs,selectedSuite] = validateTestDiscovery(testFolder,suite,selectedTags);
+
+missingPairs = setdiff(expectedPairs,discoveredPairs);
+unexpectedPairs = setdiff(discoveredPairs,expectedPairs);
+if ~isempty(missingPairs) || ~isempty(unexpectedPairs)
+    details = discoveryDifferenceDetails(missingPairs,unexpectedPairs);
+    error("WaveVortexModel:TestDiscoveryFailed","The %s test category did not match its declared test methods.%s",categoryName,details);
+end
+if isempty(selectedSuite)
+    error("WaveVortexModel:EmptyTestCategory","No tests were discovered for the %s category.",categoryName);
+end
+
+runner = testrunner("textoutput");
+results = runner.run(selectedSuite);
+passedCount = nnz([results.Passed]);
+failedCount = nnz([results.Failed]);
+incompleteCount = nnz([results.Incomplete]);
+duration = sum([results.Duration]);
+fprintf("\n%s test summary: total=%d, passed=%d, failed=%d, incomplete=%d, duration=%.3f s\n",categoryName,numel(results),passedCount,failedCount,incompleteCount,duration);
+
+if failedCount > 0 || incompleteCount > 0
+    error("WaveVortexModel:UnsuccessfulTestRun","The %s test category was unsuccessful: %d failed and %d incomplete.",categoryName,failedCount,incompleteCount);
+end
+clear pathCleanup
+end
+
+function [expectedPairs,discoveredPairs,selectedSuite] = validateTestDiscovery(testFolder,suite,selectedTags)
+primaryTags = ["smoke" "full" "exhaustive" "optional"];
+testFiles = dir(fullfile(testFolder,"Test*.m"));
+expectedPairs = strings(0,1);
+
+for iFile = 1:numel(testFiles)
+    className = erase(string(testFiles(iFile).name),".m");
+    testClass = meta.class.fromName(className);
+    if isempty(testClass) || ~isTestCaseClass(testClass)
+        error("WaveVortexModel:InvalidFormalTest","%s must define a matlab.unittest.TestCase class named %s.",testFiles(iFile).name,className);
+    end
+
+    testMethods = testClass.MethodList.findobj("Test",true);
+    if isempty(testMethods)
+        error("WaveVortexModel:InvalidFormalTest","%s does not declare any test methods.",className);
+    end
+    for iMethod = 1:numel(testMethods)
+        methodTags = string(testMethods(iMethod).TestTags);
+        validatePrimaryTags(className,testMethods(iMethod).Name,methodTags,primaryTags);
+        if any(ismember(methodTags,selectedTags))
+            expectedPairs(end+1,1) = className + "/" + testMethods(iMethod).Name; %#ok<AGROW>
+        end
+    end
+end
+
+discoveredClassNames = string({suite.TestClass});
+discoveredMethodNames = string({suite.ProcedureName});
+if any(discoveredClassNames == "")
+    accidentalNames = unique(string({suite(discoveredClassNames == "").Name}));
+    error("WaveVortexModel:AccidentalScriptTests","UnitTests discovery found script-based tests: %s",strjoin(accidentalNames,", "));
+end
+
+selectedMask = false(size(suite));
+for iTest = 1:numel(suite)
+    testTags = string(suite(iTest).Tags);
+    validatePrimaryTags(discoveredClassNames(iTest),discoveredMethodNames(iTest),testTags,primaryTags);
+    selectedMask(iTest) = any(ismember(testTags,selectedTags));
+end
+
+selectedSuite = suite(selectedMask);
+discoveredPairs = unique(discoveredClassNames(selectedMask) + "/" + discoveredMethodNames(selectedMask));
+expectedPairs = unique(expectedPairs);
+end
+
+function validatePrimaryTags(className,methodName,testTags,primaryTags)
+matchingTags = intersect(testTags,primaryTags);
+if numel(matchingTags) ~= 1
+    error("WaveVortexModel:InvalidTestClassification","%s/%s must declare exactly one primary test tag from %s; found %s.",className,methodName,strjoin(primaryTags,", "),strjoin(matchingTags,", "));
+end
+end
+
+function tf = isTestCaseClass(testClass)
+tf = testClass.Name == "matlab.unittest.TestCase";
+if tf
+    return
+end
+for superclass = testClass.SuperclassList'
+    if isTestCaseClass(superclass)
+        tf = true;
+        return
+    end
+end
+end
+
+function details = discoveryDifferenceDetails(missingPairs,unexpectedPairs)
+details = "";
+if ~isempty(missingPairs)
+    details = details + newline + "Missing: " + strjoin(missingPairs,", ");
+end
+if ~isempty(unexpectedPairs)
+    details = details + newline + "Unexpected: " + strjoin(unexpectedPairs,", ");
+end
+end


### PR DESCRIPTION
## Summary

- add canonical smoke, full, exhaustive, and optional MATLAB build tasks
- classify every formal test with explicit metadata and audit discovery against declared methods
- make failed or incomplete categories return an unsuccessful build
- preserve RunAllUnitTests as a full-suite compatibility wrapper and document the commands

## Verification

- build task listing: four category entry points present
- smoke/default: 121 passed, 0 failed, 0 incomplete
- optional Optimization Toolbox path: 1 passed
- full: expected discovery failure naming TestRandomFlow/testSolution (repair remains in #11)
- exhaustive: expected 2,536 passed and 32 failed (repairs remain in #11)
- buildfile and compatibility wrapper Code Analyzer checks: clean
- no generated test artifacts; production source, CI, manifest, and changelog unchanged

Validated with MATLAB R2025b because R2024b is not installed locally.

Closes #10