### PR TITLE
Fix random inertial coefficient initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Documented the v4.2.1 target support contract: the five current transform families, the supported latitude domain of `5 <= abs(latitude) <= 85`, MATLAB builtin FFTs, fixed and adaptive integration, and periodic `linear` and `spline` interpolation are stable; `adaptive-cell` integration is experimental; and FFTW, `exact` and `finufft` interpolation, off-grid behavior, and legacy low-level entry points are internal.
 - Enforced the supported latitude domain and restored a deterministic, order-independent green test baseline with isolated random state and temporary files.
+- Corrected combined random-flow initialization to preserve conjugate inertial `Ap` and `Am` coefficients.
 
 ## [4.2.0] - 2026-07-30
 - Added `WVPseudoTopographicWaveGeneration` with Darwin-symbol or custom-frequency initialization, adaptive-damping-aware spectral masking, resolution conversion, restart persistence, and deterministic Goff abyssal-hill generation.

--- a/FlowComponents/WVInertialOscillationMethods.m
+++ b/FlowComponents/WVInertialOscillationMethods.m
@@ -95,6 +95,8 @@ classdef WVInertialOscillationMethods < handle
             % - Parameter u: function handle that takes a single argument, u(Z)
             % - Parameter v: function handle that takes a single argument, v(Z)
             self.Ap(:,1) = self.Ap(:,1) + self.transformFromSpatialDomainWithFio(u(self.z) - sqrt(-1)*v(self.z))/2;
+            % Am stores the redundant conjugate inertial modes, so rebuild
+            % it from Ap to preserve a real-valued physical state.
             self.Am(:,1) = conj(self.Ap(:,1));
         end
 

--- a/UnitTests/TestInertialOscillationMethods.m
+++ b/UnitTests/TestInertialOscillationMethods.m
@@ -6,19 +6,21 @@ classdef TestInertialOscillationMethods < matlab.unittest.TestCase
 
     properties (ClassSetupParameter)
         Lxyz = struct('Lxyz',[15e3, 15e3, 1300]);
-        Nxyz = struct('Nx8Ny8Nz5',[8 8 30]);
-        transform = {'hydrostatic'};
+        Nxyz = struct('Nx8Ny8Nz30',[8 8 30]);
+        transform = {'constant-hydrostatic','constant-nonhydrostatic','hydrostatic','boussinesq'};
     end
 
     methods (TestClassSetup)
         function classSetup(testCase,Lxyz,Nxyz,transform)
             switch transform
-                case 'constant'
-                    testCase.wvt = WVTransformConstantStratification(Lxyz, Nxyz);
+                case 'constant-hydrostatic'
+                    testCase.wvt = WVTransformConstantStratification(Lxyz,Nxyz,isHydrostatic=true,shouldAntialias=false);
+                case 'constant-nonhydrostatic'
+                    testCase.wvt = WVTransformConstantStratification(Lxyz,Nxyz,isHydrostatic=false,shouldAntialias=false);
                 case 'hydrostatic'
-                    testCase.wvt = WVTransformHydrostatic(Lxyz, Nxyz, N2=@(z) (5.2e-3)*(5.2e-3)*ones(size(z)),shouldAntialias=0);
+                    testCase.wvt = WVTransformHydrostatic(Lxyz,Nxyz,N2=@(z) (5.2e-3)^2*ones(size(z)),shouldAntialias=false);
                 case 'boussinesq'
-                    testCase.wvt = WVTransformBoussinesq(Lxyz, Nxyz, N2=@(z) (5.2e-3)*(5.2e-3)*ones(size(z)),shouldAntialias=0);
+                    testCase.wvt = WVTransformBoussinesq(Lxyz,Nxyz,N2=@(z) (5.2e-3)^2*ones(size(z)),shouldAntialias=false);
             end
             % testCase.wvt.addOperation(testCase.wvt.operationForDynamicalVariable('u','v','eta','w',flowComponent=testCase.wvt.flowComponent('inertial')));
             testCase.solutionGroup = WVInertialOscillationComponent(testCase.wvt);
@@ -109,6 +111,131 @@ classdef TestInertialOscillationMethods < matlab.unittest.TestCase
             self.verifyEqual(finalTotalEnergy-finalInertialEnergy,initialTotalEnergy-initialInertialEnergy, "AbsTol",1e-7,"RelTol",1e-7);
         end
 
+        function testRandomFlowProducesConjugateInertialCoefficients(self)
+            seedRandomNumberGenerator(self,74653);
+            self.wvt.initWithRandomFlow(uvMax=0.02);
+
+            inertialApMask = logical(self.wvt.inertialComponent.maskAp);
+            inertialAmMask = logical(self.wvt.inertialComponent.maskAm);
+            self.verifyGreaterThan(nnz(self.wvt.Ap(inertialApMask)),0)
+            self.verifyGreaterThan(nnz(self.wvt.Am(inertialAmMask)),0)
+            self.verifyEqual(self.wvt.Am(inertialAmMask),conj(self.wvt.Ap(inertialApMask)))
+
+            primaryWaveApMask = logical(self.wvt.waveComponent.maskOfPrimaryModesForCoefficientMatrix(WVCoefficientMatrix.Ap));
+            primaryWaveAmMask = logical(self.wvt.waveComponent.maskOfPrimaryModesForCoefficientMatrix(WVCoefficientMatrix.Am));
+            self.verifyGreaterThan(nnz(self.wvt.Ap(primaryWaveApMask)),0)
+            self.verifyGreaterThan(nnz(self.wvt.Am(primaryWaveAmMask)),0)
+        end
+
+        function testAddInertialMotionsSuperposesValidState(self)
+            seedRandomNumberGenerator(self,86477);
+            [u1,v1,u2,v2] = TestInertialOscillationMethods.inertialProfiles(self.wvt);
+            self.wvt.initWithRandomFlow(uvMax=0.02);
+
+            self.wvt.setInertialMotions(u2,v2);
+            inertialApMask = logical(self.wvt.inertialComponent.maskAp);
+            inertialAmMask = logical(self.wvt.inertialComponent.maskAm);
+            incrementAp = zeros(size(self.wvt.Ap));
+            incrementAm = zeros(size(self.wvt.Am));
+            incrementAp(inertialApMask) = self.wvt.Ap(inertialApMask);
+            incrementAm(inertialAmMask) = self.wvt.Am(inertialAmMask);
+            incrementU = self.wvt.u_io;
+            incrementV = self.wvt.v_io;
+
+            self.wvt.setInertialMotions(u1,v1);
+            beforeAp = self.wvt.Ap;
+            beforeAm = self.wvt.Am;
+            beforeA0 = self.wvt.A0;
+            beforeUInertial = self.wvt.u_io;
+            beforeVInertial = self.wvt.v_io;
+            beforeU = self.wvt.u;
+            beforeV = self.wvt.v;
+
+            expectedAp = beforeAp + incrementAp;
+            expectedAm = beforeAm + incrementAm;
+            expectedTotalEnergy = TestInertialOscillationMethods.totalEnergyForCoefficients(self.wvt,expectedAp,expectedAm,beforeA0);
+            expectedInertialEnergy = TestInertialOscillationMethods.inertialEnergyForCoefficients(self.wvt,expectedAp,expectedAm);
+
+            self.wvt.addInertialMotions(u2,v2);
+
+            self.verifyEqual(self.wvt.Ap,expectedAp,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.Am,expectedAm,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.A0,beforeA0)
+            self.verifyEqual(self.wvt.Ap(~inertialApMask),beforeAp(~inertialApMask))
+            self.verifyEqual(self.wvt.Am(~inertialAmMask),beforeAm(~inertialAmMask))
+            self.verifyEqual(self.wvt.u_io,beforeUInertial+incrementU,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.v_io,beforeVInertial+incrementV,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.u,beforeU+incrementU,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.v,beforeV+incrementV,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.totalEnergy,expectedTotalEnergy,AbsTol=100*eps,RelTol=100*eps)
+            self.verifyEqual(self.wvt.inertialEnergy,expectedInertialEnergy,AbsTol=100*eps,RelTol=100*eps)
+        end
+
+        function testAddInertialMotionsAfterRandomFlow(self)
+            seedRandomNumberGenerator(self,104729);
+            [u1,v1] = TestInertialOscillationMethods.inertialProfiles(self.wvt);
+
+            self.wvt.initWithInertialMotions(u1,v1);
+            Ap1 = self.wvt.Ap;
+            Am1 = self.wvt.Am;
+            A01 = self.wvt.A0;
+            uInertial1 = self.wvt.u_io;
+            vInertial1 = self.wvt.v_io;
+            u1Total = self.wvt.u;
+            v1Total = self.wvt.v;
+
+            self.wvt.initWithRandomFlow(uvMax=0.02);
+            Ap2 = self.wvt.Ap;
+            Am2 = self.wvt.Am;
+            A02 = self.wvt.A0;
+            uInertial2 = self.wvt.u_io;
+            vInertial2 = self.wvt.v_io;
+            u2Total = self.wvt.u;
+            v2Total = self.wvt.v;
+            inertialApMask = logical(self.wvt.inertialComponent.maskAp);
+            inertialAmMask = logical(self.wvt.inertialComponent.maskAm);
+            self.verifyEqual(Am2(inertialAmMask),conj(Ap2(inertialApMask)))
+
+            expectedAp = Ap1 + Ap2;
+            expectedAm = Am1 + Am2;
+            expectedA0 = A01 + A02;
+            expectedTotalEnergy = TestInertialOscillationMethods.totalEnergyForCoefficients(self.wvt,expectedAp,expectedAm,expectedA0);
+            expectedInertialEnergy = TestInertialOscillationMethods.inertialEnergyForCoefficients(self.wvt,expectedAp,expectedAm);
+
+            self.wvt.addInertialMotions(u1,v1);
+
+            self.verifyEqual(self.wvt.Ap,expectedAp,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.Am,expectedAm,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.A0,expectedA0)
+            self.verifyEqual(self.wvt.Ap(~inertialApMask),Ap2(~inertialApMask))
+            self.verifyEqual(self.wvt.Am(~inertialAmMask),Am2(~inertialAmMask))
+            self.verifyEqual(self.wvt.u_io,uInertial1+uInertial2,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.v_io,vInertial1+vInertial2,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.u,u1Total+u2Total,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.v,v1Total+v2Total,AbsTol=100*eps)
+            self.verifyEqual(self.wvt.totalEnergy,expectedTotalEnergy,AbsTol=100*eps,RelTol=100*eps)
+            self.verifyEqual(self.wvt.inertialEnergy,expectedInertialEnergy,AbsTol=100*eps,RelTol=100*eps)
+        end
+
+    end
+
+    methods (Static, Access=private)
+        function [u1,v1,u2,v2] = inertialProfiles(wvt)
+            u1 = @(z) 0.12*exp(z/(wvt.Lz/2));
+            v1 = @(z) 0.04*exp(z/(wvt.Lz/3));
+            u2 = @(z) -0.03*cos(pi*(z+wvt.Lz)/wvt.Lz);
+            v2 = @(z) 0.07*cos(2*pi*(z+wvt.Lz)/wvt.Lz);
+        end
+
+        function energy = totalEnergyForCoefficients(wvt,Ap,Am,A0)
+            energy = sum(wvt.Apm_TE_factor(:).*(abs(Ap(:)).^2+abs(Am(:)).^2)+wvt.A0_TE_factor(:).*abs(A0(:)).^2);
+        end
+
+        function energy = inertialEnergyForCoefficients(wvt,Ap,Am)
+            maskAp = wvt.inertialComponent.maskAp;
+            maskAm = wvt.inertialComponent.maskAm;
+            energy = sum(wvt.Apm_TE_factor(:).*(maskAp(:).*abs(Ap(:)).^2+maskAm(:).*abs(Am(:)).^2));
+        end
     end
 
 end

--- a/WVFlowComponent.m
+++ b/WVFlowComponent.m
@@ -183,11 +183,11 @@ classdef WVFlowComponent < handle & matlab.mixin.Heterogeneous
                 
                 validModes = self.maskAm & self.wvt.totalFlowComponent.maskOfPrimaryModesForCoefficientMatrix(WVCoefficientMatrix.Am);
                 if any(validModes(:))
-                    Am = ((randn(self.wvt.spectralMatrixSize) + sqrt(-1)*randn(self.wvt.spectralMatrixSize))/sqrt(2));
-                    Am(~validModes) = 0;
+                    primaryAm = ((randn(self.wvt.spectralMatrixSize) + sqrt(-1)*randn(self.wvt.spectralMatrixSize))/sqrt(2));
                     if options.shouldOnlyRandomizeOrientations == 1
-                        Am(logical(validModes)) = Am(logical(validModes)) ./ abs(Am(logical(validModes)));
+                        primaryAm(logical(validModes)) = primaryAm(logical(validModes)) ./ abs(primaryAm(logical(validModes)));
                     end
+                    Am(logical(validModes)) = primaryAm(logical(validModes));
                 end
             else
                 Ap = 0;
@@ -273,4 +273,3 @@ classdef WVFlowComponent < handle & matlab.mixin.Heterogeneous
     % end
     
 end
-


### PR DESCRIPTION
## Summary
- preserve conjugate inertial Am coefficients during combined random-flow initialization
- document the intentional Am reconstruction in addInertialMotions
- add deterministic regression and superposition coverage across four stable transforms
- record the correction in the Unreleased changelog

## Verification
- buildtool test:full passed twice: 330/330
- buildtool test:exhaustive passed: 2440/2440
- inertial suite passed: 24/24
- RNG restoration, analyzer, whitespace, scope, and generated-artifact checks passed

Closes #12