### PR TITLE
Implement total-flow analytical solution lookup

### DIFF
--- a/@WVGeometryDoublyPeriodicBarotropic/WVGeometryDoublyPeriodicBarotropic.m
+++ b/@WVGeometryDoublyPeriodicBarotropic/WVGeometryDoublyPeriodicBarotropic.m
@@ -132,6 +132,45 @@ classdef WVGeometryDoublyPeriodicBarotropic < WVGeometryDoublyPeriodic & WVRotat
             [~,value] = ndgrid(self.x,self.y);
         end
 
+        function bool = isValidPrimaryModeNumber(self,kMode,lMode,jMode)
+            arguments (Input)
+                self WVGeometryDoublyPeriodicBarotropic {mustBeNonempty}
+                kMode (:,1) double {mustBeInteger}
+                lMode (:,1) double {mustBeInteger}
+                jMode (:,1) double {mustBeInteger,mustBeNonnegative}
+            end
+            arguments (Output)
+                bool (:,1) logical {mustBeMember(bool,[0 1])}
+            end
+            bool = (jMode == self.j) & self.isValidPrimaryKLModeNumber(kMode,lMode);
+        end
+
+        function bool = isValidConjugateModeNumber(self,kMode,lMode,jMode)
+            arguments (Input)
+                self WVGeometryDoublyPeriodicBarotropic {mustBeNonempty}
+                kMode (:,1) double {mustBeInteger}
+                lMode (:,1) double {mustBeInteger}
+                jMode (:,1) double {mustBeInteger,mustBeNonnegative}
+            end
+            arguments (Output)
+                bool (:,1) logical {mustBeMember(bool,[0 1])}
+            end
+            bool = (jMode == self.j) & self.isValidConjugateKLModeNumber(kMode,lMode);
+        end
+
+        function bool = isValidModeNumber(self,kMode,lMode,jMode)
+            arguments (Input)
+                self WVGeometryDoublyPeriodicBarotropic {mustBeNonempty}
+                kMode (:,1) double {mustBeInteger}
+                lMode (:,1) double {mustBeInteger}
+                jMode (:,1) double {mustBeInteger,mustBeNonnegative}
+            end
+            arguments (Output)
+                bool (:,1) logical {mustBeMember(bool,[0 1])}
+            end
+            bool = self.isValidPrimaryModeNumber(kMode,lMode,jMode) | self.isValidConjugateModeNumber(kMode,lMode,jMode);
+        end
+
         function index = indexFromModeNumber(self,kMode,lMode,jMode)
             arguments (Input)
                 self WVGeometryDoublyPeriodicBarotropic {mustBeNonempty}
@@ -142,11 +181,12 @@ classdef WVGeometryDoublyPeriodicBarotropic < WVGeometryDoublyPeriodic & WVRotat
             arguments (Output)
                 index (:,1) double {mustBeInteger,mustBePositive}
             end
-            index = self.indexFromModeNumber(kMode,lMode);
+            mustBeMember(jMode,self.j)
+            index = self.indexFromKLModeNumber(kMode,lMode);
         end
         function [kMode,lMode,jMode] = modeNumberFromIndex(self,linearIndex)
             arguments (Input)
-                self WVGeometryDoublyPeriodic {mustBeNonempty}
+                self WVGeometryDoublyPeriodicBarotropic {mustBeNonempty}
                 linearIndex (1,1) double {mustBeInteger,mustBePositive}
             end
             arguments (Output)
@@ -154,7 +194,7 @@ classdef WVGeometryDoublyPeriodicBarotropic < WVGeometryDoublyPeriodic & WVRotat
                 lMode (1,1) double {mustBeInteger}
                 jMode (1,1) double {mustBeInteger}
             end
-            [kMode,lMode] = modeNumberFromIndex@WVGeometryDoublyPeriodic(self,linearIndex);
+            [kMode,lMode] = self.klModeNumberFromIndex(linearIndex);
             jMode = self.j;
         end
     end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Implemented deterministic total-flow analytical-solution lookup across primary components and repaired barotropic mode-index conversion used by that lookup.
 - Implemented `hasMeanPressureDifference` as an MDA-only boundary diagnostic with a `1e-5` relative pressure tolerance; other flow components and transforms without an MDA component return `false`.
 - Completed the supported vertical-calculus contract: first through fourth derivatives now use ordinary MATLAB order and grid-layout validation, and all stable three-dimensional transforms provide first antiderivatives with documented G-space projection and bottom-zero conventions.
 - Restricted public field and particle interpolation to periodic `linear` and `spline` methods and removed the dead `exact` and off-grid dispatch.

--- a/Documentation/WebsiteDocumentation/users-guide/supported-features.md
+++ b/Documentation/WebsiteDocumentation/users-guide/supported-features.md
@@ -38,6 +38,7 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
 | Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
 | `hasMeanPressureDifference` | Stable | The diagnostic reports whether the mean-density-anomaly component produces a resolved horizontally averaged pressure difference between the top and bottom boundaries. Transforms without an MDA component return `false`. |
+| `WVTotalFlowComponent.solutionForModeAtIndex` | Stable | Total-flow indices select primary-component analytical solutions in lexical `shortName` order while retaining each component's local mode ordering. |
 | `exact` and `finufft` interpolation | Internal | These implementation paths and option values must not appear in public option lists or user documentation. |
 | `WVOffGridTransform`, external-wave behavior, and off-grid pressure | Internal | These incomplete remnants have no 4.2.x compatibility promise. |
 
@@ -105,7 +106,6 @@ The following contracts are part of the v4.2.1 target even though their 4.2.0 im
 
 | Interface | v4.2.1 target |
 | --- | --- |
-| `WVTotalFlowComponent.solutionForModeAtIndex` | Return the documented total-flow solution instead of a placeholder error. |
 | `summarizeDegreesOfFreedom` | Provide a general implementation for the stable transform surface. |
 
 ## Known 4.2.0 gaps and follow-up work

--- a/UnitTests/TestTotalFlowComponent.m
+++ b/UnitTests/TestTotalFlowComponent.m
@@ -1,0 +1,183 @@
+classdef TestTotalFlowComponent < matlab.unittest.TestCase
+    properties (TestParameter)
+        transformType = struct( ...
+            constantHydrostatic="constantHydrostatic", ...
+            constantNonhydrostatic="constantNonhydrostatic", ...
+            hydrostatic="hydrostatic", ...
+            boussinesq="boussinesq", ...
+            stratifiedQG="stratifiedQG", ...
+            barotropicQG="barotropicQG")
+    end
+
+    methods (Test, TestTags = "full")
+        function totalCountMatchesSortedComponentRanges(testCase,transformType)
+            wvt = testCase.newTransform(transformType);
+            [components,nModesByComponent] = testCase.sortedComponents(wvt);
+
+            testCase.verifyEqual(wvt.totalFlowComponent.nModes,sum(nModesByComponent))
+            if wvt.hasWaveComponent
+                testCase.verifyEqual(string({components.shortName}),["geostrophic" "inertial" "mda" "wave"])
+            else
+                testCase.verifyEqual(string({components.shortName}),"geostrophic")
+            end
+        end
+
+        function componentBoundariesDelegateInCallerOrder(testCase,transformType)
+            wvt = testCase.newTransform(transformType);
+            indices = testCase.componentBoundaryIndices(wvt);
+
+            seedRandomNumberGenerator(testCase,2901);
+            seededState = rng;
+            actual = wvt.totalFlowComponent.solutionForModeAtIndex(indices,amplitude='random');
+            rng(seededState)
+            expected = testCase.directSolutions(wvt,indices,'random');
+
+            testCase.verifySize(actual,size(indices))
+            testCase.verifyEquivalentSolutions(actual,expected,wvt)
+        end
+
+        function currentCoefficientsAndOutputShapesArePreserved(testCase,transformType)
+            wvt = testCase.newTransform(transformType);
+            seedRandomNumberGenerator(testCase,2902);
+            wvt.initWithRandomFlow(uvMax=0.01);
+
+            indices = flipud(testCase.componentBoundaryIndices(wvt));
+            actual = wvt.totalFlowComponent.solutionForModeAtIndex(indices,amplitude='wvt');
+            expected = testCase.directSolutions(wvt,indices,'wvt');
+
+            testCase.verifySize(actual,size(indices))
+            testCase.verifyEquivalentSolutions(actual,expected,wvt)
+            for iSolution = 1:numel(actual)
+                testCase.verifySolutionMatchesCurrentCoefficient(actual(iSolution),wvt)
+            end
+
+            scalarSolution = wvt.totalFlowComponent.solutionForModeAtIndex(indices(1),amplitude='wvt');
+            testCase.verifySize(scalarSolution,[1 1])
+            testCase.verifySolutionMatchesCurrentCoefficient(scalarSolution,wvt)
+        end
+
+        function invalidIndicesUseBuiltInValidation(testCase,transformType)
+            wvt = testCase.newTransform(transformType);
+            lookup = @(index) wvt.totalFlowComponent.solutionForModeAtIndex(index);
+
+            testCase.verifyError(@() lookup(0),'MATLAB:validators:mustBePositive')
+            testCase.verifyError(@() lookup(-1),'MATLAB:validators:mustBePositive')
+            testCase.verifyError(@() lookup(1.5),'MATLAB:validators:mustBeInteger')
+            testCase.verifyError(@() lookup(wvt.totalFlowComponent.nModes+1),'MATLAB:validators:mustBeLessThanOrEqual')
+        end
+
+        function barotropicModeIndexWrappersRoundTrip(testCase)
+            wvt = testCase.newTransform("barotropicQG");
+            spectralIndices = find(wvt.geostrophicComponent.maskA0);
+
+            for iIndex = 1:numel(spectralIndices)
+                [kMode,lMode,jMode] = wvt.modeNumberFromIndex(spectralIndices(iIndex));
+                testCase.verifyEqual(jMode,wvt.j)
+                testCase.verifyEqual(wvt.indexFromModeNumber(kMode,lMode,jMode),spectralIndices(iIndex))
+            end
+            [kMode,lMode] = wvt.modeNumberFromIndex(spectralIndices(1));
+            testCase.verifyError(@() wvt.indexFromModeNumber(kMode,lMode,1-wvt.j),'MATLAB:validators:mustBeMember')
+
+            seedRandomNumberGenerator(testCase,2903);
+            wvt.initWithRandomFlow(uvMax=0.01);
+            localIndices = [1; wvt.geostrophicComponent.nModes];
+            solutions = wvt.geostrophicComponent.solutionForModeAtIndex(localIndices,amplitude='wvt');
+            testCase.verifySize(solutions,size(localIndices))
+            for iSolution = 1:numel(solutions)
+                testCase.verifySolutionMatchesCurrentCoefficient(solutions(iSolution),wvt)
+            end
+        end
+    end
+
+    methods (Access = private)
+        function verifyEquivalentSolutions(testCase,actual,expected,wvt)
+            testCase.verifyEqual(numel(actual),numel(expected))
+            if isa(wvt,"WVTransformBarotropicQG")
+                fieldNames = ["u" "v" "eta" "qgpv" "psi"];
+            else
+                fieldNames = ["u" "v" "w" "eta" "rho_e" "p" "qgpv" "psi"];
+            end
+            x = 0.17*wvt.Lx;
+            y = 0.23*wvt.Ly;
+            z = -0.37*wvt.Lz;
+            t = 123;
+            for iSolution = 1:numel(actual)
+                testCase.verifyEqual(actual(iSolution).kMode,expected(iSolution).kMode)
+                testCase.verifyEqual(actual(iSolution).lMode,expected(iSolution).lMode)
+                testCase.verifyEqual(actual(iSolution).jMode,expected(iSolution).jMode)
+                testCase.verifyEqual(actual(iSolution).amplitude,expected(iSolution).amplitude,RelTol=1e-12,AbsTol=1e-12)
+                testCase.verifyEqual(actual(iSolution).phase,expected(iSolution).phase,RelTol=1e-12,AbsTol=1e-12)
+                testCase.verifyEqual(actual(iSolution).coefficientMatrix,expected(iSolution).coefficientMatrix)
+                testCase.verifyEqual(actual(iSolution).coefficientMatrixIndex,expected(iSolution).coefficientMatrixIndex)
+                testCase.verifyEqual(actual(iSolution).coefficientMatrixAmplitude,expected(iSolution).coefficientMatrixAmplitude,RelTol=1e-12,AbsTol=1e-12)
+                for fieldName = fieldNames
+                    actualFunction = actual(iSolution).(fieldName);
+                    expectedFunction = expected(iSolution).(fieldName);
+                    testCase.verifyEqual(actualFunction(x,y,z,t),expectedFunction(x,y,z,t),RelTol=1e-12,AbsTol=1e-12)
+                end
+                if ~isa(wvt,"WVTransformBarotropicQG")
+                    testCase.verifyEqual(actual(iSolution).ssh(x,y,t),expected(iSolution).ssh(x,y,t),RelTol=1e-12,AbsTol=1e-12)
+                end
+            end
+        end
+
+        function verifySolutionMatchesCurrentCoefficient(testCase,solution,wvt)
+            switch solution.coefficientMatrix
+                case WVCoefficientMatrix.Ap
+                    coefficient = wvt.Ap(solution.coefficientMatrixIndex);
+                case WVCoefficientMatrix.Am
+                    coefficient = wvt.Am(solution.coefficientMatrixIndex);
+                case WVCoefficientMatrix.A0
+                    coefficient = wvt.A0(solution.coefficientMatrixIndex);
+            end
+            testCase.verifyEqual(solution.coefficientMatrixAmplitude,coefficient,RelTol=1e-12,AbsTol=1e-12)
+        end
+    end
+
+    methods (Static, Access = private)
+        function [components,nModesByComponent,lastIndexByComponent] = sortedComponents(wvt)
+            components = wvt.primaryFlowComponents;
+            [~,componentOrder] = sort(string({components.shortName}));
+            components = components(componentOrder);
+            nModesByComponent = arrayfun(@(component) component.nModes,components);
+            lastIndexByComponent = cumsum(nModesByComponent);
+        end
+
+        function indices = componentBoundaryIndices(wvt)
+            [~,~,lastIndexByComponent] = TestTotalFlowComponent.sortedComponents(wvt);
+            firstIndexByComponent = [1 lastIndexByComponent(1:end-1)+1];
+            indices = unique([firstIndexByComponent(:); lastIndexByComponent(:)]);
+        end
+
+        function solutions = directSolutions(wvt,indices,amplitude)
+            [components,nModesByComponent,lastIndexByComponent] = TestTotalFlowComponent.sortedComponents(wvt);
+            solutions = WVOrthogonalSolution.empty(length(indices),0);
+            for iSolution = 1:length(indices)
+                iComponent = find(indices(iSolution) <= lastIndexByComponent,1);
+                firstIndexForComponent = lastIndexByComponent(iComponent) - nModesByComponent(iComponent) + 1;
+                localIndex = indices(iSolution) - firstIndexForComponent + 1;
+                solutions(iSolution) = components(iComponent).solutionForModeAtIndex(localIndex,amplitude=amplitude);
+            end
+        end
+
+        function wvt = newTransform(transformType)
+            Lxyz = [8e3 6e3 1e3];
+            Nxyz = [8 6 9];
+            N2 = @(z) 2e-5*exp(z/4000);
+            switch transformType
+                case "constantHydrostatic"
+                    wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=true,shouldAntialias=false);
+                case "constantNonhydrostatic"
+                    wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=false);
+                case "hydrostatic"
+                    wvt = WVTransformHydrostatic(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                case "boussinesq"
+                    wvt = WVTransformBoussinesq(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                case "stratifiedQG"
+                    wvt = WVTransformStratifiedQG(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=false);
+                case "barotropicQG"
+                    wvt = WVTransformBarotropicQG(Lxyz(1:2),Nxyz(1:2),latitude=45,shouldAntialias=false);
+            end
+        end
+    end
+end

--- a/WVTotalFlowComponent.m
+++ b/WVTotalFlowComponent.m
@@ -161,36 +161,51 @@ classdef WVTotalFlowComponent < WVPrimaryFlowComponent
             end
         end
 
-        function solution = solutionForModeAtIndex(self,index,options)
-            % return the analytical solution for the mode at this index
+        function solutions = solutionForModeAtIndex(self,index,options)
+            % Return analytical solutions from the complete primary-flow basis.
             %
-            % Returns WVAnalyticalSolution object for this index.
-            % The solution indices run from 1:nModes.
+            % Total-flow indices run from 1 through `nModes`. Primary flow
+            % components are ordered lexically by `shortName`, and each
+            % component contributes one contiguous range while retaining its
+            % own local mode ordering. Scalar inputs return a scalar solution;
+            % column-vector inputs return solutions in the requested order.
             %
-            % The solution amplitude can be set to either 'wvt' or
-            % 'random'. Setting the amplitude='wvt' will use the amplitude
-            % currently set in the wvt to initialize this solution.
-            % Otherwise an appropriate random amplitude will be created.
+            % Set `amplitude='wvt'` to reconstruct each solution from the
+            % corresponding coefficient currently stored by the transform.
+            % Set `amplitude='random'` to generate an appropriate random
+            % amplitude for each requested solution.
             %
             % - Topic: Analytical solutions
-            % - Declaration: solution = solutionForModeAtIndex(index)
-            % - Parameter index: non-negative integer less than nModes
+            % - Declaration: solutions = solutionForModeAtIndex(index,options)
+            % - Parameter index: positive integer scalar or column vector with values no greater than nModes
             % - Parameter amplitude: (optional) 'wvt' or 'random' (default)
-            % - Returns solution: an instance of WVAnalyticalSolution
+            % - Returns solutions: scalar or column vector of WVOrthogonalSolution objects
             arguments (Input)
                 self WVFlowComponent {mustBeNonempty}
-                index (:,1) double {mustBeNonnegative}
+                index (:,1) double {mustBeInteger,mustBePositive}
                 options.amplitude {mustBeMember(options.amplitude,['wvt' 'random'])} = 'random'
             end
             arguments (Output)
-                solution (:,1) WVOrthogonalSolution
+                solutions (:,1) WVOrthogonalSolution
             end
-            solution=0;
-            error('This still needs to be implemented. Need to pull from the primary components and return a solution. Not sure how this would be useful yet.')
+            mustBeLessThanOrEqual(index,self.nModes)
+
+            components = self.wvt.primaryFlowComponents;
+            [~,componentOrder] = sort(string({components.shortName}));
+            components = components(componentOrder);
+            nModesByComponent = arrayfun(@(component) component.nModes,components);
+            lastIndexByComponent = cumsum(nModesByComponent);
+
+            solutions = WVOrthogonalSolution.empty(length(index),0);
+            for iSolution = 1:length(index)
+                iComponent = find(index(iSolution) <= lastIndexByComponent,1);
+                firstIndexForComponent = lastIndexByComponent(iComponent) - nModesByComponent(iComponent) + 1;
+                localIndex = index(iSolution) - firstIndexForComponent + 1;
+                solutions(iSolution) = components(iComponent).solutionForModeAtIndex(localIndex,amplitude=options.amplitude);
+            end
         end
 
 
     end
     
 end
-

--- a/docs/classes/flow-components/wvtotalflowcomponent/index.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/index.md
@@ -45,7 +45,7 @@ in two different matrices.
 + Quadratic quantities
   + [`totalEnergyFactorForCoefficientMatrix`](/classes/flow-components/wvtotalflowcomponent/totalenergyfactorforcoefficientmatrix.html) returns the total energy multiplier for the coefficient matrix.
 + Analytical solutions
-  + [`solutionForModeAtIndex`](/classes/flow-components/wvtotalflowcomponent/solutionformodeatindex.html) return the analytical solution for the mode at this index
+  + [`solutionForModeAtIndex`](/classes/flow-components/wvtotalflowcomponent/solutionformodeatindex.html) Return analytical solutions from the complete primary-flow basis.
 + Index Gymnastics
   + [`isValidConjugateModeNumber`](/classes/flow-components/wvtotalflowcomponent/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
   + [`isValidModeNumber`](/classes/flow-components/wvtotalflowcomponent/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number

--- a/docs/classes/flow-components/wvtotalflowcomponent/solutionformodeatindex.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/solutionformodeatindex.md
@@ -9,30 +9,33 @@ mathjax: true
 
 #  solutionForModeAtIndex
 
-return the analytical solution for the mode at this index
+Return analytical solutions from the complete primary-flow basis.
 
 
 ---
 
 ## Declaration
 ```matlab
- solution = solutionForModeAtIndex(index)
+ solutions = solutionForModeAtIndex(index,options)
 ```
 ## Parameters
-+ `index`  non-negative integer less than nModes
++ `index`  positive integer scalar or column vector with values no greater than nModes
 + `amplitude`  (optional) 'wvt' or 'random' (default)
 
 ## Returns
-+ `solution`  an instance of WVAnalyticalSolution
++ `solutions`  scalar or column vector of WVOrthogonalSolution objects
 
 ## Discussion
 
-  Returns WVAnalyticalSolution object for this index.
-  The solution indices run from 1:nModes.
- 
-  The solution amplitude can be set to either 'wvt' or
-  'random'. Setting the amplitude='wvt' will use the amplitude
-  currently set in the wvt to initialize this solution.
-  Otherwise an appropriate random amplitude will be created.
+Total-flow indices run from 1 through `nModes`. Primary flow
+components are ordered lexically by `shortName`, and each
+component contributes one contiguous range while retaining its
+own local mode ordering. Scalar inputs return a scalar solution;
+column-vector inputs return solutions in the requested order.
+
+Set `amplitude='wvt'` to reconstruct each solution from the
+corresponding coefficient currently stored by the transform.
+Set `amplitude='random'` to generate an appropriate random
+amplitude for each requested solution.
  
           

--- a/docs/users-guide/supported-features.md
+++ b/docs/users-guide/supported-features.md
@@ -38,6 +38,7 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
 | Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
 | `hasMeanPressureDifference` | Stable | The diagnostic reports whether the mean-density-anomaly component produces a resolved horizontally averaged pressure difference between the top and bottom boundaries. Transforms without an MDA component return `false`. |
+| `WVTotalFlowComponent.solutionForModeAtIndex` | Stable | Total-flow indices select primary-component analytical solutions in lexical `shortName` order while retaining each component's local mode ordering. |
 | `exact` and `finufft` interpolation | Internal | These implementation paths and option values must not appear in public option lists or user documentation. |
 | `WVOffGridTransform`, external-wave behavior, and off-grid pressure | Internal | These incomplete remnants have no 4.2.x compatibility promise. |
 
@@ -105,7 +106,6 @@ The following contracts are part of the v4.2.1 target even though their 4.2.0 im
 
 | Interface | v4.2.1 target |
 | --- | --- |
-| `WVTotalFlowComponent.solutionForModeAtIndex` | Return the documented total-flow solution instead of a placeholder error. |
 | `summarizeDegreesOfFreedom` | Provide a general implementation for the stable transform surface. |
 
 ## Known 4.2.0 gaps and follow-up work


### PR DESCRIPTION
## Summary

- route total-flow indices through deterministic primary-component ranges sorted by `shortName`
- preserve caller order, output shape, random draw order, and existing `random`/`wvt` amplitude behavior
- repair fixed-`j` barotropic mode validation and KL/index conversion needed by analytical lookup
- document the stable contract and add coverage across all six stable transform configurations

## Verification

- focused tests: 25 passed
- smoke suite: 126 passed
- full suite: 447 passed
- exhaustive suite: 2,440 passed
- changed MATLAB regions are analyzer-clean
- whitespace, documentation-mirror, repository-scope, and generated-artifact checks passed

## Existing limitation

The existing barotropic analytical `p`, `rho_e`, and `ssh` handles reference `rho0`, which the barotropic transform does not define. This PR leaves individual component solution mathematics unchanged, as specified by the issue scope.

Closes #29
