### PR TITLE
Implement MDA pressure difference diagnostic

### DIFF
--- a/@WVTransform/WVTransform.m
+++ b/@WVTransform/WVTransform.m
@@ -756,13 +756,55 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         ncfile = writeToFile(self,path,props,options)
 
         function flag = hasMeanPressureDifference(self)
-            % checks if there is a non-zero mean pressure difference between the top and bottom of the fluid
+            % Diagnose an MDA mean-pressure difference between the boundaries.
             %
-            % This is probably best re-defined as a dynamical variable.
+            % Only the mean-density-anomaly (MDA) component can contribute
+            % to a horizontally averaged pressure difference between the
+            % top and bottom boundaries. The diagnostic evaluates
             %
+            % $$
+            % \Delta \bar p_{\mathrm{mda}} =
+            % \left|\langle p_{\mathrm{mda,top}}\rangle_{xy}
+            % -\langle p_{\mathrm{mda,bottom}}\rangle_{xy}\right|
+            % $$
+            %
+            % relative to the maximum absolute MDA pressure. It returns
+            % `true` when the relative difference is greater than `1e-5`.
+            % Transforms without an MDA component return `false`. Other
+            % flow components and common pressure-gauge offsets do not
+            % enter the calculation.
+            %
+            % - Topic: Initial Conditions
             % - Declaration: flag = hasMeanPressureDifference()
-            % - Returns flag: a boolean
-            error('Not yet implemented');
+            % - Returns flag: scalar logical indicating a resolved MDA boundary-pressure difference
+            arguments (Input)
+                self WVTransform {mustBeNonempty}
+            end
+            arguments (Output)
+                flag (1,1) logical
+            end
+
+            if ~isa(self,"WVMeanDensityAnomalyMethods")
+                flag = false;
+                return
+            end
+
+            mdaCoefficients = self.mdaComponent.maskA0.*self.A0;
+            if ~any(mdaCoefficients ~= 0,"all")
+                flag = false;
+                return
+            end
+
+            pressureOperation = self.operationForKnownVariable('p',flowComponent=self.mdaComponent);
+            pMDA = pressureOperation.compute(self);
+            pressureScale = max(abs(pMDA),[],"all");
+            if pressureScale == 0
+                flag = false;
+                return
+            end
+
+            meanPressureDifference = abs(mean(pMDA(:,:,end),"all") - mean(pMDA(:,:,1),"all"));
+            flag = meanPressureDifference > 1e-5*pressureScale;
         end
 
         [varargout] = spectralVariableWithResolution(self,wvtX2,varargin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Implemented `hasMeanPressureDifference` as an MDA-only boundary diagnostic with a `1e-5` relative pressure tolerance; other flow components and transforms without an MDA component return `false`.
 - Completed the supported vertical-calculus contract: first through fourth derivatives now use ordinary MATLAB order and grid-layout validation, and all stable three-dimensional transforms provide first antiderivatives with documented G-space projection and bottom-zero conventions.
 - Restricted public field and particle interpolation to periodic `linear` and `spline` methods and removed the dead `exact` and off-grid dispatch.
 - Documented the v4.2.1 target support contract: the five current transform families, the supported latitude domain of `5 <= abs(latitude) <= 85`, MATLAB builtin FFTs, fixed and adaptive integration, and periodic `linear` and `spline` interpolation are stable; `adaptive-cell` integration is experimental; and FFTW, `exact` and `finufft` interpolation, off-grid behavior, and legacy low-level entry points are internal.

--- a/Documentation/WebsiteDocumentation/users-guide/supported-features.md
+++ b/Documentation/WebsiteDocumentation/users-guide/supported-features.md
@@ -37,6 +37,7 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | FFTW and `RealToComplexTransform` integration | Internal | These backend remnants are not selectable through a supported transform contract. |
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
 | Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
+| `hasMeanPressureDifference` | Stable | The diagnostic reports whether the mean-density-anomaly component produces a resolved horizontally averaged pressure difference between the top and bottom boundaries. Transforms without an MDA component return `false`. |
 | `exact` and `finufft` interpolation | Internal | These implementation paths and option values must not appear in public option lists or user documentation. |
 | `WVOffGridTransform`, external-wave behavior, and off-grid pressure | Internal | These incomplete remnants have no 4.2.x compatibility promise. |
 
@@ -104,7 +105,6 @@ The following contracts are part of the v4.2.1 target even though their 4.2.0 im
 
 | Interface | v4.2.1 target |
 | --- | --- |
-| `hasMeanPressureDifference` | Return the documented result instead of a placeholder error. |
 | `WVTotalFlowComponent.solutionForModeAtIndex` | Return the documented total-flow solution instead of a placeholder error. |
 | `summarizeDegreesOfFreedom` | Provide a general implementation for the stable transform surface. |
 

--- a/UnitTests/TestMeanPressureDifference.m
+++ b/UnitTests/TestMeanPressureDifference.m
@@ -1,0 +1,156 @@
+classdef TestMeanPressureDifference < matlab.unittest.TestCase
+    properties
+        transformType
+        wvt
+    end
+
+    properties (ClassSetupParameter)
+        transform = struct( ...
+            constantHydrostatic="constantHydrostatic", ...
+            constantNonhydrostatic="constantNonhydrostatic", ...
+            hydrostatic="hydrostatic", ...
+            boussinesq="boussinesq", ...
+            stratifiedQG="stratifiedQG", ...
+            barotropicQG="barotropicQG")
+    end
+
+    methods (TestClassSetup)
+        function storeTransformType(testCase,transform)
+            testCase.transformType = transform;
+        end
+    end
+
+    methods (TestMethodSetup)
+        function createFreshTransform(testCase)
+            testCase.wvt = testCase.newTransform(testCase.transformType);
+        end
+    end
+
+    methods (Test, TestTags = "full")
+        function zeroStateReturnsScalarLogicalFalse(testCase)
+            flag = testCase.wvt.hasMeanPressureDifference();
+            testCase.verifyFalse(flag)
+            testCase.verifyClass(flag,"logical")
+            testCase.verifySize(flag,[1 1])
+        end
+
+        function nonMDAComponentsDoNotContribute(testCase)
+            seedRandomNumberGenerator(testCase,2801);
+            wvt = testCase.wvt;
+
+            wvt.initWithRandomFlow('geostrophic',uvMax=0.01);
+            testCase.verifyFalse(wvt.hasMeanPressureDifference())
+
+            if wvt.hasWaveComponent
+                wvt.initWithRandomFlow('wave',uvMax=0.01);
+                testCase.verifyFalse(wvt.hasMeanPressureDifference())
+
+                wvt.initWithRandomFlow('inertial',uvMax=0.01);
+                testCase.verifyFalse(wvt.hasMeanPressureDifference())
+            end
+        end
+
+        function internalMDAProducesPressureDifference(testCase)
+            wvt = testCase.wvt;
+            if ~isa(wvt,"WVMeanDensityAnomalyMethods")
+                testCase.verifyFalse(wvt.hasMeanPressureDifference())
+                return
+            end
+
+            mdaIndex = find(wvt.mdaComponent.maskA0,1);
+            wvt.A0(mdaIndex) = 1;
+            testCase.verifyTrue(wvt.hasMeanPressureDifference())
+        end
+
+        function nonMDASuperpositionDoesNotChangeResult(testCase)
+            wvt = testCase.wvt;
+            if ~isa(wvt,"WVMeanDensityAnomalyMethods")
+                testCase.verifyFalse(wvt.hasMeanPressureDifference())
+                return
+            end
+
+            mdaIndex = find(wvt.mdaComponent.maskA0,1);
+            wvt.A0(mdaIndex) = 1;
+            testCase.verifyTrue(wvt.hasMeanPressureDifference())
+
+            seedRandomNumberGenerator(testCase,2802);
+            wvt.addRandomFlow('geostrophic','wave','inertial',uvMax=0.01);
+            testCase.verifyTrue(wvt.hasMeanPressureDifference())
+        end
+
+        function totalPressureGaugeOffsetDoesNotChangeResult(testCase)
+            wvt = testCase.wvt;
+            if ~isa(wvt,"WVMeanDensityAnomalyMethods")
+                testCase.verifyFalse(wvt.hasMeanPressureDifference())
+                return
+            end
+
+            mdaIndex = find(wvt.mdaComponent.maskA0,1);
+            wvt.A0(mdaIndex) = 1;
+            testCase.verifyTrue(wvt.hasMeanPressureDifference())
+
+            totalPressure = wvt.variableWithName('p');
+            gaugeOffset = 1e6*max(abs(totalPressure),[],"all");
+            pressureAnnotation = WVVariableAnnotation('p',wvt.spatialDimensionNames,'kg/m/s2','test pressure with a common gauge offset');
+            pressureOperation = WVOperation('p',pressureAnnotation,@(~) totalPressure+gaugeOffset);
+            wvt.addOperation(pressureOperation,shouldOverwriteExisting=true,shouldSuppressWarning=true);
+            testCase.verifyEqual(wvt.variableWithName('p'),totalPressure+gaugeOffset)
+            testCase.verifyTrue(wvt.hasMeanPressureDifference())
+        end
+
+        function relativeToleranceUsesAbsoluteDifference(testCase)
+            if testCase.transformType ~= "constantHydrostatic"
+                return
+            end
+
+            wvt = testCase.wvt;
+            oddIndex = wvt.indexFromModeNumber(0,0,1);
+            evenIndex = wvt.indexFromModeNumber(0,0,2);
+
+            wvt.A0(evenIndex) = 1;
+            evenPressure = wvt.variableWithName('p');
+            pressureScale = max(abs(evenPressure),[],"all");
+            testCase.verifyFalse(wvt.hasMeanPressureDifference())
+
+            wvt.A0(:) = 0;
+            wvt.A0(oddIndex) = 1;
+            oddPressure = wvt.variableWithName('p');
+            oddDifference = abs(mean(oddPressure(:,:,end),"all") - mean(oddPressure(:,:,1),"all"));
+
+            belowToleranceAmplitude = 1e-7*pressureScale/oddDifference;
+            wvt.A0(:) = 0;
+            wvt.A0(evenIndex) = 1;
+            wvt.A0(oddIndex) = belowToleranceAmplitude;
+            testCase.verifyFalse(wvt.hasMeanPressureDifference())
+
+            aboveToleranceAmplitude = 1e-3*pressureScale/oddDifference;
+            wvt.A0(oddIndex) = aboveToleranceAmplitude;
+            testCase.verifyTrue(wvt.hasMeanPressureDifference())
+
+            wvt.A0(oddIndex) = -aboveToleranceAmplitude;
+            testCase.verifyTrue(wvt.hasMeanPressureDifference())
+        end
+    end
+
+    methods (Static, Access = private)
+        function wvt = newTransform(transformType)
+            Lxyz = [8e3 6e3 1e3];
+            Nxyz = [8 6 9];
+            N2 = @(z) 2e-5*exp(z/4000);
+            switch transformType
+                case "constantHydrostatic"
+                    wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=true,shouldAntialias=false);
+                case "constantNonhydrostatic"
+                    wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=false);
+                case "hydrostatic"
+                    wvt = WVTransformHydrostatic(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                case "boussinesq"
+                    wvt = WVTransformBoussinesq(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                case "stratifiedQG"
+                    wvt = WVTransformStratifiedQG(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                case "barotropicQG"
+                    wvt = WVTransformBarotropicQG(Lxyz(1:2),Nxyz(1:2),latitude=45,shouldAntialias=false);
+            end
+        end
+    end
+end

--- a/docs/classes/transforms/wvtransform/hasmeanpressuredifference.md
+++ b/docs/classes/transforms/wvtransform/hasmeanpressuredifference.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  hasMeanPressureDifference
 
-checks if there is a non-zero mean pressure difference between the top and bottom of the fluid
+Diagnose an MDA mean-pressure difference between the boundaries.
 
 
 ---
@@ -19,10 +19,16 @@ checks if there is a non-zero mean pressure difference between the top and botto
  flag = hasMeanPressureDifference()
 ```
 ## Returns
-+ `flag`  a boolean
++ `flag`  scalar logical indicating a resolved MDA boundary-pressure difference
 
 ## Discussion
 
-  This is probably best re-defined as a dynamical variable.
- 
-    
+Only the mean-density-anomaly (MDA) component can contribute to a horizontally averaged pressure difference between the top and bottom boundaries. The diagnostic evaluates
+
+$$
+\Delta \bar p_{\mathrm{mda}} =
+\left|\langle p_{\mathrm{mda,top}}\rangle_{xy}
+-\langle p_{\mathrm{mda,bottom}}\rangle_{xy}\right|
+$$
+
+relative to the maximum absolute MDA pressure. It returns `true` when the relative difference is greater than `1e-5`. Transforms without an MDA component return `false`. Other flow components and common pressure-gauge offsets do not enter the calculation.

--- a/docs/classes/transforms/wvtransform/index.md
+++ b/docs/classes/transforms/wvtransform/index.md
@@ -131,7 +131,7 @@ instatiate one of the concrete subclasses,
   + [`gt`](/classes/transforms/wvtransform/gt.html) 
   + [`hasClosure`](/classes/transforms/wvtransform/hasclosure.html) 
   + [`hasForcingWithName`](/classes/transforms/wvtransform/hasforcingwithname.html) 
-  + [`hasMeanPressureDifference`](/classes/transforms/wvtransform/hasmeanpressuredifference.html) checks if there is a non-zero mean pressure difference between the top and bottom of the fluid
+  + [`hasMeanPressureDifference`](/classes/transforms/wvtransform/hasmeanpressuredifference.html) diagnoses an MDA mean-pressure difference between the boundaries
   + [`hasPVComponent`](/classes/transforms/wvtransform/haspvcomponent.html) 
   + [`hasVariableWithName`](/classes/transforms/wvtransform/hasvariablewithname.html) 
   + [`hasWaveComponent`](/classes/transforms/wvtransform/haswavecomponent.html) 

--- a/docs/users-guide/supported-features.md
+++ b/docs/users-guide/supported-features.md
@@ -37,6 +37,7 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | FFTW and `RealToComplexTransform` integration | Internal | These backend remnants are not selectable through a supported transform contract. |
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
 | Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
+| `hasMeanPressureDifference` | Stable | The diagnostic reports whether the mean-density-anomaly component produces a resolved horizontally averaged pressure difference between the top and bottom boundaries. Transforms without an MDA component return `false`. |
 | `exact` and `finufft` interpolation | Internal | These implementation paths and option values must not appear in public option lists or user documentation. |
 | `WVOffGridTransform`, external-wave behavior, and off-grid pressure | Internal | These incomplete remnants have no 4.2.x compatibility promise. |
 
@@ -104,7 +105,6 @@ The following contracts are part of the v4.2.1 target even though their 4.2.0 im
 
 | Interface | v4.2.1 target |
 | --- | --- |
-| `hasMeanPressureDifference` | Return the documented result instead of a placeholder error. |
 | `WVTotalFlowComponent.solutionForModeAtIndex` | Return the documented total-flow solution instead of a placeholder error. |
 | `summarizeDegreesOfFreedom` | Provide a general implementation for the stable transform surface. |
 


### PR DESCRIPTION
## Summary

- implement `hasMeanPressureDifference` from mean-density-anomaly pressure only
- exclude non-MDA modes and common total-pressure gauge offsets from the diagnostic
- document the stable contract and add coverage across all six stable transform configurations

## Verification

- focused tests: 36 passed
- smoke suite: 126 passed
- full suite: 422 passed
- exhaustive suite: 2,440 passed
- changed MATLAB regions are analyzer-clean
- whitespace, documentation-mirror, repository-scope, and generated-artifact checks passed

Closes #28
