### PR TITLE
Complete vertical calculus contracts

### DIFF
--- a/@WVGeometryDoublyPeriodicStratified/diffZF.m
+++ b/@WVGeometryDoublyPeriodicStratified/diffZF.m
@@ -1,9 +1,24 @@
 function du = diffZF(self,u,options)
+% Differentiate an F-grid field with respect to z.
+%
+% `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+% supported. Odd orders return a G-representation and even orders return
+% an F-representation.
+%
+% - Topic: Operations — Calculus
+% - Declaration: du = diffZF(u,n=n)
+% - Parameter u: F-grid field with dimensions `[Nx Ny Nz]`
+% - Parameter n: derivative order from 1 through 4 (default 1)
+% - Returns du: vertical derivative in the alternating F/G representation
 arguments
     self        WVTransform
-    u (:,:,:)   double
-    options.n (1,1)     double = 1
+    u           double
+    options.n (1,1) double {mustBeMember(options.n,1:4)} = 1
 end
+mustBeMember(ndims(u),3);
+mustBeMember(size(u,1),self.Nx);
+mustBeMember(size(u,2),self.Ny);
+mustBeMember(size(u,3),self.Nz);
 n = options.n;
 u = permute(u,[3 1 2]); % keep adjacent in memory
 u = reshape(u,self.Nz,[]);
@@ -24,8 +39,6 @@ elseif n == 4
     DzzG = -(self.N2/self.g) .* self.QG0inv*(squeeze(1./self.h_0).*self.QG0);
     DzG = self.PF0inv*(squeeze(self.P0./(self.Q0 .* self.h_0)).*self.QG0);
     D = DzG * DzzG * DzF;
-else
-    error('Not yet implemented')
 end
 du =  D*u;
 

--- a/@WVGeometryDoublyPeriodicStratified/diffZG.m
+++ b/@WVGeometryDoublyPeriodicStratified/diffZG.m
@@ -1,9 +1,24 @@
 function du = diffZG(self,u,options)
+% Differentiate a G-grid field with respect to z.
+%
+% `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+% supported. Odd orders return an F-representation and even orders return
+% a G-representation.
+%
+% - Topic: Operations — Calculus
+% - Declaration: du = diffZG(u,n=n)
+% - Parameter u: G-grid field with dimensions `[Nx Ny Nz]`
+% - Parameter n: derivative order from 1 through 4 (default 1)
+% - Returns du: vertical derivative in the alternating G/F representation
 arguments
     self        WVTransform
-    u (:,:,:)   double
-    options.n (1,1)     double = 1
+    u           double
+    options.n (1,1) double {mustBeMember(options.n,1:4)} = 1
 end
+mustBeMember(ndims(u),3);
+mustBeMember(size(u,1),self.Nx);
+mustBeMember(size(u,2),self.Ny);
+mustBeMember(size(u,3),self.Nz);
 n = options.n;
 u = permute(u,[3 1 2]); % keep adjacent in memory
 u = reshape(u,self.Nz,[]);
@@ -21,8 +36,6 @@ elseif n == 3
 elseif n == 4
     DzzG = -(self.N2/self.g) .* self.QG0inv*(squeeze(1./self.h_0).*self.QG0);
     D = DzzG * DzzG;
-else
-    error('Not yet implemented')
 end
 du =  D*u;
 

--- a/@WVGeometryDoublyPeriodicStratified/intZF.m
+++ b/@WVGeometryDoublyPeriodicStratified/intZF.m
@@ -1,25 +1,37 @@
 function U = intZF(self,u,options)
+% Return the first antiderivative of an F-representation.
+%
+% The result is the antiderivative representable in G space. The
+% barotropic F mode is removed because it has no corresponding G mode, so
+% the result vanishes at both vertical boundaries. `u` may use the gridded
+% layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
+% array preserves that layout.
+%
+% - Topic: Operations — Calculus
+% - Declaration: U = intZF(u,n=1)
+% - Parameter u: F-representation in `[Nx Ny Nz]` or `[Nz N]` layout
+% - Parameter n: antiderivative order; only 1 is supported (default 1)
+% - Returns U: G-representation antiderivative in the input layout
 arguments
     self        WVTransform
-    u (:,:,:)   double
-    options.n (1,1)     double = 1
+    u           double
+    options.n (1,1) double = 1
 end
-n = options.n;
+mustBeMember(options.n,1);
 didShift = false;
-if size(u,3) == self.Nz
+if ndims(u) == 3
+    mustBeMember(size(u,1),self.Nx);
+    mustBeMember(size(u,2),self.Ny);
+    mustBeMember(size(u,3),self.Nz);
     u = permute(u,[3 1 2]); % keep adjacent in memory
     u = reshape(u,self.Nz,[]);
     didShift = true;
-elseif size(u,1) ~= self.Nz
-    error("incompatible size for operation");
-end
-if n == 1
-    IntZF = self.QG0inv*(squeeze(self.h_0 .* self.Q0 ./ self.P0).*self.PF0);
-    Int = IntZF;
 else
-    error('Not yet implemented')
+    mustBeMatrix(u);
+    mustBeMember(size(u,1),self.Nz);
 end
-U =  Int*u;
+IntZF = self.QG0inv*(squeeze(self.h_0 .* self.Q0 ./ self.P0).*self.PF0);
+U = IntZF*u;
 
 if didShift
     U = reshape(U,self.Nz,self.Nx,self.Ny);

--- a/@WVGeometryDoublyPeriodicStratified/intZG.m
+++ b/@WVGeometryDoublyPeriodicStratified/intZG.m
@@ -1,27 +1,38 @@
 function W = intZG(self,w,options)
+% Return the bottom-zero first antiderivative of a G-representation.
+%
+% A G-to-F antiderivative is defined up to an additive constant. This
+% method selects the representative that vanishes at the bottom boundary.
+% `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
+% `[Nz N]`; the returned array preserves that layout.
+%
+% - Topic: Operations — Calculus
+% - Declaration: W = intZG(w,n=1)
+% - Parameter w: G-representation in `[Nx Ny Nz]` or `[Nz N]` layout
+% - Parameter n: antiderivative order; only 1 is supported (default 1)
+% - Returns W: bottom-zero F-representation antiderivative in the input layout
 arguments
     self        WVTransform
     w           double
-    options.n (1,1)     double = 1
+    options.n (1,1) double = 1
 end
-n = options.n;
+mustBeMember(options.n,1);
 didShift = false;
-if size(w,3) == self.Nz
+if ndims(w) == 3
+    mustBeMember(size(w,1),self.Nx);
+    mustBeMember(size(w,2),self.Ny);
+    mustBeMember(size(w,3),self.Nz);
     w = permute(w,[3 1 2]); % keep adjacent in memory
     w = reshape(w,self.Nz,[]);
     didShift = true;
-elseif size(w,1) ~= self.Nz
-    error("incompatible size for operation");
+else
+    mustBeMatrix(w);
+    mustBeMember(size(w,1),self.Nz);
 end
 
-if n == 1
-    PF0inv = self.PF0inv - self.PF0inv(1,:);
-    IntZG = - self.g*PF0inv*(squeeze(self.P0./self.Q0).*(self.QG0 .* shiftdim(1./self.N2,-1)));
-    Int = IntZG;
-else
-    error('Not yet implemented')
-end
-W =  Int*w;
+PF0inv = self.PF0inv - self.PF0inv(1,:);
+IntZG = - self.g*PF0inv*(squeeze(self.P0./self.Q0).*(self.QG0 .* shiftdim(1./self.N2,-1)));
+W = IntZG*w;
 
 if didShift
     W = reshape(W,self.Nz,self.Nx,self.Ny);

--- a/@WVGeometryDoublyPeriodicStratifiedConstant/diffZF.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/diffZF.m
@@ -1,9 +1,24 @@
 function du = diffZF(self,u,options)
+% Differentiate an F-grid field with respect to z.
+%
+% `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+% supported. Odd orders return a G-representation and even orders return
+% an F-representation.
+%
+% - Topic: Operations — Calculus
+% - Declaration: du = diffZF(u,n=n)
+% - Parameter u: F-grid field with dimensions `[Nx Ny Nz]`
+% - Parameter n: derivative order from 1 through 4 (default 1)
+% - Returns du: vertical derivative in the alternating F/G representation
 arguments
     self        WVTransform
-    u (:,:,:)   double
-    options.n (1,1)     double = 1
+    u           double
+    options.n (1,1) double {mustBeMember(options.n,1:4)} = 1
 end
+mustBeMember(ndims(u),3);
+mustBeMember(size(u,1),self.Nx);
+mustBeMember(size(u,2),self.Ny);
+mustBeMember(size(u,3),self.Nz);
 n = options.n;
 u = permute(u,[3 1 2]); % keep adjacent in memory
 u = reshape(u,self.Nz,[]);

--- a/@WVGeometryDoublyPeriodicStratifiedConstant/diffZG.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/diffZG.m
@@ -1,9 +1,24 @@
 function du = diffZG(self,u,options)
+% Differentiate a G-grid field with respect to z.
+%
+% `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+% supported. Odd orders return an F-representation and even orders return
+% a G-representation.
+%
+% - Topic: Operations — Calculus
+% - Declaration: du = diffZG(u,n=n)
+% - Parameter u: G-grid field with dimensions `[Nx Ny Nz]`
+% - Parameter n: derivative order from 1 through 4 (default 1)
+% - Returns du: vertical derivative in the alternating G/F representation
 arguments
     self        WVTransform
-    u (:,:,:)   double
-    options.n (1,1)     double = 1
+    u           double
+    options.n (1,1) double {mustBeMember(options.n,1:4)} = 1
 end
+mustBeMember(ndims(u),3);
+mustBeMember(size(u,1),self.Nx);
+mustBeMember(size(u,2),self.Ny);
+mustBeMember(size(u,3),self.Nz);
 n = options.n;
 u = permute(u,[3 1 2]); % keep adjacent in memory
 u = reshape(u,self.Nz,[]);

--- a/@WVGeometryDoublyPeriodicStratifiedConstant/intZF.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/intZF.m
@@ -1,26 +1,44 @@
 function U = intZF(self,u,options)
+% Return the first antiderivative of an F-representation.
+%
+% The result is the antiderivative representable in G space. The
+% barotropic F mode is removed because it has no corresponding G mode, so
+% the result vanishes at both vertical boundaries. `u` may use the gridded
+% layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
+% array preserves that layout.
+%
+% - Topic: Operations — Calculus
+% - Declaration: U = intZF(u,n=1)
+% - Parameter u: F-representation in `[Nx Ny Nz]` or `[Nz N]` layout
+% - Parameter n: antiderivative order; only 1 is supported (default 1)
+% - Returns U: G-representation antiderivative in the input layout
 arguments
     self        WVTransform
-    u (:,:,:)   double
-    options.n (1,1)     double = 1
+    u           double
+    options.n (1,1) double = 1
 end
-error("Not yet implemented for constant stratification")
-% n = options.n;
-% if size(u,3) == self.Nz
-%     u = permute(u,[3 1 2]); % keep adjacent in memory
-%     u = reshape(u,self.Nz,[]);
-% elseif size(u,1) ~= self.Nz
-%     error("incompatible size for operation");
-% end
-% if n == 1
-%     IntZF = self.QG0inv*(squeeze(self.h_0 .* self.Q0 ./ self.P0).*self.PF0);
-%     Int = IntZF;
-% else
-%     error('Not yet implemented')
-% end
-% U =  Int*u;
-% 
-% U = reshape(U,self.Nz,self.Nx,self.Ny);
-% U = permute(U,[2 3 1]);
+mustBeMember(options.n,1);
+didShift = false;
+if ndims(u) == 3
+    mustBeMember(size(u,1),self.Nx);
+    mustBeMember(size(u,2),self.Ny);
+    mustBeMember(size(u,3),self.Nz);
+    u = permute(u,[3 1 2]); % keep adjacent in memory
+    u = reshape(u,self.Nz,[]);
+    didShift = true;
+else
+    mustBeMatrix(u);
+    mustBeMember(size(u,1),self.Nz);
+end
+
+m = reshape(pi*self.j/self.Lz,[],1);
+inverseM = zeros(size(m));
+inverseM(m ~= 0) = 1./m(m ~= 0);
+U = self.iDST*(inverseM .* (self.DCT*u));
+
+if didShift
+    U = reshape(U,self.Nz,self.Nx,self.Ny);
+    U = permute(U,[2 3 1]);
+end
 
 end

--- a/@WVGeometryDoublyPeriodicStratifiedConstant/intZG.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/intZG.m
@@ -1,28 +1,44 @@
 function W = intZG(self,w,options)
+% Return the bottom-zero first antiderivative of a G-representation.
+%
+% A G-to-F antiderivative is defined up to an additive constant. This
+% method selects the representative that vanishes at the bottom boundary.
+% `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
+% `[Nz N]`; the returned array preserves that layout.
+%
+% - Topic: Operations — Calculus
+% - Declaration: W = intZG(w,n=1)
+% - Parameter w: G-representation in `[Nx Ny Nz]` or `[Nz N]` layout
+% - Parameter n: antiderivative order; only 1 is supported (default 1)
+% - Returns W: bottom-zero F-representation antiderivative in the input layout
 arguments
     self        WVTransform
     w           double
-    options.n (1,1)     double = 1
+    options.n (1,1) double = 1
 end
-error("Not yet implemented for constant stratification")
-% n = options.n;
-% if size(w,3) == self.Nz
-%     w = permute(w,[3 1 2]); % keep adjacent in memory
-%     w = reshape(w,self.Nz,[]);
-% elseif size(w,1) ~= self.Nz
-%     error("incompatible size for operation");
-% end
-% 
-% if n == 1
-%     PF0inv = self.PF0inv - self.PF0inv(1,:);
-%     IntZG = - self.g*PF0inv*(squeeze(self.P0./self.Q0).*(wvt.QG0 .* shiftdim(1./wvt.N2,-1)));
-%     Int = IntZG;
-% else
-%     error('Not yet implemented')
-% end
-% W =  Int*w;
-% 
-% W = reshape(W,self.Nz,self.Nx,self.Ny);
-% W = permute(W,[2 3 1]);
+mustBeMember(options.n,1);
+didShift = false;
+if ndims(w) == 3
+    mustBeMember(size(w,1),self.Nx);
+    mustBeMember(size(w,2),self.Ny);
+    mustBeMember(size(w,3),self.Nz);
+    w = permute(w,[3 1 2]); % keep adjacent in memory
+    w = reshape(w,self.Nz,[]);
+    didShift = true;
+else
+    mustBeMatrix(w);
+    mustBeMember(size(w,1),self.Nz);
+end
+
+m = reshape(pi*self.j/self.Lz,[],1);
+inverseM = zeros(size(m));
+inverseM(m ~= 0) = 1./m(m ~= 0);
+W = -self.iDCT*(inverseM .* (self.DST*w));
+W = W - W(1,:);
+
+if didShift
+    W = reshape(W,self.Nz,self.Nx,self.Ny);
+    W = permute(W,[2 3 1]);
+end
 
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Completed the supported vertical-calculus contract: first through fourth derivatives now use ordinary MATLAB order and grid-layout validation, and all stable three-dimensional transforms provide first antiderivatives with documented G-space projection and bottom-zero conventions.
 - Restricted public field and particle interpolation to periodic `linear` and `spline` methods and removed the dead `exact` and off-grid dispatch.
 - Documented the v4.2.1 target support contract: the five current transform families, the supported latitude domain of `5 <= abs(latitude) <= 85`, MATLAB builtin FFTs, fixed and adaptive integration, and periodic `linear` and `spline` interpolation are stable; `adaptive-cell` integration is experimental; and FFTW, `exact` and `finufft` interpolation, off-grid behavior, and legacy low-level entry points are internal.
 - Enforced the supported latitude domain and restored a deterministic, order-independent green test baseline with isolated random state and temporary files.

--- a/Documentation/WebsiteDocumentation/users-guide/supported-features.md
+++ b/Documentation/WebsiteDocumentation/users-guide/supported-features.md
@@ -36,6 +36,7 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | MATLAB builtin FFT implementation | Stable | This is the supported Fourier-transform backend. |
 | FFTW and `RealToComplexTransform` integration | Internal | These backend remnants are not selectable through a supported transform contract. |
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
+| Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
 | `exact` and `finufft` interpolation | Internal | These implementation paths and option values must not appear in public option lists or user documentation. |
 | `WVOffGridTransform`, external-wave behavior, and off-grid pressure | Internal | These incomplete remnants have no 4.2.x compatibility promise. |
 
@@ -103,8 +104,6 @@ The following contracts are part of the v4.2.1 target even though their 4.2.0 im
 
 | Interface | v4.2.1 target |
 | --- | --- |
-| `diffZF` and `diffZG` | Support derivative orders 1 through 4 and reject other orders with a clear, stable error. |
-| `intZF` and `intZG` | Support first-order integration for every stable three-dimensional transform and reject higher orders with a clear, stable error. |
 | `hasMeanPressureDifference` | Return the documented result instead of a placeholder error. |
 | `WVTotalFlowComponent.solutionForModeAtIndex` | Return the documented total-flow solution instead of a placeholder error. |
 | `summarizeDegreesOfFreedom` | Provide a general implementation for the stable transform surface. |

--- a/UnitTests/TestVerticalCalculus.m
+++ b/UnitTests/TestVerticalCalculus.m
@@ -1,0 +1,181 @@
+classdef TestVerticalCalculus < matlab.unittest.TestCase
+    properties
+        wvt
+        isConstant
+    end
+
+    properties (ClassSetupParameter)
+        transformType = struct( ...
+            constantHydrostatic="constantHydrostatic", ...
+            constantNonhydrostatic="constantNonhydrostatic", ...
+            hydrostatic="hydrostatic", ...
+            boussinesq="boussinesq", ...
+            stratifiedQG="stratifiedQG")
+    end
+
+    methods (TestClassSetup)
+        function createTransform(testCase,transformType)
+            Lxyz = [6e3 4e3 1e3];
+            Nxyz = [6 6 9];
+            N2 = @(z) 2e-5*exp(z/4000);
+            switch transformType
+                case "constantHydrostatic"
+                    testCase.wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=true,shouldAntialias=false);
+                    testCase.isConstant = true;
+                case "constantNonhydrostatic"
+                    testCase.wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=false);
+                    testCase.isConstant = true;
+                case "hydrostatic"
+                    testCase.wvt = WVTransformHydrostatic(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                    testCase.isConstant = false;
+                case "boussinesq"
+                    testCase.wvt = WVTransformBoussinesq(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                    testCase.isConstant = false;
+                case "stratifiedQG"
+                    testCase.wvt = WVTransformStratifiedQG(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                    testCase.isConstant = false;
+            end
+        end
+    end
+
+    methods (Test, TestTags = "full")
+        function constantModesDifferentiateAnalytically(testCase)
+            if ~testCase.isConstant
+                return
+            end
+
+            wvt = testCase.wvt;
+            [X,Y,Z] = wvt.xyzGrid;
+            horizontal = cos(2*pi*X/wvt.Lx).*cos(2*pi*Y/wvt.Ly);
+            mode = 2;
+            m = mode*pi/wvt.Lz;
+            theta = m*(Z+wvt.Lz);
+            F = horizontal.*cos(theta);
+            G = horizontal.*sin(theta);
+            expectedF = { ...
+                -m*horizontal.*sin(theta), ...
+                -(m^2)*horizontal.*cos(theta), ...
+                (m^3)*horizontal.*sin(theta), ...
+                (m^4)*horizontal.*cos(theta)};
+            expectedG = { ...
+                m*horizontal.*cos(theta), ...
+                -(m^2)*horizontal.*sin(theta), ...
+                -(m^3)*horizontal.*cos(theta), ...
+                (m^4)*horizontal.*sin(theta)};
+
+            for n = 1:4
+                testCase.verifyRelative(wvt.diffZF(F,n=n),expectedF{n},2e-11)
+                testCase.verifyRelative(wvt.diffZG(G,n=n),expectedG{n},2e-11)
+            end
+        end
+
+        function variableModesSatisfyDefiningIdentities(testCase)
+            if testCase.isConstant
+                return
+            end
+
+            wvt = testCase.wvt;
+            [X,Y,~] = wvt.xyzGrid;
+            horizontal = cos(2*pi*X/wvt.Lx).*cos(2*pi*Y/wvt.Ly);
+            modeIndex = 2;
+            F = horizontal.*reshape(wvt.FinvMatrix(:,modeIndex),1,1,wvt.Nz);
+            G = horizontal.*reshape(wvt.GinvMatrix(:,modeIndex),1,1,wvt.Nz);
+            expectedDzF = -reshape(wvt.N2,1,1,wvt.Nz).*G/wvt.g;
+            expectedDzG = F/wvt.h_0(modeIndex);
+
+            testCase.verifyRelative(wvt.diffZF(F),expectedDzF,2e-11)
+            testCase.verifyRelative(wvt.diffZG(G),expectedDzG,2e-11)
+        end
+
+        function directAndRepeatedDerivativesAgree(testCase)
+            wvt = testCase.wvt;
+            [F,G] = testCase.modeFields;
+
+            repeatedF = wvt.diffZF(F);
+            repeatedG = wvt.diffZG(G);
+            testCase.verifyRelative(wvt.diffZF(F,n=1),repeatedF,2e-11)
+            testCase.verifyRelative(wvt.diffZG(G,n=1),repeatedG,2e-11)
+            for n = 2:4
+                if mod(n,2) == 0
+                    repeatedF = wvt.diffZG(repeatedF);
+                    repeatedG = wvt.diffZF(repeatedG);
+                else
+                    repeatedF = wvt.diffZF(repeatedF);
+                    repeatedG = wvt.diffZG(repeatedG);
+                end
+                testCase.verifyRelative(wvt.diffZF(F,n=n),repeatedF,2e-11)
+                testCase.verifyRelative(wvt.diffZG(G,n=n),repeatedG,2e-11)
+            end
+        end
+
+        function firstAntiderivativesSatisfyContracts(testCase)
+            wvt = testCase.wvt;
+            [F,G] = testCase.modeFields;
+
+            intF = wvt.intZF(F);
+            intG = wvt.intZG(G);
+            testCase.verifyRelative(wvt.diffZG(intF),F,2e-11)
+            testCase.verifyRelative(wvt.diffZF(intG),G,2e-11)
+            testCase.verifyLessThanOrEqual(max(abs(intF(:,:,[1 end])),[],"all"),2e-11*max(norm(intF(:)),1))
+            testCase.verifyLessThanOrEqual(max(abs(intG(:,:,1)),[],"all"),2e-11*max(norm(intG(:)),1))
+
+            barotropicF = wvt.FinvMatrix(:,1);
+            testCase.verifyLessThanOrEqual(norm(wvt.intZF(barotropicF)),2e-11*max(norm(barotropicF),1))
+        end
+
+        function integrationPreservesSupportedLayouts(testCase)
+            wvt = testCase.wvt;
+            [F,G] = testCase.modeFields;
+            FMatrix = reshape(permute(F,[3 1 2]),wvt.Nz,[]);
+            GMatrix = reshape(permute(G,[3 1 2]),wvt.Nz,[]);
+
+            intFGrid = wvt.intZF(F);
+            intGGrid = wvt.intZG(G);
+            intFMatrix = wvt.intZF(FMatrix);
+            intGMatrix = wvt.intZG(GMatrix);
+            testCase.verifySize(intFGrid,[wvt.Nx wvt.Ny wvt.Nz])
+            testCase.verifySize(intGGrid,[wvt.Nx wvt.Ny wvt.Nz])
+            testCase.verifySize(intFMatrix,size(FMatrix))
+            testCase.verifySize(intGMatrix,size(GMatrix))
+            testCase.verifyEqual(intFMatrix,reshape(permute(intFGrid,[3 1 2]),wvt.Nz,[]),RelTol=2e-13,AbsTol=2e-13)
+            testCase.verifyEqual(intGMatrix,reshape(permute(intGGrid,[3 1 2]),wvt.Nz,[]),RelTol=2e-13,AbsTol=2e-13)
+
+            FColumn = wvt.FinvMatrix(:,2);
+            GColumn = wvt.GinvMatrix(:,2);
+            testCase.verifySize(wvt.intZF(FColumn),[wvt.Nz 1])
+            testCase.verifySize(wvt.intZG(GColumn),[wvt.Nz 1])
+        end
+
+        function invalidOrdersAndLayoutsUseBuiltinValidation(testCase)
+            wvt = testCase.wvt;
+            grid = zeros(wvt.Nx,wvt.Ny,wvt.Nz);
+            testCase.verifyError(@()wvt.diffZF(grid,n=0),"MATLAB:validators:mustBeMember")
+            testCase.verifyError(@()wvt.diffZG(grid,n=5),"MATLAB:validators:mustBeMember")
+            testCase.verifyError(@()wvt.intZF(grid,n=2),"MATLAB:validators:mustBeMember")
+            testCase.verifyError(@()wvt.intZG(grid,n=2),"MATLAB:validators:mustBeMember")
+            testCase.verifyError(@()wvt.diffZF(zeros(wvt.Nx,wvt.Ny)),"MATLAB:validators:mustBeMember")
+            testCase.verifyError(@()wvt.diffZG(zeros(wvt.Nx+1,wvt.Ny,wvt.Nz)),"MATLAB:validators:mustBeMember")
+            testCase.verifyError(@()wvt.intZF(zeros(wvt.Nz-1,2)),"MATLAB:validators:mustBeMember")
+            testCase.verifyError(@()wvt.intZG(zeros(wvt.Nz,2,1,2)),"MATLAB:validators:mustBeMatrix")
+        end
+    end
+
+    methods (Access = private)
+        function [F,G] = modeFields(testCase)
+            wvt = testCase.wvt;
+            [X,Y,~] = wvt.xyzGrid;
+            horizontal = cos(2*pi*X/wvt.Lx).*cos(2*pi*Y/wvt.Ly);
+            FProfile = wvt.FinvMatrix(:,2) + 0.3*wvt.FinvMatrix(:,3);
+            GProfile = wvt.GinvMatrix(:,2) - 0.2*wvt.GinvMatrix(:,3);
+            F = horizontal.*reshape(FProfile,1,1,wvt.Nz);
+            G = horizontal.*reshape(GProfile,1,1,wvt.Nz);
+        end
+    end
+
+    methods (Access = private)
+        function verifyRelative(testCase,actual,expected,tolerance)
+            errorValue = norm(actual(:)-expected(:))/max(norm(expected(:)),eps);
+            testCase.verifyLessThanOrEqual(errorValue,tolerance)
+        end
+    end
+end

--- a/docs/classes/transforms/wvtransformboussinesq/diffzf.md
+++ b/docs/classes/transforms/wvtransformboussinesq/diffzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZF
 
-
-
+Differentiate an F-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZF(u,n=n)
+```
+## Parameters
++ `u`  F-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating F/G representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return a G-representation and even orders return an F-representation.

--- a/docs/classes/transforms/wvtransformboussinesq/diffzg.md
+++ b/docs/classes/transforms/wvtransformboussinesq/diffzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZG
 
-
-
+Differentiate a G-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZG(u,n=n)
+```
+## Parameters
++ `u`  G-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating G/F representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return an F-representation and even orders return a G-representation.

--- a/docs/classes/transforms/wvtransformboussinesq/intzf.md
+++ b/docs/classes/transforms/wvtransformboussinesq/intzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZF
 
-
-
+Return the first antiderivative of an F-representation.
 
 ---
 
+## Declaration
+```matlab
+U = intZF(u,n=1)
+```
+## Parameters
++ `u`  F-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `U`  G-representation antiderivative in the input layout
+
+## Discussion
+
+The result is the antiderivative representable in G space. The barotropic F mode is removed because it has no corresponding G mode, so the result vanishes at both vertical boundaries. `u` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformboussinesq/intzg.md
+++ b/docs/classes/transforms/wvtransformboussinesq/intzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZG
 
-
-
+Return the bottom-zero first antiderivative of a G-representation.
 
 ---
 
+## Declaration
+```matlab
+W = intZG(w,n=1)
+```
+## Parameters
++ `w`  G-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `W`  bottom-zero F-representation antiderivative in the input layout
+
+## Discussion
+
+A G-to-F antiderivative is defined up to an additive constant. This method selects the representative that vanishes at the bottom boundary. `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformconstantstratification/diffzf.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/diffzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZF
 
-
-
+Differentiate an F-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZF(u,n=n)
+```
+## Parameters
++ `u`  F-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating F/G representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return a G-representation and even orders return an F-representation.

--- a/docs/classes/transforms/wvtransformconstantstratification/diffzg.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/diffzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZG
 
-
-
+Differentiate a G-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZG(u,n=n)
+```
+## Parameters
++ `u`  G-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating G/F representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return an F-representation and even orders return a G-representation.

--- a/docs/classes/transforms/wvtransformconstantstratification/intzf.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/intzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZF
 
-
-
+Return the first antiderivative of an F-representation.
 
 ---
 
+## Declaration
+```matlab
+U = intZF(u,n=1)
+```
+## Parameters
++ `u`  F-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `U`  G-representation antiderivative in the input layout
+
+## Discussion
+
+The result is the antiderivative representable in G space. The barotropic F mode is removed because it has no corresponding G mode, so the result vanishes at both vertical boundaries. `u` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformconstantstratification/intzg.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/intzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZG
 
-
-
+Return the bottom-zero first antiderivative of a G-representation.
 
 ---
 
+## Declaration
+```matlab
+W = intZG(w,n=1)
+```
+## Parameters
++ `w`  G-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `W`  bottom-zero F-representation antiderivative in the input layout
+
+## Discussion
+
+A G-to-F antiderivative is defined up to an additive constant. This method selects the representative that vanishes at the bottom boundary. `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformhydrostatic/diffzf.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/diffzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZF
 
-
-
+Differentiate an F-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZF(u,n=n)
+```
+## Parameters
++ `u`  F-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating F/G representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return a G-representation and even orders return an F-representation.

--- a/docs/classes/transforms/wvtransformhydrostatic/diffzg.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/diffzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZG
 
-
-
+Differentiate a G-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZG(u,n=n)
+```
+## Parameters
++ `u`  G-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating G/F representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return an F-representation and even orders return a G-representation.

--- a/docs/classes/transforms/wvtransformhydrostatic/intzf.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/intzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZF
 
-
-
+Return the first antiderivative of an F-representation.
 
 ---
 
+## Declaration
+```matlab
+U = intZF(u,n=1)
+```
+## Parameters
++ `u`  F-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `U`  G-representation antiderivative in the input layout
+
+## Discussion
+
+The result is the antiderivative representable in G space. The barotropic F mode is removed because it has no corresponding G mode, so the result vanishes at both vertical boundaries. `u` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformhydrostatic/intzg.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/intzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZG
 
-
-
+Return the bottom-zero first antiderivative of a G-representation.
 
 ---
 
+## Declaration
+```matlab
+W = intZG(w,n=1)
+```
+## Parameters
++ `w`  G-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `W`  bottom-zero F-representation antiderivative in the input layout
+
+## Discussion
+
+A G-to-F antiderivative is defined up to an additive constant. This method selects the representative that vanishes at the bottom boundary. `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformstratifiedqg/diffzf.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/diffzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZF
 
-
-
+Differentiate an F-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZF(u,n=n)
+```
+## Parameters
++ `u`  F-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating F/G representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return a G-representation and even orders return an F-representation.

--- a/docs/classes/transforms/wvtransformstratifiedqg/diffzg.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/diffzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  diffZG
 
-
-
+Differentiate a G-grid field with respect to z.
 
 ---
 
+## Declaration
+```matlab
+du = diffZG(u,n=n)
+```
+## Parameters
++ `u`  G-grid field with dimensions `[Nx Ny Nz]`
++ `n`  derivative order from 1 through 4 (default 1)
+
+## Returns
++ `du`  vertical derivative in the alternating G/F representation
+
+## Discussion
+
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are supported. Odd orders return an F-representation and even orders return a G-representation.

--- a/docs/classes/transforms/wvtransformstratifiedqg/intzf.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/intzf.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZF
 
-
-
+Return the first antiderivative of an F-representation.
 
 ---
 
+## Declaration
+```matlab
+U = intZF(u,n=1)
+```
+## Parameters
++ `u`  F-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `U`  G-representation antiderivative in the input layout
+
+## Discussion
+
+The result is the antiderivative representable in G space. The barotropic F mode is removed because it has no corresponding G mode, so the result vanishes at both vertical boundaries. `u` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformstratifiedqg/intzg.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/intzg.md
@@ -9,8 +9,21 @@ mathjax: true
 
 #  intZG
 
-
-
+Return the bottom-zero first antiderivative of a G-representation.
 
 ---
 
+## Declaration
+```matlab
+W = intZG(w,n=1)
+```
+## Parameters
++ `w`  G-representation in `[Nx Ny Nz]` or `[Nz N]` layout
++ `n`  antiderivative order; only 1 is supported (default 1)
+
+## Returns
++ `W`  bottom-zero F-representation antiderivative in the input layout
+
+## Discussion
+
+A G-to-F antiderivative is defined up to an additive constant. This method selects the representative that vanishes at the bottom boundary. `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned array preserves that layout.

--- a/docs/users-guide/supported-features.md
+++ b/docs/users-guide/supported-features.md
@@ -36,6 +36,7 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | MATLAB builtin FFT implementation | Stable | This is the supported Fourier-transform backend. |
 | FFTW and `RealToComplexTransform` integration | Internal | These backend remnants are not selectable through a supported transform contract. |
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
+| Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
 | `exact` and `finufft` interpolation | Internal | These implementation paths and option values must not appear in public option lists or user documentation. |
 | `WVOffGridTransform`, external-wave behavior, and off-grid pressure | Internal | These incomplete remnants have no 4.2.x compatibility promise. |
 
@@ -103,8 +104,6 @@ The following contracts are part of the v4.2.1 target even though their 4.2.0 im
 
 | Interface | v4.2.1 target |
 | --- | --- |
-| `diffZF` and `diffZG` | Support derivative orders 1 through 4 and reject other orders with a clear, stable error. |
-| `intZF` and `intZG` | Support first-order integration for every stable three-dimensional transform and reject higher orders with a clear, stable error. |
 | `hasMeanPressureDifference` | Return the documented result instead of a placeholder error. |
 | `WVTotalFlowComponent.solutionForModeAtIndex` | Return the documented total-flow solution instead of a placeholder error. |
 | `summarizeDegreesOfFreedom` | Provide a general implementation for the stable transform surface. |


### PR DESCRIPTION
## Summary

- complete the supported first-through-fourth vertical derivative contract with built-in MATLAB validation
- implement constant-stratification first antiderivatives with the documented G-space projection and bottom-zero conventions
- add full-category coverage across all five stable 3-D configurations and synchronize the API/support documentation

## Verification

- `TestVerticalCalculus`: 30 passed
- `buildtool test:smoke`: 126 passed
- `buildtool test:full`: 386 passed
- `buildtool test:exhaustive`: 2,440 passed
- MATLAB analyzer clean for changed source and tests
- whitespace, scope, support-page mirror, and artifact checks passed

Closes #27
