### PR TITLE
Restrict public interpolation to supported methods

### DIFF
--- a/@WVModel/WVModel.m
+++ b/@WVModel/WVModel.m
@@ -371,15 +371,15 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             % Add particles to be advected by the flow.
             %
             % - Topic: Particles
-            % - Declaration: addParticles(name,fluxOp,x,y,z,trackedFieldNames,options)
+            % - Declaration: addParticles(name,isXYOnly,x,y,z,trackedFieldNames,options)
             % - Parameter name: a unique name to call the particles
-            % - Parameter fluxOp: a WVParticleFluxOperation, used to determine how the flow advects the particles
+            % - Parameter isXYOnly: whether particles are advected only in the horizontal dimensions
             % - Parameter x: x-coordinate location of the particles
             % - Parameter y: y-coordinate location of the particles
             % - Parameter z: z-coordinate location of the particles
-            % - Parameter trackedFields: strings of variable names
-            % - Parameter advectionInterpolation: (optional) interpolation method used for particle advection. "linear" (default), "spline", "exact"
-            % - Parameter trackedVarInterpolation: (optional) interpolation method used for tracked field. "linear" (default), "spline", "exact"
+            % - Parameter trackedFieldNames: strings of variable names
+            % - Parameter advectionInterpolation: (optional) `linear` (default) or `spline` interpolation for particle advection
+            % - Parameter trackedVarInterpolation: (optional) `linear` or `spline` (default) interpolation for tracked fields
             % - Parameter absToleranceXY: (adapative) absolute tolerance in meters for particle advection in (x,y). 1e-1 (default)
             % - Parameter absToleranceZ: (adapative) absolute tolerance  in meters for particle advection in (z). 1e-2 (default)
             arguments
@@ -394,8 +394,8 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
                 trackedFieldNames char
             end
             arguments
-                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline","exact","finufft"])} = "linear"
-                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline","exact","finufft"])} = "spline"
+                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline"])} = "linear"
+                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline"])} = "spline"
                 options.outputGroupName = "wave-vortex"
                 options.absToleranceXY = 1e-1; % 100 km * 10^{-6}
                 options.absToleranceZ = 1e-2;
@@ -429,8 +429,8 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             % - Parameter y: y-coordinate location of the particles
             % - Parameter z: z-coordinate location of the particles
             % - Parameter trackedFields: strings of variable names
-            % - Parameter advectionInterpolation: (optional) interpolation method used for particle advection. "linear" (default), "spline", "exact"
-            % - Parameter trackedVarInterpolation: (optional) interpolation method used for tracked field. "linear" (default), "spline", "exact"
+            % - Parameter advectionInterpolation: (optional) `linear` (default) or `spline` interpolation for particle advection
+            % - Parameter trackedVarInterpolation: (optional) `linear` (default) or `spline` interpolation for tracked fields
             % - Parameter absToleranceXY: (adapative) absolute tolerance in meters for particle advection in (x,y). 1e-1 (default)
             % - Parameter absToleranceZ: (adapative) absolute tolerance  in meters for particle advection in (z). 1e-2 (default)
             %
@@ -443,8 +443,8 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             % many flows this will have sufficient accuracy and allow you
             % to place float at nearly every grid point without slowing
             % down the model integration. However, if high accuracy is
-            % required, you may want to use cubic "spline" interpolation or
-            % even "exact" at the expense of computational speed.
+            % required, you may want to use cubic "spline" interpolation at
+            % the expense of computational speed.
             %
             % You can track the value of any known WVVariableAnnotation along the
             % particle's flow path, e.g., relative vorticity. These values
@@ -475,8 +475,8 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
                 trackedFields char
             end
             arguments
-                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline","exact","finufft"])} = "linear"
-                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline","exact","finufft"])} = "linear"
+                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline"])} = "linear"
+                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline"])} = "linear"
                 options.absToleranceXY = 1e-1;
                 options.absToleranceZ = 1e-2;
             end
@@ -517,7 +517,15 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
 
         function setDrifterPositions(self,x,y,z,trackedFields,options)
             % Set positions of drifter-like particles to be advected.
+            %
             % - Topic: Particles
+            % - Declaration: setDrifterPositions(self,x,y,z,trackedFields,options)
+            % - Parameter x: x-coordinate locations of the particles
+            % - Parameter y: y-coordinate locations of the particles
+            % - Parameter z: optional z-coordinate locations of the particles
+            % - Parameter trackedFields: variable names to sample along each trajectory
+            % - Parameter advectionInterpolation: (optional) `linear` (default) or `spline` interpolation for particle advection
+            % - Parameter trackedVarInterpolation: (optional) `linear` (default) or `spline` interpolation for tracked fields
             arguments
                 self WVModel {mustBeNonempty}
                 x (1,:) double
@@ -528,8 +536,8 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
                 trackedFields char
             end
             arguments
-                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline","exact","finufft"])} = "linear"
-                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline","exact","finufft"])} = "linear"
+                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline"])} = "linear"
+                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline"])} = "linear"
                 options.absToleranceXY = 1e-1;
             end
             optionCell = namedargs2cell(options);

--- a/@WVTransform/WVTransform.m
+++ b/@WVTransform/WVTransform.m
@@ -254,12 +254,10 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         % Primary method for accessing the dynamical variables
         [varargout] = variableWithName(self, variableNames);
         
-        % Primary method for accessing the dynamical variables on the at
-        % any position or time.
+        % Access dynamical variables at arbitrary positions.
         %
-        % The method argument specifies how off-grid values should be
-        % interpolated: linear, spline or exact. Use 'exact' for the slow,
-        % but accurate, spectral interpolation.
+        % The interpolation method may be `linear` or `spline`. Horizontal
+        % coordinates are wrapped periodically before interpolation.
         % - Topic: Lagrangian
         [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,options)
 

--- a/@WVTransform/variableAtPositionWithName.m
+++ b/@WVTransform/variableAtPositionWithName.m
@@ -1,14 +1,12 @@
 function [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,options)
-% Primary method for accessing the dynamical variables on the at any
-% position in the domain.
+% Access dynamical variables at arbitrary positions in the domain.
 %
 % Computes (or retrieves from cache) any known state variables and computes
 % their values at the requested positions (x,y,z). For two-dimensional
 % variables, interpolation uses only (x,y), and z may be empty.
 %
-% The method argument specifies how off-grid values should be interpolated.
-% Use 'exact' for the slow, but accurate, spectral interpolation. Otherwise
-% use 'spline' or some other method used by Matlab's interp function.
+% The interpolation method may be `linear` or `spline`. Horizontal
+% coordinates are wrapped periodically before interpolation.
 %
 % - Topic: State Variables
 % - Declaration: [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,options)
@@ -16,7 +14,7 @@ function [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,optio
 % - Parameter y: array of y-positions
 % - Parameter z: array of z-positions, or empty for two-dimensional variables
 % - Parameter variableNames: strings of variable names.
-% - Parameter interpolationMethod: (optional) `linear`,`spline`,`exact`. Default `linear`.
+% - Parameter interpolationMethod: (optional) `linear` or `spline`. Default `linear`.
 arguments
     self WVTransform {mustBeNonempty}
     x (1,:) double
@@ -27,28 +25,10 @@ arguments (Repeating)
     variableNames char
 end
 arguments
-    options.interpolationMethod char {mustBeMember(options.interpolationMethod,["linear","spline","exact","finufft"])} = "linear"
+    options.interpolationMethod char {mustBeMember(options.interpolationMethod,["linear","spline"])} = "linear"
 end
 
 varargout = cell(size(variableNames));
-if strcmp(options.interpolationMethod,"exact")
-    error('I ripped this out.')
-    if isempty(self.ongridModes)
-        self.ongridModes = WVOffGridTransform(self.offgridModes.verticalModes,self.offgridModes.latitude,self.offgridModes.N2Function);
-        [omega, alpha, ~, ~, mode, phi, A, norm] = self.waveModesFromWaveCoefficients();
-        self.ongridModes.setExternalWavesWithFrequencies(omega, alpha, mode, phi, A, norm);
-    end
-    [varargout{:}] = self.ongridModes.externalVariablesAtTimePosition(t,x,y,z, variableNames{:});
-else
-    [varargout{:}] = self.variableWithName(variableNames{:});
-    [varargout{:}] = self.interpolatedFieldAtPosition(x,y,z,options.interpolationMethod,varargout{:});
-end
-
-% if ~isempty(self.offgridModes) && ~isempty(self.offgridModes.k_ext)
-%     varargoutExt = cell(size(variableNames));
-%     [varargoutExt{:}] = self.externalVariablesAtTimePosition(self.t,x,y,z,variableNames{:});
-%     for iArg=1:length(varargout)
-%         varargout{iArg} = varargout{iArg} + varargoutExt{iArg};
-%     end
-% end
+[varargout{:}] = self.variableWithName(variableNames{:});
+[varargout{:}] = self.interpolatedFieldAtPosition(x,y,z,options.interpolationMethod,varargout{:});
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Restricted public field and particle interpolation to periodic `linear` and `spline` methods and removed the dead `exact` and off-grid dispatch.
 - Documented the v4.2.1 target support contract: the five current transform families, the supported latitude domain of `5 <= abs(latitude) <= 85`, MATLAB builtin FFTs, fixed and adaptive integration, and periodic `linear` and `spline` interpolation are stable; `adaptive-cell` integration is experimental; and FFTW, `exact` and `finufft` interpolation, off-grid behavior, and legacy low-level entry points are internal.
 - Enforced the supported latitude domain and restored a deterministic, order-independent green test baseline with isolated random state and temporary files.
 - Corrected combined random-flow initialization to preserve conjugate inertial `Ap` and `Am` coefficients.

--- a/ObservingSystems/WVLagrangianParticles.m
+++ b/ObservingSystems/WVLagrangianParticles.m
@@ -20,16 +20,18 @@ classdef WVLagrangianParticles < WVObservingSystem
 
     methods
         function self = WVLagrangianParticles(model,options)
-            %create a new observing system
+            % Create a Lagrangian-particle observing system.
             %
-            % This class is intended to be subclassed, so it generally
-            % assumed that this initialization will not be called directly.
+            % This class is intended to be subclassed, so this initializer
+            % is generally called by a model particle facade.
             %
             % - Topic: Initialization
-            % - Declaration: self = WVObservingSystem(model,name)
+            % - Declaration: self = WVLagrangianParticles(model,options)
             % - Parameter model: the WVModel instance
             % - Parameter name: name of the observing system
-            % - Returns self: a new instance of WVObservingSystem
+            % - Parameter advectionInterpolation: (optional) `linear` (default) or `spline` interpolation for particle advection
+            % - Parameter trackedVarInterpolation: (optional) `linear` (default) or `spline` interpolation for tracked fields
+            % - Returns self: a new WVLagrangianParticles instance
             arguments
                 model WVModel
                 options.name {mustBeText}
@@ -38,8 +40,8 @@ classdef WVLagrangianParticles < WVObservingSystem
                 options.z (1,:) double
                 options.isXYOnly (1,1) logical = false
                 options.trackedFieldNames
-                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline","exact","finufft"])} = "linear"
-                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline","exact","finufft"])} = "linear"
+                options.advectionInterpolation char {mustBeMember(options.advectionInterpolation,["linear","spline"])} = "linear"
+                options.trackedVarInterpolation char {mustBeMember(options.trackedVarInterpolation,["linear","spline"])} = "linear"
                 options.absToleranceXY = 1e-1; % 100 km * 10^{-6}
                 options.absToleranceZ = 1e-2;  
             end

--- a/README.md
+++ b/README.md
@@ -13,13 +13,11 @@ If you use these classes, please cite the JFM paper.
 ### Table of contents
 1. [Quick Start](#quick-start)
 2. [Introduction](#introduction)
-4. [Gridded wave modes](#gridded-wave-modes)
-5. [External wave modes](#external-wave-modes)
-6. [Dynamical variables](#dynamical-variables)
+3. [Gridded wave modes](#gridded-wave-modes)
+4. [Dynamical variables](#dynamical-variables)
     1. [Eulerian](#eulerian)
     2. [Lagrangian](#lagrangian)
-    3. [Internal and external variables](#internal-and-external-variables)
-7. [Initialization](#initialization)
+5. [Initialization](#initialization)
 
 ------------------------
 
@@ -77,7 +75,7 @@ rho = wavemodel.DensityFieldAtTime(t);
 zeta = wavemodel.IsopycnalDisplacementFieldAtTime(t);
 ```
 
-The model also supports external/free wave modes that do not fit in the gridded domain, as well as a series of functions for advecting particles.
+The model also includes functions for advecting particles.
 
 Introduction
 ------------
@@ -86,7 +84,7 @@ The linear internal wave model adds together an arbitrary number single-mode pla
 
 The `InternalWaveModel` class is divided into two subclasses, depending on the stratification. The constant stratification model `InternalWaveModelConstantStratification` takes advantage of the fact that the vertical modes in constant stratification are simply sines and cosines, and uses the fast fourier transform to sum the vertical modes. For more general stratification profiles, the class `InternalWaveModelArbitraryStratification` computes the vertical modes using the [`InternalModes` class](../InternalModes/) and then sums them with a (slow) matrix multiplication. This technique will often be *slower* than simplying time-stepping the linearized equations of motion using a Runge-Kutta time stepping routine, but comes with the advantage that the vertical extent of the model can be arbitrarily defined. This allows a model to be constructed with high resolution in regions of interested.
 
-Initializing the model creates a user-specified standard evenly-spaced, periodic grid. This grid useful because it allows wave modes to be computed with the Fast Fourier Transform (FFT) algorithm and both the constant and arbitrary stratification classes use this grid to quickly compute the horizontal component of the solution. However, such a grid limits the wavelengths of each wave to be integer multiples of the grid spacing. To get around this limitation, the linear wave model supports an arbitrary number of [external (or free) wave modes](#external-wave-modes) that are not required to fit in the gridded model. These wave modes are linearly added to the gridded modes, but must be computed using the slower discrete fourier transform.
+Initializing the model creates a user-specified standard evenly-spaced, periodic grid. This grid is useful because it allows wave modes to be computed with the Fast Fourier Transform (FFT) algorithm and both the constant and arbitrary stratification classes use this grid to quickly compute the horizontal component of the solution.
 
 Gridded wave modes
 ------------
@@ -110,34 +108,6 @@ wavemodel.removeAllWaves();
 ```
 and they will be set to 0 amplitude.
 
-
-External wave modes
-------------
-
-The external wave modes can be added or set either by specifying the wavelength of the modes,
-```matlab
-omega = wavemodel.addExternalWavesWithWavenumbers(k,l,j,phi,A,norm);
-omega = wavemodel.setExternalWavesWithWavenumbers(k,l,j,phi,A,norm);
-```
-or by specifying the frequency of the modes,
-```matlab
-k = wavemodel.addExternalWavesWithFrequencies(omega, alpha, j, phi, A, norm);
-k = wavemodel.setExternalWavesWithFrequencies(omega, alpha, j, phi, A, norm);
-```
-The `Set` methods will remove all external modes and then add the list you give it, and the `Add` methods will append these modes to the existing list. You can call,
-```matlab
-wavemodel.removeAllExternalWaves();
-```
-to remove all external modes.
-
-The amplitude of the waves is set with respect to a given norm of the internal mode (see [`InternalModes` class](../InternalModes/) for more details). Typically, one would want to use `Normalization.uMax`  if you are simply setting the maximum wave velocity.
-
-You can extract the nonzero *gridded* wave components, and feed those directly into the external wave modes. The amplitude in this case uses `Normalization.kConstant`. This can be done with two lines of code,
-```matlab
-[omega, alpha, mode, phi, A, norm] = wavemodel.waveModesFromWaveCoefficients();
-wavemodel.setExternalWavesWithFrequencies(omega, alpha, mode, phi, A, norm);
-```
-but of course now have you external waves with the exact same values as the gridded waves, which isn't likely very helpful.
 
 Dynamical variables
 ------------
@@ -173,7 +143,7 @@ Fundamentally these routines are just calling `VariableFieldsAtTime`, which lets
 
 ### Lagrangian
 
-These methods will return values at any point in space and time. The argument `interpolationMethod` specifies how off-grid values should be interpolated. Use `'exact'` for the slow, but accurate, spectral interpolation. Otherwise use `'spline'` or some other method accepted by Matlab's `interp` function.
+These methods will return values at any point in space and time. The argument `interpolationMethod` specifies whether periodic off-grid values use `'linear'` or cubic `'spline'` interpolation.
 
 As an example, lets create some floats at various depths in the water column.
 ```matlab
@@ -185,7 +155,7 @@ x = (0:N-1)*dx;
 y = (0:N-1)*dy;
 z = (0:nLevels-1)*(-wavemodel.Lz/(2*(nLevels-1)));
 ```
-Now we can call the various Lagrangian methods to return the dynamical fields at those positions. First, we need to specify how we want to interpolate the gridded dynamical fields. The two most obvious choices are `'exact'`, if we want to use spectral interpolation, or `'spline'`, if we want a good accuracy speed tradeoff. It may also being worth using `'linear'` interpolation if accuracy is less important. The following code returns the values of the dynamical variables at the positions we requested,
+Now we can call the various Lagrangian methods to return the dynamical fields at those positions. Cubic `'spline'` interpolation offers a good accuracy-speed tradeoff, while `'linear'` interpolation is useful when speed is more important. The following code returns the values of the dynamical variables at the positions we requested,
 
 ```matlab
 interpolationMethod = 'spline';
@@ -199,24 +169,6 @@ As with the Eulerian accessor methods, you can request all the dynamical variabl
 ```
 which provides the optimal speed advantage.
 
-### Internal and external variables
-
-As explained in the introduction, the model is composed of *gridded* or *internal* wave modes and *external* or *free* wave modes.
-
-If you so choose, you can also access the dynamical variables associated with the internal and external wave modes separately (which always sum to the total). The following code accesses the Eulerian and Lagrangian versions of the internal wave modes,
-```matlab
-[u,v,w,rho_prime,zeta] = wavemodel.InternalVariableFieldsAtTime(t,'u','v','w','rho_prime','zeta');
-[u,v,w,rho_prime,zeta] = wavemodel.InternalVariablesAtTimePosition(t,x,y,z,interpolationMethod,'u','v','w','rho_prime','zeta');
-```
-In practice, the Eulerian function `InternalVariableFieldsAtTime` is doing all the heavy lifting by computing the FFTs for the gridded modes. The Lagrangian function `InternalVariablesAtTimePosition` uses the Eulerian solutions and interpolates the position at the user requested point, unless `'exact'` interpolation is requested.
-
-The external dynamical variables can be access with,
-```matlab
-[u,v,w,rho_prime,zeta] = wavemodel.externalVariableFieldsAtTime(t,'u','v','w','rho_prime','zeta');
-[u,v,w,rho_prime,zeta] = wavemodel.externalVariablesAtTimePosition(t,x,y,z,'u','v','w','rho_prime','zeta');
-```
-Notice that interpolation is not an option, because these values are always exact.
-
 Initialization
 ------------
 
@@ -229,7 +181,6 @@ where the only required argument indicates the GM reference level. This function
 - `'j_star'` takes any integer value, default is 3.
 - `'shouldRandomizeAmplitude'` takes a 0 or 1 to indicate whether or not the amplitude should be randomized with a Gaussian random variable with expectation matching the GM value. The default is 0.
 - `'maxDeltaOmega'` is the maximum width in frequency that will be integrated over for assigned energy. By default it is self.Nmax-self.f.
-- `'initializeModes'`  is used to determine which modes get initialized. Possible values are `'all'`, `'internalOnly'`, or `'externalOnly'` . Default is `'all'`
 - `'energyWarningThreshold'` will provide a warning if the energy of a single mode exceeds a certain value of the total energy in that modal band. Values between 0 and 1. Default is 0.5 (e.g., you get a warning if the energy in a single mode exceeds 50% of the total energy).
 - `'excludeNyquist'` takes a 0 or 1 to indicate whether or not to include the Nyquist wavenumbers in initialization. Default 1.
 - `'maxK'` and `'minK'` can be set to limit the wavenumbers that will be initialized. By default all resolved wavenumbers are initialized (other than the Nyquist, as above).

--- a/UnitTests/TestInterpolatedFieldAtPosition.m
+++ b/UnitTests/TestInterpolatedFieldAtPosition.m
@@ -2,8 +2,10 @@ classdef TestInterpolatedFieldAtPosition < matlab.unittest.TestCase
 
     properties
         wvt
+        barotropicTransform
         field2D
         field3D
+        barotropicField
     end
 
     methods (TestClassSetup)
@@ -28,6 +30,15 @@ classdef TestInterpolatedFieldAtPosition < matlab.unittest.TestCase
             annotation3D = WVVariableAnnotation('interpolationTest3D',{'x','y','z'},'1','synthetic three-dimensional interpolation test field');
             testCase.wvt.addOperation(WVOperation('interpolationTest2D',annotation2D,@(~) surfaceField));
             testCase.wvt.addOperation(WVOperation('interpolationTest3D',annotation3D,@(~) volumeField));
+
+            testCase.barotropicTransform = WVTransformBarotropicQG(Lxyz(1:2),Nxyz(1:2),latitude=30,shouldAntialias=false);
+            XBarotropic = testCase.barotropicTransform.X;
+            YBarotropic = testCase.barotropicTransform.Y;
+            testCase.barotropicField = 0.4*cos(2*pi*XBarotropic/testCase.barotropicTransform.Lx) ...
+                + 0.6*sin(2*pi*YBarotropic/testCase.barotropicTransform.Ly) ...
+                - 0.1*cos(2*pi*(XBarotropic/testCase.barotropicTransform.Lx-YBarotropic/testCase.barotropicTransform.Ly));
+            barotropicAnnotation = WVVariableAnnotation('barotropicInterpolationTest',{'x','y'},'1','synthetic barotropic interpolation test field');
+            testCase.barotropicTransform.addOperation(WVOperation('barotropicInterpolationTest',barotropicAnnotation,@(~) testCase.barotropicField));
         end
     end
 
@@ -36,7 +47,7 @@ classdef TestInterpolatedFieldAtPosition < matlab.unittest.TestCase
             [x,y] = testCase.horizontalQueryPoints();
 
             actual = testCase.wvt.variableAtPositionWithName(x,y,[],'interpolationTest2D');
-            expected = testCase.periodicInterpolation2D(testCase.field2D,x,y);
+            expected = testCase.periodicInterpolation2D(testCase.wvt,testCase.field2D,x,y);
 
             testCase.verifySize(actual,size(x));
             testCase.verifyEqual(actual,expected,AbsTol=1e-12);
@@ -54,6 +65,118 @@ classdef TestInterpolatedFieldAtPosition < matlab.unittest.TestCase
             testCase.verifySize(actual,size(x));
             testCase.verifyEqual(actual,expected,AbsTol=1e-12);
         end
+
+        function testSupportedMethodsReturnMultipleFields(testCase)
+            [x,y] = testCase.horizontalQueryPoints();
+            zGrid = testCase.wvt.z;
+            z = reshape((zGrid(2:5)+zGrid(3:6))/2,1,[]);
+
+            for method = ["linear" "spline"]
+                [actual2D,actual3D] = testCase.wvt.variableAtPositionWithName(x,y,z,'interpolationTest2D','interpolationTest3D',interpolationMethod=method);
+                expected2D = testCase.wvt.variableAtPositionWithName(x,y,z,'interpolationTest2D',interpolationMethod=method);
+                expected3D = testCase.wvt.variableAtPositionWithName(x,y,z,'interpolationTest3D',interpolationMethod=method);
+
+                testCase.verifySize(actual2D,size(x));
+                testCase.verifySize(actual3D,size(x));
+                testCase.verifyEqual(actual2D,expected2D);
+                testCase.verifyEqual(actual3D,expected3D);
+            end
+        end
+
+        function testSupportedMethodsArePeriodic(testCase)
+            [x,y] = testCase.horizontalQueryPoints();
+            zGrid = testCase.wvt.z;
+            z = reshape((zGrid(2:5)+zGrid(3:6))/2,1,[]);
+            xShifted = x + [testCase.wvt.Lx -testCase.wvt.Lx 2*testCase.wvt.Lx -2*testCase.wvt.Lx];
+            yShifted = y + [-testCase.wvt.Ly 2*testCase.wvt.Ly -2*testCase.wvt.Ly testCase.wvt.Ly];
+
+            for method = ["linear" "spline"]
+                [expected2D,expected3D] = testCase.wvt.variableAtPositionWithName(x,y,z,'interpolationTest2D','interpolationTest3D',interpolationMethod=method);
+                [actual2D,actual3D] = testCase.wvt.variableAtPositionWithName(xShifted,yShifted,z,'interpolationTest2D','interpolationTest3D',interpolationMethod=method);
+
+                testCase.verifySize(actual2D,size(x));
+                testCase.verifySize(actual3D,size(x));
+                testCase.verifyEqual(actual2D,expected2D,AbsTol=1e-12);
+                testCase.verifyEqual(actual3D,expected3D,AbsTol=1e-12);
+            end
+        end
+
+        function testSupportedMethodsReproduceGridValues(testCase)
+            iX = [1 4 8];
+            iY = [2 5 1];
+            iZ = [1 4 7];
+            x = reshape(testCase.wvt.x(iX),1,[]);
+            y = reshape(testCase.wvt.y(iY),1,[]);
+            z = reshape(testCase.wvt.z(iZ),1,[]);
+            expected2D = reshape(testCase.field2D(sub2ind(size(testCase.field2D),iX,iY)),1,[]);
+            expected3D = reshape(testCase.field3D(sub2ind(size(testCase.field3D),iX,iY,iZ)),1,[]);
+
+            for method = ["linear" "spline"]
+                [actual2D,actual3D] = testCase.wvt.variableAtPositionWithName(x,y,z,'interpolationTest2D','interpolationTest3D',interpolationMethod=method);
+                testCase.verifyEqual(actual2D,expected2D,AbsTol=1e-12);
+                testCase.verifyEqual(actual3D,expected3D,AbsTol=1e-12);
+            end
+        end
+
+        function testSplineIsContinuousAcrossPeriodicSeams(testCase)
+            dx = testCase.wvt.x(2)-testCase.wvt.x(1);
+            dy = testCase.wvt.y(2)-testCase.wvt.y(1);
+            epsilonX = 1e-7*dx;
+            epsilonY = 1e-7*dy;
+            z = testCase.wvt.z(4);
+
+            [left2D,left3D] = testCase.wvt.variableAtPositionWithName(testCase.wvt.Lx-epsilonX,2.4*dy,z,'interpolationTest2D','interpolationTest3D',interpolationMethod='spline');
+            [right2D,right3D] = testCase.wvt.variableAtPositionWithName(epsilonX,2.4*dy,z,'interpolationTest2D','interpolationTest3D',interpolationMethod='spline');
+            [bottom2D,bottom3D] = testCase.wvt.variableAtPositionWithName(3.2*dx,testCase.wvt.Ly-epsilonY,z,'interpolationTest2D','interpolationTest3D',interpolationMethod='spline');
+            [top2D,top3D] = testCase.wvt.variableAtPositionWithName(3.2*dx,epsilonY,z,'interpolationTest2D','interpolationTest3D',interpolationMethod='spline');
+
+            tolerance = 1e-5*max(abs([testCase.field2D(:);testCase.field3D(:)]));
+            testCase.verifyLessThan(abs(right2D-left2D),tolerance);
+            testCase.verifyLessThan(abs(right3D-left3D),tolerance);
+            testCase.verifyLessThan(abs(top2D-bottom2D),tolerance);
+            testCase.verifyLessThan(abs(top3D-bottom3D),tolerance);
+        end
+
+        function testBarotropicSupportedInterpolation(testCase)
+            transform = testCase.barotropicTransform;
+            dx = transform.x(2)-transform.x(1);
+            dy = transform.y(2)-transform.y(1);
+            x = [3.25*dx -0.25*dx 3.25*dx transform.Lx+0.2*dx];
+            y = [3.4*dy 3.4*dy transform.Ly+0.3*dy transform.Ly-0.25*dy];
+            xShifted = x + [transform.Lx -transform.Lx 2*transform.Lx -2*transform.Lx];
+            yShifted = y + [-transform.Ly 2*transform.Ly -2*transform.Ly transform.Ly];
+
+            for method = ["linear" "spline"]
+                expected = transform.variableAtPositionWithName(x,y,[],'barotropicInterpolationTest',interpolationMethod=method);
+                actual = transform.variableAtPositionWithName(xShifted,yShifted,[],'barotropicInterpolationTest',interpolationMethod=method);
+                testCase.verifySize(actual,size(x));
+                testCase.verifyEqual(actual,expected,AbsTol=1e-12);
+            end
+
+            expectedLinear = testCase.periodicInterpolation2D(transform,testCase.barotropicField,x,y);
+            actualLinear = transform.variableAtPositionWithName(x,y,[],'barotropicInterpolationTest',interpolationMethod='linear');
+            testCase.verifyEqual(actualLinear,expectedLinear,AbsTol=1e-12);
+
+            iX = [1 4 8];
+            iY = [2 5 1];
+            xGrid = reshape(transform.x(iX),1,[]);
+            yGrid = reshape(transform.y(iY),1,[]);
+            expectedGrid = reshape(testCase.barotropicField(sub2ind(size(testCase.barotropicField),iX,iY)),1,[]);
+            for method = ["linear" "spline"]
+                actualGrid = transform.variableAtPositionWithName(xGrid,yGrid,[],'barotropicInterpolationTest',interpolationMethod=method);
+                testCase.verifyEqual(actualGrid,expectedGrid,AbsTol=1e-12);
+            end
+
+            epsilonX = 1e-7*dx;
+            epsilonY = 1e-7*dy;
+            left = transform.variableAtPositionWithName(transform.Lx-epsilonX,2.4*dy,[],'barotropicInterpolationTest',interpolationMethod='spline');
+            right = transform.variableAtPositionWithName(epsilonX,2.4*dy,[],'barotropicInterpolationTest',interpolationMethod='spline');
+            bottom = transform.variableAtPositionWithName(3.2*dx,transform.Ly-epsilonY,[],'barotropicInterpolationTest',interpolationMethod='spline');
+            top = transform.variableAtPositionWithName(3.2*dx,epsilonY,[],'barotropicInterpolationTest',interpolationMethod='spline');
+            tolerance = 1e-5*max(abs(testCase.barotropicField(:)));
+            testCase.verifyLessThan(abs(right-left),tolerance);
+            testCase.verifyLessThan(abs(top-bottom),tolerance);
+        end
     end
 
     methods (Access=private)
@@ -66,10 +189,11 @@ classdef TestInterpolatedFieldAtPosition < matlab.unittest.TestCase
             y = [3.4*dy 3.4*dy testCase.wvt.Ly+0.3*dy testCase.wvt.Ly-0.25*dy];
         end
 
-        function expected = periodicInterpolation2D(testCase,field,x,y)
-            [xPeriodic,yPeriodic] = testCase.periodicGrid();
+        function expected = periodicInterpolation2D(~,transform,field,x,y)
+            xPeriodic = [transform.x(end)-transform.Lx;transform.x;transform.x(1)+transform.Lx];
+            yPeriodic = [transform.y(end)-transform.Ly;transform.y;transform.y(1)+transform.Ly];
             fieldPeriodic = field([end 1:end 1],[end 1:end 1]);
-            expected = interpn(xPeriodic,yPeriodic,fieldPeriodic,mod(x,testCase.wvt.Lx),mod(y,testCase.wvt.Ly),'linear');
+            expected = interpn(xPeriodic,yPeriodic,fieldPeriodic,mod(x,transform.Lx),mod(y,transform.Ly),'linear');
         end
 
         function expected = periodicInterpolation3D(testCase,field,x,y,z)

--- a/UnitTests/TestPublicInterpolationContract.m
+++ b/UnitTests/TestPublicInterpolationContract.m
@@ -1,0 +1,111 @@
+classdef TestPublicInterpolationContract < matlab.unittest.TestCase
+
+    properties
+        wvt
+    end
+
+    properties (TestParameter)
+        invalidInterpolationMethod = {'exact','finufft','nearest'}
+        supportedInterpolationMethod = {'linear','spline'}
+    end
+
+    methods (TestClassSetup)
+        function classSetup(testCase)
+            Lxyz = [1000 800 500];
+            Nxyz = [8 8 7];
+            N2 = @(z) (5.2e-3)^2*(1 + 0.2*z/Lxyz(3));
+            testCase.wvt = WVTransformHydrostatic(Lxyz,Nxyz,N2=N2,shouldAntialias=false);
+        end
+    end
+
+    methods (Test, TestTags = "full")
+        function testTransformRejectsUnsupportedMethods(testCase,invalidInterpolationMethod)
+            testCase.verifyError(@() testCase.wvt.variableAtPositionWithName(0,0,[],'u',interpolationMethod=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+        end
+
+        function testLagrangianParticlesRejectUnsupportedAdvection(testCase,invalidInterpolationMethod)
+            model = testCase.model();
+            testCase.verifyError(@() WVLagrangianParticles(model,name='invalid',x=0,y=0,z=-100,trackedFieldNames={},advectionInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+        end
+
+        function testLagrangianParticlesRejectUnsupportedTrackedFields(testCase,invalidInterpolationMethod)
+            model = testCase.model();
+            testCase.verifyError(@() WVLagrangianParticles(model,name='invalid',x=0,y=0,z=-100,trackedFieldNames={},trackedVarInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+        end
+
+        function testAddParticlesRejectsUnsupportedMethods(testCase,invalidInterpolationMethod)
+            model = testCase.model();
+            testCase.verifyError(@() model.addParticles('invalid-advection',false,0,0,-100,advectionInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+            testCase.verifyError(@() model.addParticles('invalid-tracked',false,0,0,-100,trackedVarInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+        end
+
+        function testSetFloatPositionsRejectsUnsupportedMethods(testCase,invalidInterpolationMethod)
+            model = testCase.model();
+            testCase.verifyError(@() model.setFloatPositions(0,0,-100,advectionInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+            testCase.verifyError(@() model.setFloatPositions(0,0,-100,trackedVarInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+        end
+
+        function testSetDrifterPositionsRejectsUnsupportedMethods(testCase,invalidInterpolationMethod)
+            model = testCase.model();
+            testCase.verifyError(@() model.setDrifterPositions(0,0,[],advectionInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+            testCase.verifyError(@() model.setDrifterPositions(0,0,[],trackedVarInterpolation=invalidInterpolationMethod),'MATLAB:validators:mustBeMember');
+        end
+
+        function testSupportedMethodsPropagateThroughParticleAPIs(testCase,supportedInterpolationMethod)
+            directModel = testCase.model();
+            direct = WVLagrangianParticles(directModel,name='direct',x=0,y=0,z=-100,trackedFieldNames={},advectionInterpolation=supportedInterpolationMethod,trackedVarInterpolation=supportedInterpolationMethod);
+            testCase.verifyEqual(direct.advectionInterpolation,supportedInterpolationMethod);
+            testCase.verifyEqual(direct.trackedVarInterpolation,supportedInterpolationMethod);
+
+            particleModel = testCase.model();
+            particleModel.addParticles('particles',false,0,0,-100,advectionInterpolation=supportedInterpolationMethod,trackedVarInterpolation=supportedInterpolationMethod);
+            particles = particleModel.fluxedObservingSystemWithName('particles');
+            testCase.verifyEqual(particles.advectionInterpolation,supportedInterpolationMethod);
+            testCase.verifyEqual(particles.trackedVarInterpolation,supportedInterpolationMethod);
+
+            floatModel = testCase.model();
+            floatModel.setFloatPositions(0,0,-100,advectionInterpolation=supportedInterpolationMethod,trackedVarInterpolation=supportedInterpolationMethod);
+            floats = floatModel.fluxedObservingSystemWithName('float');
+            testCase.verifyEqual(floats.advectionInterpolation,supportedInterpolationMethod);
+            testCase.verifyEqual(floats.trackedVarInterpolation,supportedInterpolationMethod);
+
+            drifterModel = testCase.model();
+            drifterModel.setDrifterPositions(0,0,[],advectionInterpolation=supportedInterpolationMethod,trackedVarInterpolation=supportedInterpolationMethod);
+            drifters = drifterModel.fluxedObservingSystemWithName('drifter');
+            testCase.verifyEqual(drifters.advectionInterpolation,supportedInterpolationMethod);
+            testCase.verifyEqual(drifters.trackedVarInterpolation,supportedInterpolationMethod);
+        end
+
+        function testParticleInterpolationDefaults(testCase)
+            directModel = testCase.model();
+            direct = WVLagrangianParticles(directModel,name='direct',x=0,y=0,z=-100,trackedFieldNames={});
+            testCase.verifyEqual(direct.advectionInterpolation,'linear');
+            testCase.verifyEqual(direct.trackedVarInterpolation,'linear');
+
+            particleModel = testCase.model();
+            particleModel.addParticles('particles',false,0,0,-100);
+            particles = particleModel.fluxedObservingSystemWithName('particles');
+            testCase.verifyEqual(particles.advectionInterpolation,'linear');
+            testCase.verifyEqual(particles.trackedVarInterpolation,'spline');
+
+            floatModel = testCase.model();
+            floatModel.setFloatPositions(0,0,-100);
+            floats = floatModel.fluxedObservingSystemWithName('float');
+            testCase.verifyEqual(floats.advectionInterpolation,'linear');
+            testCase.verifyEqual(floats.trackedVarInterpolation,'linear');
+
+            drifterModel = testCase.model();
+            drifterModel.setDrifterPositions(0,0,[]);
+            drifters = drifterModel.fluxedObservingSystemWithName('drifter');
+            testCase.verifyEqual(drifters.advectionInterpolation,'linear');
+            testCase.verifyEqual(drifters.trackedVarInterpolation,'linear');
+        end
+    end
+
+    methods (Access=private)
+        function model = model(testCase)
+            model = WVModel(testCase.wvt,shouldUseLinearDynamics=true);
+        end
+    end
+
+end

--- a/docs/classes/observing-systems/wvlagrangianparticles/wvlagrangianparticles.md
+++ b/docs/classes/observing-systems/wvlagrangianparticles/wvlagrangianparticles.md
@@ -9,25 +9,27 @@ mathjax: true
 
 #  WVLagrangianParticles
 
-create a new observing system
+Create a Lagrangian-particle observing system.
 
 
 ---
 
 ## Declaration
 ```matlab
- self = WVObservingSystem(model,name)
+ self = WVLagrangianParticles(model,options)
 ```
 ## Parameters
 + `model`  the WVModel instance
 + `name`  name of the observing system
++ `advectionInterpolation`  (optional) `linear` (default) or `spline` interpolation for particle advection
++ `trackedVarInterpolation`  (optional) `linear` (default) or `spline` interpolation for tracked fields
 
 ## Returns
-+ `self`  a new instance of WVObservingSystem
++ `self`  a new WVLagrangianParticles instance
 
 ## Discussion
 
-  This class is intended to be subclassed, so it generally
-  assumed that this initialization will not be called directly.
+  This class is intended to be subclassed, so this initializer
+  is generally called by a model particle facade.
  
           

--- a/docs/classes/transforms/wvtransform/variableatpositionwithname.md
+++ b/docs/classes/transforms/wvtransform/variableatpositionwithname.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  variableAtPositionWithName
 
-Primary method for accessing the dynamical variables on the at any
+Access dynamical variables at arbitrary positions in the domain.
 
 
 ---
@@ -23,17 +23,15 @@ Primary method for accessing the dynamical variables on the at any
 + `y`  array of y-positions
 + `z`  array of z-positions, or empty for two-dimensional variables
 + `variableNames`  strings of variable names.
-+ `interpolationMethod`  (optional) `linear`,`spline`,`exact`. Default `linear`.
++ `interpolationMethod`  (optional) `linear` or `spline`. Default `linear`.
 
 ## Discussion
-position in the domain.
- 
+
   Computes (or retrieves from cache) any known state variables and computes
   their values at the requested positions (x,y,z). For two-dimensional
   variables, interpolation uses only (x,y), and z may be empty.
  
-  The method argument specifies how off-grid values should be interpolated.
-  Use 'exact' for the slow, but accurate, spectral interpolation. Otherwise
-  use 'spline' or some other method used by Matlab's interp function.
+  The interpolation method may be `linear` or `spline`. Horizontal
+  coordinates are wrapped periodically before interpolation.
  
               

--- a/docs/classes/wvmodel/addparticles.md
+++ b/docs/classes/wvmodel/addparticles.md
@@ -16,17 +16,17 @@ Add particles to be advected by the flow.
 
 ## Declaration
 ```matlab
- addParticles(name,fluxOp,x,y,z,trackedFieldNames,options)
+ addParticles(name,isXYOnly,x,y,z,trackedFieldNames,options)
 ```
 ## Parameters
 + `name`  a unique name to call the particles
-+ `fluxOp`  a WVParticleFluxOperation, used to determine how the flow advects the particles
++ `isXYOnly`  whether particles are advected only in the horizontal dimensions
 + `x`  x-coordinate location of the particles
 + `y`  y-coordinate location of the particles
 + `z`  z-coordinate location of the particles
-+ `trackedFields`  strings of variable names
-+ `advectionInterpolation`  (optional) interpolation method used for particle advection. "linear" (default), "spline", "exact"
-+ `trackedVarInterpolation`  (optional) interpolation method used for tracked field. "linear" (default), "spline", "exact"
++ `trackedFieldNames`  strings of variable names
++ `advectionInterpolation`  (optional) `linear` (default) or `spline` interpolation for particle advection
++ `trackedVarInterpolation`  (optional) `linear` or `spline` (default) interpolation for tracked fields
 + `absToleranceXY`  (adapative) absolute tolerance in meters for particle advection in (x,y). 1e-1 (default)
 + `absToleranceZ`  (adapative) absolute tolerance  in meters for particle advection in (z). 1e-2 (default)
 

--- a/docs/classes/wvmodel/setdrifterpositions.md
+++ b/docs/classes/wvmodel/setdrifterpositions.md
@@ -14,3 +14,14 @@ Set positions of drifter-like particles to be advected.
 
 ---
 
+## Declaration
+```matlab
+ setDrifterPositions(self,x,y,z,trackedFields,options)
+```
+## Parameters
++ `x`  x-coordinate locations of the particles
++ `y`  y-coordinate locations of the particles
++ `z`  optional z-coordinate locations of the particles
++ `trackedFields`  variable names to sample along each trajectory
++ `advectionInterpolation`  (optional) `linear` (default) or `spline` interpolation for particle advection
++ `trackedVarInterpolation`  (optional) `linear` (default) or `spline` interpolation for tracked fields

--- a/docs/classes/wvmodel/setfloatpositions.md
+++ b/docs/classes/wvmodel/setfloatpositions.md
@@ -23,8 +23,8 @@ Set positions of float-like particles to be advected by the model.
 + `y`  y-coordinate location of the particles
 + `z`  z-coordinate location of the particles
 + `trackedFields`  strings of variable names
-+ `advectionInterpolation`  (optional) interpolation method used for particle advection. "linear" (default), "spline", "exact"
-+ `trackedVarInterpolation`  (optional) interpolation method used for tracked field. "linear" (default), "spline", "exact"
++ `advectionInterpolation`  (optional) `linear` (default) or `spline` interpolation for particle advection
++ `trackedVarInterpolation`  (optional) `linear` (default) or `spline` interpolation for tracked fields
 + `absToleranceXY`  (adapative) absolute tolerance in meters for particle advection in (x,y). 1e-1 (default)
 + `absToleranceZ`  (adapative) absolute tolerance  in meters for particle advection in (z). 1e-2 (default)
 
@@ -40,8 +40,8 @@ Set positions of float-like particles to be advected by the model.
   many flows this will have sufficient accuracy and allow you
   to place float at nearly every grid point without slowing
   down the model integration. However, if high accuracy is
-  required, you may want to use cubic "spline" interpolation or
-  even "exact" at the expense of computational speed.
+  required, you may want to use cubic "spline" interpolation at
+  the expense of computational speed.
  
   You can track the value of any known WVVariableAnnotation along the
   particle's flow path, e.g., relative vorticity. These values


### PR DESCRIPTION
## Summary

- restrict public field and particle interpolation options to linear and spline
- remove dead exact and off-grid dispatch while preserving protected internal backends
- add periodic interpolation and public option-contract coverage
- update focused API documentation, changelog, and unsupported README claims

## Verification

- focused interpolation and contract tests: 28 passed
- smoke: 126 passed
- full: 356 passed
- exhaustive: 2440 passed
- MATLAB analyzer, whitespace, scope, and artifact checks completed

Closes #26