### PR TITLE
WVM-421-07: Add core transform invariant coverage

### DIFF
--- a/@WVGeometryCartesianXYZ/indexFromModeNumber.m
+++ b/@WVGeometryCartesianXYZ/indexFromModeNumber.m
@@ -2,12 +2,15 @@ function index = indexFromModeNumber(self,kMode,lMode,jMode)
 % return the linear index into a spectral matrix given (k,l,j)
 %
 % This function will return the linear index in a spectral
-% matrix given a mode number.
+% matrix given a mode number. Scalar and column-vector inputs preserve
+% their shape and ordering; conjugate mode numbers map to their primary
+% coefficient.
 %
 % - Topic: Index Gymnastics
 % - Declaration: index = indexFromModeNumber(kMode,lMode,jMode)
 % - Parameter kMode: integer
 % - Parameter lMode: integer
+% - Parameter jMode: integer vertical mode number present in `self.j`
 % - Returns index: a non-negative integer number
 arguments (Input)
     self WVTransform {mustBeNonempty}
@@ -18,10 +21,14 @@ end
 arguments (Output)
     index (:,1) double {mustBeInteger,mustBePositive}
 end
-if ~self.isValidModeNumber(kMode,lMode,jMode)
+if ~all(self.isValidModeNumber(kMode,lMode,jMode))
     error('Invalid WV mode number!');
 end
 [kMode,lMode] = self.primaryKLModeNumberFromKLModeNumber(kMode,lMode);
 klIndex = self.indexFromKLModeNumber(kMode,lMode);
-index = sub2ind(self.spectralMatrixSize,jMode+1,klIndex);
+[isPresent,jIndex] = ismember(jMode,self.j);
+if ~all(isPresent)
+    error('Invalid WV vertical mode number!');
+end
+index = sub2ind(self.spectralMatrixSize,jIndex,klIndex);
 end

--- a/@WVGeometryCartesianXYZ/isValidConjugateModeNumber.m
+++ b/@WVGeometryCartesianXYZ/isValidConjugateModeNumber.m
@@ -23,6 +23,6 @@ arguments (Output)
     bool (:,1) logical {mustBeMember(bool,[0 1])}
 end
 klCheck = self.isValidConjugateKLModeNumber(kMode,lMode);
-jCheck = jMode >= 0 & jMode <= self.Nj;
+jCheck = ismember(jMode,self.j);
 bool = klCheck & jCheck;
 end

--- a/@WVGeometryCartesianXYZ/isValidPrimaryModeNumber.m
+++ b/@WVGeometryCartesianXYZ/isValidPrimaryModeNumber.m
@@ -21,6 +21,6 @@ arguments (Output)
     bool (:,1) logical {mustBeMember(bool,[0 1])}
 end
 klCheck = self.isValidPrimaryKLModeNumber(kMode,lMode);
-jCheck = jMode >= 0 & jMode <= self.Nj;
+jCheck = ismember(jMode,self.j);
 bool = klCheck & jCheck;
 end

--- a/@WVGeometryCartesianXYZ/modeNumberFromIndex.m
+++ b/@WVGeometryCartesianXYZ/modeNumberFromIndex.m
@@ -1,4 +1,15 @@
 function [kMode,lMode,jMode] = modeNumberFromIndex(self,linearIndex)
+% Return mode numbers for spectral linear indices.
+%
+% Scalar and column-vector inputs preserve their shape and ordering. Each
+% index must lie within the current spectral matrix.
+%
+% - Topic: Index Gymnastics
+% - Declaration: [kMode,lMode,jMode] = modeNumberFromIndex(linearIndex)
+% - Parameter linearIndex: positive integer scalar or column vector
+% - Returns kMode: integer scalar or column vector
+% - Returns lMode: integer scalar or column vector
+% - Returns jMode: integer scalar or column vector
 arguments (Input)
     self WVTransform {mustBeNonempty}
     linearIndex (:,1) double {mustBeInteger,mustBePositive}
@@ -8,7 +19,8 @@ arguments (Output)
     lMode (:,1) double {mustBeInteger}
     jMode (:,1) double {mustBeInteger,mustBeNonnegative}
 end
+mustBeLessThanOrEqual(linearIndex,prod(self.spectralMatrixSize))
 [jIndex,klIndex] = ind2sub(self.spectralMatrixSize,linearIndex);
 [kMode,lMode] = self.klModeNumberFromIndex(klIndex);
-jMode = jIndex - 1;
+jMode = self.j(jIndex);
 end

--- a/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
+++ b/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
@@ -225,7 +225,10 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % - Topic: Initialization
             % - Declaration:  self = WVGeometryDoublyPeriodic(Lxy, Nxy, options)
             % - Parameter Lxy: length of the domain (in meters) in the two periodic coordinate directions, e.g. [Lx Ly]
-            % - Parameter Nxy: number of grid points in the two coordinate directions, e.g. [Nx Ny]
+            % Both even and odd positive integer grid sizes are supported. A
+            % Nyquist mode exists only in an even-sized direction.
+            %
+            % - Parameter Nxy: positive integer grid counts in the two coordinate directions, e.g. [Nx Ny]
             % - Parameter conjugateDimension: (optional) set which dimension in the DFT grid is assumed to have the redundant conjugates (1 or 2), default is 2
             % - Parameter shouldAntialias: (optional) set whether the WV grid excludes the quadratically aliased modes [0 1] (default 1)
             % - Parameter shouldExcludeNyquist: (optional) set whether the WV grid excludes Nyquist modes[0 1] (default 1)
@@ -234,8 +237,8 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % - Returns geom: a new WVGeometryDoublyPeriodic instance
             arguments
                 Lxy (1,2) double {mustBePositive}
-                Nxy (1,2) double {mustBePositive}
-                options.Nz (1,1) double {mustBePositive} = 1
+                Nxy (1,2) double {mustBeInteger,mustBePositive}
+                options.Nz (1,1) double {mustBeInteger,mustBePositive} = 1
                 options.conjugateDimension (1,1) double {mustBeMember(options.conjugateDimension,[1 2])} = 2
                 options.shouldAntialias (1,1) logical = true
                 options.shouldExcludeNyquist (1,1) logical = true
@@ -631,7 +634,8 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % This function will return the linear index into the (k_wv,l_wv) arrays,
             % given the mode numbers (kMode,lMode). Note that this will
             % *not* normalize the mode to the primary mode number, but will
-            % throw an error.
+            % throw an error. Scalar and column-vector inputs preserve their
+            % shape and ordering.
             %
             % - Topic: Index gymnastics
             % - Declaration: index = indexFromKLModeNumber(kMode,lMode,jMode)
@@ -646,18 +650,21 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             arguments (Output)
                 index (:,1) double {mustBeInteger,mustBePositive}
             end
-            if ~self.isValidKLModeNumber(kMode,lMode)
-                error('Invalid WV mode number!');
+            if ~all(self.isValidPrimaryKLModeNumber(kMode,lMode))
+                error('Invalid WV primary mode number!');
             end
-            indices = 1:self.Nkl;
-            index = indices(self.kMode_wv == kMode & self.lMode_wv == lMode);
+            [isPresent,index] = ismember([kMode,lMode],[self.kMode_wv,self.lMode_wv],'rows');
+            if ~all(isPresent)
+                error('Invalid WV primary mode number!');
+            end
         end
 
         function [kMode,lMode] = klModeNumberFromIndex(self,linearIndex)
             % return mode number from a linear index into a WV matrix
             %
             % This function will return the mode numbers (kMode,lMode)
-            % given some linear index into a WV structured matrix.
+            % given some linear index into a WV structured matrix. Scalar
+            % and column-vector inputs preserve their shape and ordering.
             %
             % - Topic: Index gymnastics
             % - Declaration: [kMode,lMode] = klModeNumberFromIndex(self,linearIndex)
@@ -666,12 +673,13 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % - Returns lMode: integer
             arguments (Input)
                 self WVGeometryDoublyPeriodic {mustBeNonempty}
-                linearIndex (1,1) double {mustBeInteger,mustBePositive}
+                linearIndex (:,1) double {mustBeInteger,mustBePositive}
             end
             arguments (Output)
-                kMode (1,1) double {mustBeInteger}
-                lMode (1,1) double {mustBeInteger}
+                kMode (:,1) double {mustBeInteger}
+                lMode (:,1) double {mustBeInteger}
             end
+            mustBeLessThanOrEqual(linearIndex,self.Nkl)
             kMode = self.kMode_wv(linearIndex);
             lMode = self.lMode_wv(linearIndex);
         end
@@ -1164,7 +1172,8 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % Fourier domain these degrees-of-freedom are more complicated,
             % because some modes are strictly real-valued (k=l=0 and
             % Nyquist), while others are complex, and there are redundant
-            % Hermitian conjugates.
+            % Hermitian conjugates. Nyquist coordinates contribute
+            % self-conjugate modes only in even-sized dimensions.
             %
             % - Topic: Utility function
             % - Declaration: matrix = WVGeometryDoublyPeriodic.degreesOfFreedomForFourierCoefficients(Nx,Ny,conjugateDimension);
@@ -1180,11 +1189,18 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
 
             dof = WVGeometryDoublyPeriodic.degreesOfFreedomForComplexMatrix(Nx,Ny);
 
-            % self-conjugate modes only have one degree-of-freedom
-            dof(1,1) = 1;
-            dof(Nx/2+1,1) = 1;
-            dof(Nx/2+1,Ny/2+1) = 1;
-            dof(1,Ny/2+1) = 1;
+            % Self-conjugate modes only have one degree of freedom. Each
+            % even-sized dimension contributes a Nyquist coordinate; odd
+            % dimensions have no Nyquist mode.
+            selfConjugateK = 1;
+            selfConjugateL = 1;
+            if mod(Nx,2) == 0
+                selfConjugateK(end+1) = Nx/2+1;
+            end
+            if mod(Ny,2) == 0
+                selfConjugateL(end+1) = Ny/2+1;
+            end
+            dof(selfConjugateK,selfConjugateL) = 1;
 
             % and remove the conjugates.
             mask = WVGeometryDoublyPeriodic.maskForConjugateFourierCoefficients(Nx,Ny,conjugateDimension=options.conjugateDimension);
@@ -1239,7 +1255,8 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % returns a mask with locations of modes that are not fully resolved
             %
             % Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-            % modes are located a standard FFT matrix.
+            % modes are located in a standard FFT matrix. A direction has
+            % a Nyquist coordinate only when its grid size is even.
             %
             % Basic usage,
             % ```matlab
@@ -1263,8 +1280,12 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
                 nyquistMask double {mustBeNonnegative}
             end
             nyquistMask = zeros(Nx,Ny,Nz);
-            nyquistMask(Nx/2+1,:,:) = 1;
-            nyquistMask(:,Ny/2+1,:) = 1;
+            if mod(Nx,2) == 0
+                nyquistMask(Nx/2+1,:,:) = 1;
+            end
+            if mod(Ny,2) == 0
+                nyquistMask(:,Ny/2+1,:) = 1;
+            end
         end
 
         function mask = maskForConjugateFourierCoefficients(Nx,Ny,options)
@@ -1296,36 +1317,18 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
                 mask double {mustBeNonnegative}
             end
 
-            mask = zeros([Nx Ny]);
+            kMode = [0:ceil(Nx/2)-1 -floor(Nx/2):-1]';
+            lMode = [0:ceil(Ny/2)-1 -floor(Ny/2):-1]';
+            [K,L] = ndgrid(kMode,lMode);
+            kIsSelfConjugate = K == 0 | (mod(Nx,2) == 0 & K == -Nx/2);
+            lIsSelfConjugate = L == 0 | (mod(Ny,2) == 0 & L == -Ny/2);
+
             if options.conjugateDimension == 1
-                % The order of the for-loop is chosen carefully here.
-                for iK=1:(Nx/2+1)
-                    for iL=1:Ny
-                        if iK == 1 && iL > Ny/2 % avoid letting k=0, l=Ny/2+1 terms set themselves again
-                            continue;
-                        elseif iK == Nx/2+1 && iL > Ny/2 % avoid letting k=0, l=Ny/2+1 terms set themselves again
-                            continue;
-                        else
-                            mask = WVGeometryDoublyPeriodic.setConjugateToUnity(mask,iK,iL,Nx,Ny);
-                        end
-                    end
-                end
-            elseif options.conjugateDimension == 2
-                % The order of the for-loop is chosen carefully here.
-                for iL=1:(Ny/2+1)
-                    for iK=1:Nx
-                        if iL == 1 && iK > Nx/2 % avoid letting l=0, k=Nx/2+1 terms set themselves again
-                            continue;
-                        elseif iL == Ny/2+1 && iK > Nx/2 % avoid letting l=0, k=Nx/2+1 terms set themselves again
-                            continue;
-                        else
-                            mask = WVGeometryDoublyPeriodic.setConjugateToUnity(mask,iK,iL,Nx,Ny);
-                        end
-                    end
-                end
+                isPrimary = K > 0 | (kIsSelfConjugate & (L > 0 | lIsSelfConjugate));
             else
-                error('invalid conjugate dimension')
+                isPrimary = L > 0 | (lIsSelfConjugate & (K > 0 | kIsSelfConjugate));
             end
+            mask = double(~isPrimary);
         end
 
         function flag = isHermitian(A,options)
@@ -1357,14 +1360,14 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             N = size(A,2);
             K = size(A,3);
 
-            flag = 0;
+            flag = true;
             for k=1:K
                 for i=M:-1:1
                     for j=N:-1:1
                         ii = mod(M-i+1, M) + 1;
                         jj = mod(N-j+1, N) + 1;
                         if A(i,j,k) ~= conj(A(ii,jj,k))
-                            flag = 1;
+                            flag = false;
                             if options.shouldReportErrors == 1
                                 fprintf('(i,j,k)=(%d,%d,%d) is not conjugate with (%d,%d,%d)\n',i,j,k,ii,jj,k)
                             else

--- a/@WVGeometryDoublyPeriodicBarotropic/WVGeometryDoublyPeriodicBarotropic.m
+++ b/@WVGeometryDoublyPeriodicBarotropic/WVGeometryDoublyPeriodicBarotropic.m
@@ -41,7 +41,7 @@ classdef WVGeometryDoublyPeriodicBarotropic < WVGeometryDoublyPeriodic & WVRotat
             % - Returns wvt: a new Cartesian2DBarotropic instance
             arguments
                 Lxy (1,2) double {mustBePositive}
-                Nxy (1,2) double {mustBePositive}
+                Nxy (1,2) double {mustBeInteger,mustBePositive}
                 geomOptions.shouldAntialias (1,1) logical = true
                 rotatingOptions.rotationRate (1,1) double = 7.2921E-5
                 rotatingOptions.planetaryRadius (1,1) double = 6.371e6
@@ -182,20 +182,25 @@ classdef WVGeometryDoublyPeriodicBarotropic < WVGeometryDoublyPeriodic & WVRotat
                 index (:,1) double {mustBeInteger,mustBePositive}
             end
             mustBeMember(jMode,self.j)
+            if ~all(self.isValidModeNumber(kMode,lMode,jMode))
+                error('Invalid WV mode number!');
+            end
+            [kMode,lMode] = self.primaryKLModeNumberFromKLModeNumber(kMode,lMode);
             index = self.indexFromKLModeNumber(kMode,lMode);
         end
         function [kMode,lMode,jMode] = modeNumberFromIndex(self,linearIndex)
             arguments (Input)
                 self WVGeometryDoublyPeriodicBarotropic {mustBeNonempty}
-                linearIndex (1,1) double {mustBeInteger,mustBePositive}
+                linearIndex (:,1) double {mustBeInteger,mustBePositive}
             end
             arguments (Output)
-                kMode (1,1) double {mustBeInteger}
-                lMode (1,1) double {mustBeInteger}
-                jMode (1,1) double {mustBeInteger}
+                kMode (:,1) double {mustBeInteger}
+                lMode (:,1) double {mustBeInteger}
+                jMode (:,1) double {mustBeInteger}
             end
+            mustBeLessThanOrEqual(linearIndex,self.Nkl)
             [kMode,lMode] = self.klModeNumberFromIndex(linearIndex);
-            jMode = self.j;
+            jMode = repmat(self.j,size(linearIndex));
         end
     end
 

--- a/@WVTransform/spectralVariableWithResolution.m
+++ b/@WVTransform/spectralVariableWithResolution.m
@@ -1,12 +1,13 @@
 function [varargout] = spectralVariableWithResolution(self,wvtX2,varargin)
 % create a new variable with different resolution
 %
-% Given a variable with dimensions [Nj Nkl], this returns a new variable
-% with dimensions matching wvtX2. This can be either increased or decreased
-% resolution.
+% Given a variable with dimensions `[Nj Nkl]`, this returns a new variable
+% with dimensions matching `wvtX2`. Coefficients are matched by their
+% integer `(kMode,lMode,jMode)` identities. Modes absent from the target are
+% discarded and target modes absent from the source are initialized to zero.
 %
 % - Topic: Utility function
-% - Declaration: varX2 = spectralVariableWithResolution(var,Nklj)
+% - Declaration: varX2 = spectralVariableWithResolution(wvtX2,var)
 % - Parameter var: a variable with dimensions [Nj Nkl]
 % - Parameter wvtX2: a WVTransform of different size.
 % - Returns varX2: matrix the size Nklj
@@ -15,8 +16,13 @@ if ~isequal(self.Lx,wvtX2.Lx) || ~isequal(self.Ly,wvtX2.Ly) || ~isequal(self.Lz,
     error('These transforms are not compatible.')
 end
 
-Nkl = min(self.Nkl,wvtX2.Nkl);
-Nj = min(self.Nj,wvtX2.Nj);
+sourceK = repmat(self.kMode_wv.',self.Nj,1);
+sourceL = repmat(self.lMode_wv.',self.Nj,1);
+sourceJ = repmat(self.j,1,self.Nkl);
+targetK = repmat(wvtX2.kMode_wv.',wvtX2.Nj,1);
+targetL = repmat(wvtX2.lMode_wv.',wvtX2.Nj,1);
+targetJ = repmat(wvtX2.j,1,wvtX2.Nkl);
+[isCommon,sourceIndex] = ismember([targetK(:),targetL(:),targetJ(:)],[sourceK(:),sourceL(:),sourceJ(:)],'rows');
 
 varargout = cell(size(varargin));
 for iVar=1:length(varargin)
@@ -24,7 +30,7 @@ for iVar=1:length(varargin)
         varargout{iVar} = [];
     else
         varargout{iVar} = zeros(wvtX2.spectralMatrixSize);
-        varargout{iVar}(1:Nj,1:Nkl) = varargin{iVar}(1:Nj,1:Nkl);
+        varargout{iVar}(isCommon) = varargin{iVar}(sourceIndex(isCommon));
     end
 end
 

--- a/@WVTransformBarotropicQG/WVTransformBarotropicQG.m
+++ b/@WVTransformBarotropicQG/WVTransformBarotropicQG.m
@@ -171,7 +171,7 @@ classdef WVTransformBarotropicQG < WVGeometryDoublyPeriodicBarotropic & WVTransf
         end
 
         function wvtX2 = waveVortexTransformWithResolution(self,m)
-            names = {'shouldAntialias','h','planetaryRadius','rotationRate','latitude','g'};
+            names = {'shouldAntialias','h','j','planetaryRadius','rotationRate','latitude','g'};
             optionArgs = {};
             for i=1:length(names)
                 optionArgs{2*i-1} = names{i};
@@ -208,8 +208,27 @@ classdef WVTransformBarotropicQG < WVGeometryDoublyPeriodicBarotropic & WVTransf
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         function energy = get.totalEnergySpatiallyIntegrated(self)
+            % Return horizontally averaged barotropic energy.
+            %
+            % The spatial invariant is
+            % $$E = \frac{h}{2}\langle u^2+v^2\rangle + \frac{g}{2}\langle\eta^2\rangle.$$
+            %
+            % - Topic: Energetics
+            % - Returns energy: horizontally averaged energy per unit density
             [u,v,eta] = self.variableWithName('u','v','eta');
-            energy = sum(shiftdim(self.z_int,-2).*mean(mean( u.^2 + v.^2 + shiftdim(self.N2,-2).*eta.*eta, 1 ),2 ) )/2;
+            energy = self.h*mean(u.^2+v.^2,'all')/2 + self.g*mean(eta.^2,'all')/2;
+        end
+
+        function enstrophy = totalEnstrophySpatiallyIntegrated(self)
+            % Return horizontally averaged barotropic potential enstrophy.
+            %
+            % The spatial invariant is
+            % $$Z = \frac{h}{2}\langle q_{\mathrm{QG}}^2\rangle.$$
+            %
+            % - Topic: Energetics
+            % - Declaration: enstrophy = totalEnstrophySpatiallyIntegrated()
+            % - Returns enstrophy: horizontally averaged potential enstrophy
+            enstrophy = self.h*mean(self.qgpv.^2,'all')/2;
         end
 
         function energy = get.totalEnergy(self)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added compact invariant coverage across every stable transform on even and odd grids; corrected parity-aware Nyquist and Hermitian bookkeeping, vector mode/index mappings, coefficient-preserving resolution conversion, and barotropic spatial energy and enstrophy diagnostics.
 - Generalized `summarizeDegreesOfFreedom` across every stable transform with deterministic grid metadata and primary-component mask counts.
 - Implemented deterministic total-flow analytical-solution lookup across primary components and repaired barotropic mode-index conversion used by that lookup.
 - Implemented `hasMeanPressureDifference` as an MDA-only boundary diagnostic with a `1e-5` relative pressure tolerance; other flow components and transforms without an MDA component return `false`.

--- a/Documentation/WebsiteDocumentation/users-guide/supported-features.md
+++ b/Documentation/WebsiteDocumentation/users-guide/supported-features.md
@@ -34,6 +34,9 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | `WVTransformBarotropicQG` | Stable | The equivalent-barotropic quasigeostrophic transform is supported. |
 | Latitude | Stable | Supported transforms accept both hemispheres for `5 <= abs(latitude) <= 85`, including the endpoints. |
 | MATLAB builtin FFT implementation | Stable | This is the supported Fourier-transform backend. |
+| Even and odd builtin horizontal grids | Stable | Positive integer grid counts are supported independently in each periodic direction. Nyquist modes exist and are excluded only along even-sized directions. |
+| Transform indexing and resolution conversion | Stable | Scalar and column-vector mode/index mappings are bijective on supported modes. Resolution and explicit-antialias conversions preserve coefficients identified by common integer mode numbers and initialize new modes to zero. |
+| Spectral and spatial quadratic invariants | Stable | Energy and, where defined, enstrophy agree within the documented transform discretization tolerance. |
 | FFTW and `RealToComplexTransform` integration | Internal | These backend remnants are not selectable through a supported transform contract. |
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
 | Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
@@ -105,7 +108,6 @@ The Internal forcing classes currently reside under `Forcing/Experimental`; thei
 
 - [WVM-421-04: Restore a deterministic green test baseline](https://github.com/JeffreyEarly/wave-vortex-model/issues/11) will enforce the supported latitude range and reconcile the existing latitude tests.
 - [WVM-421-06: Resolve exact interpolation and placeholder public-method contracts](https://github.com/JeffreyEarly/wave-vortex-model/issues/13) will implement the stable derivative, integral, pressure, modal-solution, and summary contracts and remove internal interpolation choices from public-facing option lists.
-- [WVM-421-07: Add core transform invariant coverage](https://github.com/JeffreyEarly/wave-vortex-model/issues/14) will add representative and exhaustive coverage for every stable transform.
 - [WVM-421-08: Add model, forcing, observing, output, and persistence coverage](https://github.com/JeffreyEarly/wave-vortex-model/issues/15) will cover the stable subsystem contracts and evaluate the experimental integration path separately.
 - [WVM-421-09: Resolve correctness-related analyzer findings and legacy package artifacts](https://github.com/JeffreyEarly/wave-vortex-model/issues/16) will quarantine or remove internal remnants and correct internal misspellings without changing the stable model facade.
 

--- a/FlowComponents/WVGeostrophicComponent.m
+++ b/FlowComponents/WVGeostrophicComponent.m
@@ -100,7 +100,7 @@ classdef WVGeostrophicComponent < WVPrimaryFlowComponent
                             variableFactor = (f/g)*mask;
                         case "eta"
                             variableFactor = (f/g)*mask;
-                            variableFactor(1,:) = 0;
+                            variableFactor(self.wvt.J == 0) = 0;
                         case "A0N"
                             variableFactor = (f./(self.wvt.h_0.*(K2 + Lr2inv)));
                             variableFactor(self.wvt.J==0) = 0;
@@ -148,7 +148,7 @@ classdef WVGeostrophicComponent < WVPrimaryFlowComponent
                             variableFactor = -(f/g)./(K2 + Lr2inv);
                         case "eta"
                             variableFactor = -(f/g)./(K2 + Lr2inv);
-                            variableFactor(1,:) = 0;
+                            variableFactor(self.wvt.J == 0) = 0;
                         case "A0N"
                             variableFactor = -(f./self.wvt.h_0).*mask;
                             variableFactor(self.wvt.J==0) = 0;
@@ -393,4 +393,3 @@ classdef WVGeostrophicComponent < WVPrimaryFlowComponent
 
     end 
 end
-

--- a/Forcing/WVPseudoTopographicWaveGeneration.m
+++ b/Forcing/WVPseudoTopographicWaveGeneration.m
@@ -348,8 +348,10 @@ classdef WVPseudoTopographicWaveGeneration < WVForcing
             end
 
             terrainFourier = self.wvt.transformFromSpatialDomainWithFourier(repmat(self.topographicHeight,1,1,self.wvt.Nz));
-            terrainFourierX2 = self.wvt.spectralVariableWithResolution(wvtX2,terrainFourier);
-            terrainX2 = wvtX2.transformToSpatialDomainWithFourier(repmat(terrainFourierX2(1,:),wvtX2.Nz,1));
+            [isCommon,sourceIndex] = ismember([wvtX2.kMode_wv,wvtX2.lMode_wv],[self.wvt.kMode_wv,self.wvt.lMode_wv],"rows");
+            terrainFourierX2 = zeros(1,wvtX2.Nkl);
+            terrainFourierX2(isCommon) = terrainFourier(1,sourceIndex(isCommon));
+            terrainX2 = wvtX2.transformToSpatialDomainWithFourier(repmat(terrainFourierX2,wvtX2.Nz,1));
             forcing = WVPseudoTopographicWaveGeneration(wvtX2,topographicHeight=real(terrainX2(:,:,1)),barotropicVelocityAmplitude=self.barotropicVelocityAmplitude,frequency=self.frequency,rampDuration=self.rampDuration,startTime=self.startTime,shouldAvoidAdaptiveDamping=self.shouldAvoidAdaptiveDamping,maximumForcedHorizontalWavenumber=self.maximumForcedHorizontalWavenumber,maximumForcedVerticalMode=self.maximumForcedVerticalMode,name=string(self.name));
             forcing.darwinSymbol = self.darwinSymbol;
         end

--- a/UnitTests/README.md
+++ b/UnitTests/README.md
@@ -35,3 +35,9 @@ Every formal test method declares exactly one primary tag:
 - `optional` requires a declared optional dependency. The current optional category exercises the supported Optimization Toolbox path; unavailable dependencies produce an incomplete, unsuccessful run.
 
 Any failed or incomplete test makes its build task unsuccessful. Full and exhaustive discovery also check declared test metadata so a class or method cannot be silently omitted.
+
+## Core transform invariant matrix
+
+`TestCoreTransformInvariants` applies the compact full-category invariant matrix to constant-stratification hydrostatic and nonhydrostatic transforms, variable-stratification hydrostatic and Boussinesq transforms, stratified QG, and barotropic QG. The matrix uses both `[8 6 9]` and `[9 7 8]` grids; focused horizontal checks also cover mixed even/odd dimensions. `TestCoreTransformInvariantSmoke` provides one fast representative path, while the existing spectral-differentiation classes retain the large exhaustive parameter sweeps.
+
+Fourier round trips, Hermitian conjugacy, indexing, and constant-stratification derivatives use scale-aware machine-precision tolerances. Variable-stratification projections and spatial-versus-spectral quadratic invariants use relative tolerances up to `1e-3` on these deliberately small grids because their vertical discretization error is larger than floating-point roundoff. Test diagnostics identify the transform, grid parity, and invariant.

--- a/UnitTests/TestCoreTransformInvariantSmoke.m
+++ b/UnitTests/TestCoreTransformInvariantSmoke.m
@@ -1,0 +1,47 @@
+classdef TestCoreTransformInvariantSmoke < matlab.unittest.TestCase
+    methods (Test, TestTags = "smoke")
+        function representativeInvariantPath(testCase)
+            wvt = WVTransformConstantStratification([6e3 4e3 1e3],[8 6 9],N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=true);
+            seedRandomNumberGenerator(testCase,14001);
+            wvt.initWithRandomFlow(uvMax=0.01);
+
+            spectralIndices = (1:prod(wvt.spectralMatrixSize))';
+            [kMode,lMode,jMode] = wvt.modeNumberFromIndex(spectralIndices);
+            testCase.verifyEqual(wvt.indexFromModeNumber(kMode,lMode,jMode),spectralIndices)
+
+            [u,v,w,eta] = wvt.variableWithName("u","v","w","eta");
+            [Ap,Am,A0] = wvt.transformUVWEtaToWaveVortex(u,v,w,eta);
+            testCase.verifyRelative(Ap,wvt.Ap,2e-12,"constant nonhydrostatic coefficient round trip")
+            testCase.verifyRelative(Am,wvt.Am,2e-12,"constant nonhydrostatic coefficient round trip")
+            testCase.verifyRelative(A0,wvt.A0,2e-12,"constant nonhydrostatic coefficient round trip")
+            testCase.verifyRelative(wvt.totalEnergySpatiallyIntegrated,wvt.totalEnergy,2e-12,"constant nonhydrostatic Parseval energy")
+
+            [X,~,Z] = wvt.xyzGrid;
+            field = cos(4*pi*X/wvt.Lx).*cos(2*pi*(Z+wvt.Lz)/wvt.Lz);
+            testCase.verifyRelative(wvt.diffX(field),-(4*pi/wvt.Lx)*sin(4*pi*X/wvt.Lx).*cos(2*pi*(Z+wvt.Lz)/wvt.Lz),2e-12,"constant nonhydrostatic horizontal derivative")
+            testCase.verifyRelative(wvt.diffZF(field),-(2*pi/wvt.Lz)*cos(4*pi*X/wvt.Lx).*sin(2*pi*(Z+wvt.Lz)/wvt.Lz),2e-12,"constant nonhydrostatic vertical derivative")
+
+            resized = wvt.waveVortexTransformWithResolution([9 7 8]);
+            testCase.verifyEqual(resized.t,wvt.t)
+            explicit = wvt.waveVortexTransformWithExplicitAntialiasing();
+            testCase.verifyFalse(explicit.shouldAntialias)
+            testCase.verifyTrue(explicit.hasForcingWithName("antialias filter"))
+
+            for horizontalSize = {[8 7],[9 6]}
+                geometry = WVGeometryDoublyPeriodic([6e3 4e3],horizontalSize{1},shouldAntialias=false);
+                [X,Y] = ndgrid(geometry.x,geometry.y);
+                parityField = cos(4*pi*X/geometry.Lx+2*pi*Y/geometry.Ly);
+                parityCoefficients = geometry.transformFromSpatialDomainWithFourier(parityField);
+                reconstructed = geometry.transformToSpatialDomainWithFourier(parityCoefficients);
+                testCase.verifyRelative(reconstructed,parityField,2e-12,"mixed-parity Fourier round trip")
+            end
+        end
+    end
+
+    methods (Access = private)
+        function verifyRelative(testCase,actual,expected,tolerance,diagnostic)
+            relativeError = norm(actual(:)-expected(:))/max(norm(expected(:)),eps);
+            testCase.verifyLessThanOrEqual(relativeError,tolerance,diagnostic)
+        end
+    end
+end

--- a/UnitTests/TestCoreTransformInvariants.m
+++ b/UnitTests/TestCoreTransformInvariants.m
@@ -1,0 +1,221 @@
+classdef TestCoreTransformInvariants < matlab.unittest.TestCase
+    properties
+        wvt
+        transformType
+        gridType
+    end
+
+    properties (ClassSetupParameter)
+        transform = struct( ...
+            constantHydrostatic="constantHydrostatic", ...
+            constantNonhydrostatic="constantNonhydrostatic", ...
+            hydrostatic="hydrostatic", ...
+            boussinesq="boussinesq", ...
+            stratifiedQG="stratifiedQG", ...
+            barotropicQG="barotropicQG")
+        grid = struct(even=[8 6 9],odd=[9 7 8])
+    end
+
+    methods (TestClassSetup)
+        function createTransform(testCase,transform,grid)
+            testCase.transformType = string(transform);
+            testCase.gridType = string(matlab.lang.makeValidName(sprintf("%dx%dx%d",grid)));
+            testCase.wvt = testCase.transformForConfiguration(transform,grid,shouldAntialias=false);
+        end
+    end
+
+    methods (Test, TestTags = "full")
+        function geometryConjugacyAndIndexBijections(testCase)
+            wvt = testCase.wvt;
+            diagnostic = testCase.diagnostic("geometry, conjugacy, and indexing");
+
+            degreesOfFreedom = WVGeometryDoublyPeriodic.degreesOfFreedomForRealMatrix(wvt.Nx,wvt.Ny,conjugateDimension=wvt.conjugateDimension);
+            testCase.verifyEqual(sum(degreesOfFreedom,"all"),wvt.Nx*wvt.Ny,diagnostic)
+
+            nyquistMask = WVGeometryDoublyPeriodic.maskForNyquistModes(wvt.Nx,wvt.Ny);
+            if mod(wvt.Nx,2) == 0
+                testCase.verifyTrue(all(nyquistMask(wvt.Nx/2+1,:),"all"),diagnostic)
+            else
+                testCase.verifyFalse(any(nyquistMask,"all") && mod(wvt.Ny,2) == 1,diagnostic)
+                testCase.verifyTrue(any(wvt.kMode_wv == floor(wvt.Nx/2)),diagnostic)
+            end
+            if mod(wvt.Ny,2) == 0
+                testCase.verifyTrue(all(nyquistMask(:,wvt.Ny/2+1),"all"),diagnostic)
+            else
+                testCase.verifyTrue(any(wvt.lMode_wv == floor(wvt.Ny/2)),diagnostic)
+            end
+
+            spectralIndices = (1:prod(wvt.spectralMatrixSize))';
+            [kMode,lMode,jMode] = wvt.modeNumberFromIndex(spectralIndices);
+            testCase.verifyEqual(wvt.indexFromModeNumber(kMode,lMode,jMode),spectralIndices,diagnostic)
+            conjugateCandidate = find((kMode ~= 0 | lMode ~= 0) & wvt.isValidConjugateModeNumber(-kMode,-lMode,jMode),1);
+            testCase.assertNotEmpty(conjugateCandidate,diagnostic)
+            testCase.verifyEqual(wvt.indexFromModeNumber(-kMode(conjugateCandidate),-lMode(conjugateCandidate),jMode(conjugateCandidate)),spectralIndices(conjugateCandidate),diagnostic)
+            reordered = spectralIndices([numel(spectralIndices); 1; min(3,numel(spectralIndices))]);
+            [kReordered,lReordered,jReordered] = wvt.modeNumberFromIndex(reordered);
+            testCase.verifyEqual(wvt.indexFromModeNumber(kReordered,lReordered,jReordered),reordered,diagnostic)
+            testCase.verifyFalse(wvt.isValidPrimaryModeNumber(kMode(1),lMode(1),max(wvt.j)+1),diagnostic)
+            testCase.verifyError(@()wvt.modeNumberFromIndex(prod(wvt.spectralMatrixSize)+1),"MATLAB:validators:mustBeLessThanOrEqual")
+            testCase.verifyError(@()wvt.klModeNumberFromIndex(wvt.Nkl+1),"MATLAB:validators:mustBeLessThanOrEqual")
+
+            seedRandomNumberGenerator(testCase,14002);
+            spatialField = randn(wvt.spatialMatrixSize);
+            dftField = wvt.transformFromSpatialDomainToDFTGrid(spatialField);
+            testCase.verifyTrue(WVGeometryDoublyPeriodic.isHermitian(dftField),diagnostic)
+            testCase.verifyLessThanOrEqual(abs(imag(dftField(1,1))),10*eps,diagnostic)
+            dftField(1,1) = dftField(1,1)+1i;
+            testCase.verifyFalse(WVGeometryDoublyPeriodic.isHermitian(dftField),diagnostic)
+        end
+
+        function physicalSpectralRoundTripsAndQuadraticInvariants(testCase)
+            wvt = testCase.wvt;
+            diagnostic = testCase.diagnostic("round trip, energy, and enstrophy");
+            seedRandomNumberGenerator(testCase,14003);
+            wvt.initWithRandomFlow(uvMax=0.01);
+
+            switch testCase.transformType
+                case {"constantHydrostatic","hydrostatic"}
+                    [u,v,eta] = wvt.variableWithName("u","v","eta");
+                    [Ap,Am,A0] = wvt.transformUVEtaToWaveVortex(u,v,eta);
+                    testCase.verifyCoefficients(Ap,Am,A0,5e-10,diagnostic)
+                case {"constantNonhydrostatic","boussinesq"}
+                    [u,v,w,eta] = wvt.variableWithName("u","v","w","eta");
+                    [Ap,Am,A0] = wvt.transformUVWEtaToWaveVortex(u,v,w,eta);
+                    coefficientTolerance = 5e-10;
+                    if testCase.transformType == "boussinesq"
+                        coefficientTolerance = 1e-3;
+                    end
+                    testCase.verifyCoefficients(Ap,Am,A0,coefficientTolerance,diagnostic)
+                otherwise
+                    qgpv = wvt.variableWithName("qgpv");
+                    A0 = wvt.transformQGPVToWaveVortex(qgpv);
+                    testCase.verifyRelative(A0,wvt.A0,5e-10,diagnostic)
+            end
+
+            testCase.verifyRelative(wvt.totalEnergySpatiallyIntegrated,wvt.totalEnergy,1e-3,diagnostic)
+            testCase.verifyRelative(wvt.totalEnstrophySpatiallyIntegrated,wvt.totalEnstrophy,1e-3,diagnostic)
+        end
+
+        function analyticalHorizontalDifferentiation(testCase)
+            wvt = testCase.wvt;
+            diagnostic = testCase.diagnostic("horizontal differentiation");
+            X = wvt.X;
+            Y = wvt.Y;
+            k = 2*pi*min(2,floor((wvt.Nx-1)/2))/wvt.Lx;
+            l = 2*pi*min(2,floor((wvt.Ny-1)/2))/wvt.Ly;
+            field = cos(k*X+l*Y);
+            testCase.verifyRelative(wvt.diffX(field),-k*sin(k*X+l*Y).*ones(size(field)),5e-12,diagnostic)
+            testCase.verifyRelative(wvt.diffY(field),-l*sin(k*X+l*Y).*ones(size(field)),5e-12,diagnostic)
+            testCase.verifyRelative(wvt.diffX(field,n=4),k^4*field,5e-12,diagnostic)
+            testCase.verifyRelative(wvt.diffY(field,n=4),l^4*field,5e-12,diagnostic)
+        end
+
+        function resolutionAndAntialiasConversionsPreserveCommonModes(testCase)
+            wvt = testCase.wvt;
+            diagnostic = testCase.diagnostic("resolution conversion");
+            seedRandomNumberGenerator(testCase,14004);
+            wvt.initWithRandomFlow(uvMax=0.01);
+            wvt.t0 = 11;
+            wvt.t = 13;
+
+            if numel(wvt.spatialMatrixSize) == 3
+                largerSize = [wvt.Nx+2 wvt.Ny+2 wvt.Nz+1];
+                smallerSize = [max(5,wvt.Nx-2) max(5,wvt.Ny-2) max(5,wvt.Nz-1)];
+            else
+                largerSize = [wvt.Nx+2 wvt.Ny+2];
+                smallerSize = [max(5,wvt.Nx-2) max(5,wvt.Ny-2)];
+            end
+            larger = wvt.waveVortexTransformWithResolution(largerSize);
+            smaller = wvt.waveVortexTransformWithResolution(smallerSize);
+            testCase.verifyConversion(wvt,larger,diagnostic)
+            testCase.verifyConversion(wvt,smaller,diagnostic)
+
+            if testCase.gridType == "x8x6x9" && any(testCase.transformType == ["constantHydrostatic" "constantNonhydrostatic" "hydrostatic" "boussinesq"])
+                antialiased = testCase.transformForConfiguration(testCase.transformType,[8 6 9],shouldAntialias=true);
+                seedRandomNumberGenerator(testCase,14005);
+                antialiased.initWithRandomFlow(uvMax=0.01);
+                explicit = antialiased.waveVortexTransformWithExplicitAntialiasing();
+                testCase.verifyFalse(explicit.shouldAntialias,diagnostic)
+                testCase.verifyTrue(explicit.hasForcingWithName("antialias filter"),diagnostic)
+                testCase.verifyConversion(antialiased,explicit,diagnostic)
+            end
+        end
+    end
+
+    methods (Access = private)
+        function verifyCoefficients(testCase,Ap,Am,A0,tolerance,diagnostic)
+            testCase.verifyRelative(Ap,testCase.wvt.Ap,tolerance,diagnostic)
+            testCase.verifyRelative(Am,testCase.wvt.Am,tolerance,diagnostic)
+            testCase.verifyRelative(A0,testCase.wvt.A0,tolerance,diagnostic)
+        end
+
+        function verifyConversion(testCase,source,target,diagnostic)
+            testCase.verifyEqual(class(target),class(source),diagnostic)
+            testCase.verifyEqual([target.Lx target.Ly target.Lz],[source.Lx source.Ly source.Lz],diagnostic)
+            testCase.verifyEqual(target.t0,source.t0,diagnostic)
+            testCase.verifyEqual(target.t,source.t,diagnostic)
+            if isa(source,"WVGeometryDoublyPeriodicBarotropic")
+                testCase.verifyEqual(target.j,source.j,diagnostic)
+            end
+
+            sourceK = repmat(source.kMode_wv.',source.Nj,1);
+            sourceL = repmat(source.lMode_wv.',source.Nj,1);
+            sourceJ = repmat(source.j,1,source.Nkl);
+            targetK = repmat(target.kMode_wv.',target.Nj,1);
+            targetL = repmat(target.lMode_wv.',target.Nj,1);
+            targetJ = repmat(target.j,1,target.Nkl);
+            [isCommon,sourceIndex] = ismember([targetK(:),targetL(:),targetJ(:)],[sourceK(:),sourceL(:),sourceJ(:)],"rows");
+            for coefficientName = ["A0" "Ap" "Am"]
+                if isempty(source.(coefficientName))
+                    testCase.verifyEmpty(target.(coefficientName),diagnostic)
+                else
+                    targetCoefficient = target.(coefficientName);
+                    sourceCoefficient = source.(coefficientName);
+                    if numel(sourceCoefficient) ~= prod(source.spectralMatrixSize)
+                        testCase.verifyEqual(targetCoefficient,sourceCoefficient,diagnostic)
+                        continue
+                    end
+                    targetCoefficient = targetCoefficient(:);
+                    sourceCoefficient = sourceCoefficient(:);
+                    testCase.verifyEqual(targetCoefficient(isCommon),sourceCoefficient(sourceIndex(isCommon)),diagnostic)
+                    testCase.verifyEqual(targetCoefficient(~isCommon),zeros(size(targetCoefficient(~isCommon))),diagnostic)
+                end
+            end
+        end
+
+        function text = diagnostic(testCase,invariant)
+            text = sprintf("%s on %s grid: %s",testCase.transformType,testCase.gridType,invariant);
+        end
+
+        function verifyRelative(testCase,actual,expected,tolerance,diagnostic)
+            relativeError = norm(actual(:)-expected(:))/max(norm(expected(:)),eps);
+            testCase.verifyLessThanOrEqual(relativeError,tolerance,diagnostic)
+        end
+    end
+
+    methods (Static, Access = private)
+        function wvt = transformForConfiguration(transform,Nxyz,options)
+            arguments
+                transform string
+                Nxyz (1,3) double
+                options.shouldAntialias (1,1) logical
+            end
+            Lxyz = [6e3 4e3 1e3];
+            N2 = @(z) 2e-5*exp(z/4000);
+            switch transform
+                case "constantHydrostatic"
+                    wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=true,shouldAntialias=options.shouldAntialias);
+                case "constantNonhydrostatic"
+                    wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=options.shouldAntialias);
+                case "hydrostatic"
+                    wvt = WVTransformHydrostatic(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=options.shouldAntialias);
+                case "boussinesq"
+                    wvt = WVTransformBoussinesq(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=options.shouldAntialias);
+                case "stratifiedQG"
+                    wvt = WVTransformStratifiedQG(Lxyz,Nxyz,N2=N2,latitude=45,shouldAntialias=options.shouldAntialias);
+                case "barotropicQG"
+                    wvt = WVTransformBarotropicQG(Lxyz(1:2),Nxyz(1:2),latitude=45,shouldAntialias=options.shouldAntialias,j=0);
+            end
+        end
+    end
+end

--- a/docs/classes/transforms/wvtransform/spectralvariablewithresolution.md
+++ b/docs/classes/transforms/wvtransform/spectralvariablewithresolution.md
@@ -9,14 +9,14 @@ mathjax: true
 
 #  spectralVariableWithResolution
 
-create a new variable with different resolution
+Create a spectral variable at a different resolution
 
 
 ---
 
 ## Declaration
 ```matlab
- varX2 = spectralVariableWithResolution(var,Nklj)
+ varX2 = spectralVariableWithResolution(wvtX2,var)
 ```
 ## Parameters
 + `var`  a variable with dimensions [Nj Nkl]
@@ -27,8 +27,9 @@ create a new variable with different resolution
 
 ## Discussion
 
-  Given a variable with dimensions [Nj Nkl], this returns a new variable
-  with dimensions matching wvtX2. This can be either increased or decreased
-  resolution.
+  Given a variable with dimensions `[Nj Nkl]`, this returns a new variable
+  with dimensions matching `wvtX2`. Coefficients are matched by integer
+  `(kMode,lMode,jMode)` identity. Modes absent from the target are discarded,
+  and target modes absent from the source are initialized to zero.
  
           

--- a/docs/classes/transforms/wvtransform/wavevortextransformwithresolution.md
+++ b/docs/classes/transforms/wvtransform/wavevortextransformwithresolution.md
@@ -9,8 +9,11 @@ mathjax: true
 
 #  waveVortexTransformWithResolution
 
+Create a compatible transform at a new resolution.
 
-
+Common spectral coefficients are preserved by integer
+`(kMode,lMode,jMode)` identity. New modes are initialized to zero and modes
+outside the target resolution are discarded. Domain lengths, physical
+configuration, and model time are preserved.
 
 ---
-

--- a/docs/classes/transforms/wvtransformbarotropicqg/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/indexfrommodenumber.md
@@ -9,8 +9,10 @@ mathjax: true
 
 #  indexFromModeNumber
 
+Return the spectral linear index for `(kMode,lMode,jMode)`. Scalar and
+column-vector inputs preserve their shape and ordering; conjugate mode numbers
+map to their primary coefficient.
 
 
 
 ---
-

--- a/docs/classes/transforms/wvtransformbarotropicqg/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/maskfornyquistmodes.md
@@ -29,7 +29,8 @@ returns a mask with locations of modes that are not fully resolved
 ## Discussion
 
   Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located a standard FFT matrix.
+  modes are located in a standard FFT matrix. A direction has a Nyquist
+  coordinate only when its grid size is even.
  
   Basic usage,
   ```matlab

--- a/docs/classes/transforms/wvtransformbarotropicqg/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/modenumberfromindex.md
@@ -9,8 +9,10 @@ mathjax: true
 
 #  modeNumberFromIndex
 
+Return `(kMode,lMode,jMode)` for spectral linear indices. Scalar and
+column-vector inputs preserve their shape and ordering, and each index must
+lie within the current spectral matrix.
 
 
 
 ---
-

--- a/docs/classes/transforms/wvtransformbarotropicqg/totalenstrophyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/totalenstrophyspatiallyintegrated.md
@@ -9,8 +9,15 @@ mathjax: true
 
 #  totalEnstrophySpatiallyIntegrated
 
+Return horizontally averaged barotropic potential enstrophy.
 
+The spatial invariant is
 
+$$Z = \frac{h}{2}\langle q_{\mathrm{QG}}^2\rangle.$$
 
 ---
 
+## Declaration
+```matlab
+enstrophy = totalEnstrophySpatiallyIntegrated()
+```

--- a/docs/classes/transforms/wvtransformboussinesq/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/indexfrommodenumber.md
@@ -28,6 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 ## Discussion
 
   This function will return the linear index in a spectral
-  matrix given a mode number.
+  matrix given a mode number. Scalar and column-vector inputs preserve their
+  shape and ordering; conjugate mode numbers map to their primary coefficient.
  
           

--- a/docs/classes/transforms/wvtransformboussinesq/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/maskfornyquistmodes.md
@@ -29,7 +29,8 @@ returns a mask with locations of modes that are not fully resolved
 ## Discussion
 
   Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located a standard FFT matrix.
+  modes are located in a standard FFT matrix. A direction has a Nyquist
+  coordinate only when its grid size is even.
  
   Basic usage,
   ```matlab

--- a/docs/classes/transforms/wvtransformboussinesq/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/modenumberfromindex.md
@@ -9,8 +9,10 @@ mathjax: true
 
 #  modeNumberFromIndex
 
+Return `(kMode,lMode,jMode)` for spectral linear indices. Scalar and
+column-vector inputs preserve their shape and ordering, and each index must
+lie within the current spectral matrix.
 
 
 
 ---
-

--- a/docs/classes/transforms/wvtransformconstantstratification/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/indexfrommodenumber.md
@@ -28,6 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 ## Discussion
 
   This function will return the linear index in a spectral
-  matrix given a mode number.
+  matrix given a mode number. Scalar and column-vector inputs preserve their
+  shape and ordering; conjugate mode numbers map to their primary coefficient.
  
           

--- a/docs/classes/transforms/wvtransformconstantstratification/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/maskfornyquistmodes.md
@@ -29,7 +29,8 @@ returns a mask with locations of modes that are not fully resolved
 ## Discussion
 
   Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located a standard FFT matrix.
+  modes are located in a standard FFT matrix. A direction has a Nyquist
+  coordinate only when its grid size is even.
  
   Basic usage,
   ```matlab

--- a/docs/classes/transforms/wvtransformconstantstratification/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/modenumberfromindex.md
@@ -9,8 +9,10 @@ mathjax: true
 
 #  modeNumberFromIndex
 
+Return `(kMode,lMode,jMode)` for spectral linear indices. Scalar and
+column-vector inputs preserve their shape and ordering, and each index must
+lie within the current spectral matrix.
 
 
 
 ---
-

--- a/docs/classes/transforms/wvtransformhydrostatic/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/indexfrommodenumber.md
@@ -28,6 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 ## Discussion
 
   This function will return the linear index in a spectral
-  matrix given a mode number.
+  matrix given a mode number. Scalar and column-vector inputs preserve their
+  shape and ordering; conjugate mode numbers map to their primary coefficient.
  
           

--- a/docs/classes/transforms/wvtransformhydrostatic/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/maskfornyquistmodes.md
@@ -29,7 +29,8 @@ returns a mask with locations of modes that are not fully resolved
 ## Discussion
 
   Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located a standard FFT matrix.
+  modes are located in a standard FFT matrix. A direction has a Nyquist
+  coordinate only when its grid size is even.
  
   Basic usage,
   ```matlab

--- a/docs/classes/transforms/wvtransformhydrostatic/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/modenumberfromindex.md
@@ -9,8 +9,10 @@ mathjax: true
 
 #  modeNumberFromIndex
 
+Return `(kMode,lMode,jMode)` for spectral linear indices. Scalar and
+column-vector inputs preserve their shape and ordering, and each index must
+lie within the current spectral matrix.
 
 
 
 ---
-

--- a/docs/classes/transforms/wvtransformstratifiedqg/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/indexfrommodenumber.md
@@ -28,6 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 ## Discussion
 
   This function will return the linear index in a spectral
-  matrix given a mode number.
+  matrix given a mode number. Scalar and column-vector inputs preserve their
+  shape and ordering; conjugate mode numbers map to their primary coefficient.
  
           

--- a/docs/classes/transforms/wvtransformstratifiedqg/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/maskfornyquistmodes.md
@@ -29,7 +29,8 @@ returns a mask with locations of modes that are not fully resolved
 ## Discussion
 
   Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located a standard FFT matrix.
+  modes are located in a standard FFT matrix. A direction has a Nyquist
+  coordinate only when its grid size is even.
  
   Basic usage,
   ```matlab

--- a/docs/classes/transforms/wvtransformstratifiedqg/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/modenumberfromindex.md
@@ -9,8 +9,10 @@ mathjax: true
 
 #  modeNumberFromIndex
 
+Return `(kMode,lMode,jMode)` for spectral linear indices. Scalar and
+column-vector inputs preserve their shape and ordering, and each index must
+lie within the current spectral matrix.
 
 
 
 ---
-

--- a/docs/users-guide/supported-features.md
+++ b/docs/users-guide/supported-features.md
@@ -34,6 +34,9 @@ No feature is assigned to Deprecated in the v4.2.1 target contract.
 | `WVTransformBarotropicQG` | Stable | The equivalent-barotropic quasigeostrophic transform is supported. |
 | Latitude | Stable | Supported transforms accept both hemispheres for `5 <= abs(latitude) <= 85`, including the endpoints. |
 | MATLAB builtin FFT implementation | Stable | This is the supported Fourier-transform backend. |
+| Even and odd builtin horizontal grids | Stable | Positive integer grid counts are supported independently in each periodic direction. Nyquist modes exist and are excluded only along even-sized directions. |
+| Transform indexing and resolution conversion | Stable | Scalar and column-vector mode/index mappings are bijective on supported modes. Resolution and explicit-antialias conversions preserve coefficients identified by common integer mode numbers and initialize new modes to zero. |
+| Spectral and spatial quadratic invariants | Stable | Energy and, where defined, enstrophy agree within the documented transform discretization tolerance. |
 | FFTW and `RealToComplexTransform` integration | Internal | These backend remnants are not selectable through a supported transform contract. |
 | Periodic `linear` and `spline` interpolation | Stable | These are the only interpolation methods exposed by the supported public interpolation contract. |
 | Vertical calculus for stable 3-D transforms | Stable | `diffZF` and `diffZG` support orders 1 through 4 on `[Nx Ny Nz]` grids. `intZF` and `intZG` support first antiderivatives on `[Nx Ny Nz]` grids and `[Nz N]` matrices. Unsupported orders and layouts are rejected through ordinary MATLAB argument validation. |
@@ -105,7 +108,6 @@ The Internal forcing classes currently reside under `Forcing/Experimental`; thei
 
 - [WVM-421-04: Restore a deterministic green test baseline](https://github.com/JeffreyEarly/wave-vortex-model/issues/11) will enforce the supported latitude range and reconcile the existing latitude tests.
 - [WVM-421-06: Resolve exact interpolation and placeholder public-method contracts](https://github.com/JeffreyEarly/wave-vortex-model/issues/13) will implement the stable derivative, integral, pressure, modal-solution, and summary contracts and remove internal interpolation choices from public-facing option lists.
-- [WVM-421-07: Add core transform invariant coverage](https://github.com/JeffreyEarly/wave-vortex-model/issues/14) will add representative and exhaustive coverage for every stable transform.
 - [WVM-421-08: Add model, forcing, observing, output, and persistence coverage](https://github.com/JeffreyEarly/wave-vortex-model/issues/15) will cover the stable subsystem contracts and evaluate the experimental integration path separately.
 - [WVM-421-09: Resolve correctness-related analyzer findings and legacy package artifacts](https://github.com/JeffreyEarly/wave-vortex-model/issues/16) will quarantine or remove internal remnants and correct internal misspellings without changing the stable model facade.
 


### PR DESCRIPTION
## Summary

- add compact smoke and full invariant coverage across all six stable transform configurations
- support even, odd, and mixed-parity builtin horizontal grids with parity-aware Nyquist and Hermitian bookkeeping
- correct vector mode/index mappings, mode-identity resolution conversion, and barotropic spatial energy/enstrophy
- keep topographic-forcing resolution conversion aligned with horizontal Fourier mode identities
- update the support matrix, test documentation, API pages, and changelog

## Verification

- focused invariant suite: 49 passed
- smoke: 127 passed
- full: 514 passed
- exhaustive: 2440 passed
- MATLAB analysis completed with no new findings
- documentation mirror, whitespace, repository-scope, and artifact checks passed

Closes #14