### PR TITLE
Cover stable observing-system behavior and composition

### DIFF
--- a/@WVModel/WVModel.m
+++ b/@WVModel/WVModel.m
@@ -220,19 +220,7 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
                 self WVModel {mustBeNonempty}
                 anObservingSystem (1,1) WVCoefficients
             end
-            % prepend, so that its always first
-            if isempty(self.fluxedObservingSystems)
-                self.fluxedObservingSystems = anObservingSystem;
-            else
-                if ~isa(self.fluxedObservingSystems(1),'WVCoefficients')
-                    idx = find(size(self.fluxedObservingSystems) > 1, 1);
-                    if isempty(idx)
-                        idx = 1;
-                    end
-                    self.fluxedObservingSystems = cat(idx, anObservingSystem, self.fluxedObservingSystems);
-                end
-            end
-            self.recomputeIndicesForFluxedSystems();
+            self.addFluxedObservingSystem(anObservingSystem);
         end 
 
         function addFluxedObservingSystem(self,anObservingSystem)
@@ -243,12 +231,34 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
                 self WVModel {mustBeNonempty}
                 anObservingSystem WVObservingSystem
             end
-            for iObs=1:length(anObservingSystem)
-                alreadyInArray = any(cellfun(@(x) isequal(x, anObservingSystem(iObs)), num2cell(self.fluxedObservingSystems)));
-                if ~alreadyInArray
-                    self.fluxedObservingSystems(end+1) = anObservingSystem(iObs);
+            registeredSystems = self.fluxedObservingSystems;
+            for iObs = 1:length(anObservingSystem)
+                observer = anObservingSystem(iObs);
+                if observer.model ~= self
+                    error('The observing system %s was not initialized for this model.',observer.name);
+                end
+
+                sameHandle = cellfun(@(existing) existing == observer,num2cell(registeredSystems));
+                if any(sameHandle)
+                    continue;
+                end
+
+                if any(strcmp(string({registeredSystems.name}),string(observer.name)))
+                    error('An observing system named %s is already registered with this model.',observer.name);
+                end
+
+                if isempty(registeredSystems)
+                    registeredSystems = observer;
+                elseif isa(observer,'WVCoefficients')
+                    if any(arrayfun(@(existing) isa(existing,'WVCoefficients'),registeredSystems))
+                        error('A WVCoefficients observing system is already registered with this model.');
+                    end
+                    registeredSystems = [observer registeredSystems];
+                else
+                    registeredSystems(end+1) = observer;
                 end
             end
+            self.fluxedObservingSystems = registeredSystems;
             self.recomputeIndicesForFluxedSystems();
         end
 
@@ -260,9 +270,21 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
                 self WVModel {mustBeNonempty}
                 anObservingSystem WVObservingSystem
             end
-            for iObs=1:length(anObservingSystem)
-                self.fluxedObservingSystems = setdiff(self.fluxedObservingSystems,anObservingSystem(iObs),'stable');
+            registeredSystems = self.fluxedObservingSystems;
+            removeMask = false(size(registeredSystems));
+            for iObs = 1:length(anObservingSystem)
+                observer = anObservingSystem(iObs);
+                if observer.model ~= self
+                    error('The observing system %s was not initialized for this model.',observer.name);
+                end
+                sameHandle = cellfun(@(existing) existing == observer,num2cell(registeredSystems));
+                if ~any(sameHandle)
+                    error('The observing system %s is not registered with this model.',observer.name);
+                end
+                removeMask = removeMask | sameHandle;
             end
+            registeredSystems(removeMask) = [];
+            self.fluxedObservingSystems = registeredSystems;
             self.recomputeIndicesForFluxedSystems();
         end
 
@@ -277,12 +299,11 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             arguments (Output)
                 anObservingSystem WVObservingSystem
             end
-            anObservingSystem = [];
-            for i = 1:length(self.fluxedObservingSystems)
-                if strcmp(self.fluxedObservingSystems(i).name,name)
-                    anObservingSystem = self.fluxedObservingSystems(i);
-                end
+            idx = find(strcmp(string({self.fluxedObservingSystems.name}),string(name)),1);
+            if isempty(idx)
+                error('No fluxed observing system named %s is registered with this model.',name);
             end
+            anObservingSystem = self.fluxedObservingSystems(idx);
         end
 
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -401,7 +422,7 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
                 options.absToleranceZ = 1e-2;
             end
 
-            observingSystem = WVLagrangianParticles(self,name=name,isXYOnly=isXYOnly,x=x,y=y,z=z,trackedFieldNames=trackedFieldNames,advectionInterpolation=options.advectionInterpolation,trackedVarInterpolation=options.trackedVarInterpolation);
+            observingSystem = WVLagrangianParticles(self,name=name,isXYOnly=isXYOnly,x=x,y=y,z=z,trackedFieldNames=trackedFieldNames,advectionInterpolation=options.advectionInterpolation,trackedVarInterpolation=options.trackedVarInterpolation,absToleranceXY=options.absToleranceXY,absToleranceZ=options.absToleranceZ);
             if isscalar(self.outputFiles) && isscalar(self.outputFiles(1).outputGroups)
                 self.outputFiles(1).outputGroups(1).addObservingSystem(observingSystem);
             elseif isempty(self.outputFiles)
@@ -742,6 +763,8 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
 
         function F = fluxAtTimeCellArray(self,t,y0)
             self.nFluxComputations = self.nFluxComputations + 1;
+            % Linear models have no coefficient observer to advance the transform time.
+            self.wvt.t = t;
             F = cell(self.nFluxComponents,1);
             for i = 1:length(self.fluxedObservingSystems)
                 F(self.indicesForFluxedSystem{i}) = self.fluxedObservingSystems(i).fluxAtTime(t,y0(self.indicesForFluxedSystem{i}));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Corrected observing-system ownership and composition, linear-time flux evaluation, particle tolerance and tracked-field propagation, and periodic one-based mooring indexing.
 - Added compact invariant coverage across every stable transform on even and odd grids; corrected parity-aware Nyquist and Hermitian bookkeeping, vector mode/index mappings, coefficient-preserving resolution conversion, and barotropic spatial energy and enstrophy diagnostics.
 - Generalized `summarizeDegreesOfFreedom` across every stable transform with deterministic grid metadata and primary-component mask counts.
 - Implemented deterministic total-flow analytical-solution lookup across primary components and repaired barotropic mode-index conversion used by that lookup.

--- a/ObservingSystems/WVLagrangianParticles.m
+++ b/ObservingSystems/WVLagrangianParticles.m
@@ -106,6 +106,7 @@ classdef WVLagrangianParticles < WVObservingSystem
             % - Topic: Particles
             % - Declaration: [x,y,z,trackedFields] = particlePositions(name)
             % - Parameter name: name of the particles
+            self.updateParticleTrackedFields();
             x = self.x;
             y = self.y;
             z = self.z;
@@ -176,10 +177,10 @@ classdef WVLagrangianParticles < WVObservingSystem
 
         function updateIntegratorValues(self,t,y0)
             % passes updated values of the variables being integrated.
-            self.x = y0{1};
-            self.y = y0{2};
+            self.x(:) = y0{1};
+            self.y(:) = y0{2};
             if ~self.isXYOnly
-                self.z = y0{3};
+                self.z(:) = y0{3};
             end
         end
 

--- a/ObservingSystems/WVMooring.m
+++ b/ObservingSystems/WVMooring.m
@@ -77,12 +77,14 @@ classdef WVMooring < WVObservingSystem
                 y = options.y;
             end
 
+            x = mod(x,model.wvt.Lx);
+            y = mod(y,model.wvt.Ly);
             self.x = x;
             self.y = y;
             dx = model.wvt.x(2)-model.wvt.x(1);
-            self.x_index = floor(x/dx);
+            self.x_index = floor(x/dx) + 1;
             dy = model.wvt.y(2)-model.wvt.y(1);
-            self.y_index = floor(y/dy);
+            self.y_index = floor(y/dy) + 1;
         end
 
         function names = get.trackedFieldNames(self)

--- a/UnitTests/TestObservingSystems.m
+++ b/UnitTests/TestObservingSystems.m
@@ -1,0 +1,302 @@
+classdef TestObservingSystems < matlab.unittest.TestCase
+    properties (TestParameter)
+        integratorType = struct(fixed="fixed",adaptive="adaptive")
+    end
+
+    methods (Test, TestTags = "full")
+        function modelRegistryUsesIdentityAndAtomicMutations(testCase)
+            model = TestObservingSystems.linearModel3D();
+            particles = TestObservingSystems.particles(model,"particles",0);
+            model.addFluxedObservingSystem(particles);
+
+            model.addFluxedObservingSystem(particles);
+            testCase.verifyEqual(numel(model.fluxedObservingSystems),1)
+            testCase.verifyTrue(model.fluxedObservingSystems(1) == particles)
+
+            duplicate = TestObservingSystems.particles(model,"particles",100);
+            testCase.verifyError(@()model.addFluxedObservingSystem(duplicate),'')
+            TestObservingSystems.verifyRegistry(testCase,model,particles,{1:3})
+
+            otherModel = TestObservingSystems.linearModel3D();
+            foreign = TestObservingSystems.particles(otherModel,"foreign",0);
+            testCase.verifyError(@()model.addFluxedObservingSystem(foreign),'')
+            testCase.verifyError(@()model.removeFluxedObservingSystem(foreign),'')
+            TestObservingSystems.verifyRegistry(testCase,model,particles,{1:3})
+
+            testCase.verifyError(@()model.removeFluxedObservingSystem(duplicate),'')
+            testCase.verifyError(@()model.fluxedObservingSystemWithName("missing"),'')
+            TestObservingSystems.verifyRegistry(testCase,model,particles,{1:3})
+
+            model.removeFluxedObservingSystem(particles);
+            testCase.verifyEmpty(model.fluxedObservingSystems)
+            testCase.verifyEqual(model.nFluxComponents,0)
+            testCase.verifyEmpty(model.indicesForFluxedSystem)
+        end
+
+        function coefficientsRemainFirstAndIndicesRemainContiguous(testCase)
+            model = TestObservingSystems.linearModel3D();
+            particles = TestObservingSystems.particles(model,"particles",0);
+            tracer = WVTracer(model,name="tracer",phi=zeros(model.wvt.spatialMatrixSize));
+            coefficients = WVCoefficients(model);
+
+            model.addFluxedObservingSystem(particles);
+            model.addFluxedObservingSystem(tracer);
+            model.addFluxedObservingSystem(coefficients);
+            TestObservingSystems.verifyRegistry(testCase,model,[coefficients particles tracer],{1:3,4:6,7})
+
+            duplicateCoefficients = WVCoefficients(model);
+            testCase.verifyError(@()model.addFluxedCoefficients(duplicateCoefficients),'')
+            TestObservingSystems.verifyRegistry(testCase,model,[coefficients particles tracer],{1:3,4:6,7})
+
+            model.removeFluxedObservingSystem(particles);
+            TestObservingSystems.verifyRegistry(testCase,model,[coefficients tracer],{1:3,4})
+
+            replacementParticles = TestObservingSystems.particles(model,"replacement",100);
+            model.addFluxedObservingSystem(replacementParticles);
+            TestObservingSystems.verifyRegistry(testCase,model,[coefficients tracer replacementParticles],{1:3,4,5:7})
+        end
+
+        function outputGroupLifecycleIsIdentityBasedAndAtomic(testCase)
+            model = TestObservingSystems.linearModel3D();
+            outputGroup = WVModelOutputGroup(model,name="memory-only");
+            eulerian = model.eulerianObservingSystem;
+            particles = TestObservingSystems.particles(model,"particles",0);
+            tracer = WVTracer(model,name="tracer",phi=zeros(model.wvt.spatialMatrixSize));
+
+            outputGroup.addObservingSystem(eulerian);
+            outputGroup.addObservingSystem(particles);
+            outputGroup.addObservingSystem(tracer);
+            testCase.verifyTrue(outputGroup.observingSystemWithName("particles") == particles)
+            TestObservingSystems.verifyRegistry(testCase,model,[particles tracer],{1:3,4})
+
+            duplicate = TestObservingSystems.particles(model,"particles",100);
+            testCase.verifyError(@()outputGroup.addObservingSystem(duplicate),'')
+            testCase.verifyError(@()outputGroup.removeObservingSystem(duplicate),'')
+            testCase.verifyEqual(numel(outputGroup.observingSystems),3)
+            TestObservingSystems.verifyRegistry(testCase,model,[particles tracer],{1:3,4})
+
+            otherModel = TestObservingSystems.linearModel3D();
+            foreign = TestObservingSystems.particles(otherModel,"foreign",0);
+            testCase.verifyError(@()outputGroup.addObservingSystem(foreign),'')
+            testCase.verifyError(@()outputGroup.removeObservingSystem(foreign),'')
+            testCase.verifyError(@()outputGroup.observingSystemWithName("missing"),'')
+            testCase.verifyEqual(numel(outputGroup.observingSystems),3)
+            TestObservingSystems.verifyRegistry(testCase,model,[particles tracer],{1:3,4})
+
+            outputGroup.removeObservingSystem(particles);
+            testCase.verifyEqual(string({outputGroup.observingSystems.name}),["eulerian fields" "tracer"])
+            TestObservingSystems.verifyRegistry(testCase,model,tracer,{1})
+
+            outputGroup.removeObservingSystem(eulerian);
+            testCase.verifyTrue(outputGroup.observingSystems(1) == tracer)
+            TestObservingSystems.verifyRegistry(testCase,model,tracer,{1})
+        end
+
+        function outputGroupUsesCanonicalCoefficientObserver(testCase)
+            model = TestObservingSystems.linearModel3D();
+            canonicalCoefficients = WVCoefficients(model,absTolerance=1e-6);
+            model.addFluxedCoefficients(canonicalCoefficients);
+            restoredCoefficients = WVCoefficients(model,absTolerance=4e-8);
+            outputGroup = WVModelOutputGroup(model,name="memory-only");
+
+            outputGroup.addObservingSystem(restoredCoefficients);
+
+            testCase.verifyTrue(outputGroup.observingSystems(1) == canonicalCoefficients)
+            testCase.verifyTrue(model.fluxedObservingSystems(1) == canonicalCoefficients)
+            testCase.verifyEqual(canonicalCoefficients.absTolerance,4e-8)
+            TestObservingSystems.verifyRegistry(testCase,model,canonicalCoefficients,{1:3})
+        end
+
+        function suppliedEulerianAndCoefficientContracts(testCase)
+            model3D = TestObservingSystems.linearModel3D();
+            eulerian = model3D.eulerianObservingSystem;
+            eulerian.setNetCDFOutputVariables('u','A0');
+            testCase.verifyEqual(eulerian.fieldNames,["u" "A0"])
+            testCase.verifyEqual(eulerian.nOutputVariables,2)
+            eulerian.addNetCDFOutputVariables('v','u');
+            testCase.verifyEqual(sort(eulerian.fieldNames),sort(["u" "v" "A0"]))
+            eulerian.removeNetCDFOutputVariables('A0');
+            testCase.verifyFalse(any(eulerian.fieldNames == "A0"))
+            fieldsBeforeFailure = eulerian.fieldNames;
+            testCase.verifyError(@()eulerian.addNetCDFOutputVariables('not-a-field'),'')
+            testCase.verifyEqual(eulerian.fieldNames,fieldsBeforeFailure)
+
+            coefficients3D = WVCoefficients(model3D,absTolerance=2e-7);
+            testCase.verifyEqual(double(coefficients3D.nFluxComponents),3)
+            testCase.verifyEqual(coefficients3D.lengthOfFluxComponents(),repmat(numel(model3D.wvt.Ap),3,1))
+            initial3D = coefficients3D.initialConditions();
+            testCase.verifyEqual(initial3D,{model3D.wvt.Ap;model3D.wvt.Am;model3D.wvt.A0})
+            tolerances3D = coefficients3D.absErrorTolerance();
+            testCase.verifyEqual(cellfun(@numel,tolerances3D),repmat(numel(model3D.wvt.Ap),3,1))
+            testCase.verifyTrue(all(cellfun(@(value)all(isfinite(value),"all"),tolerances3D)))
+
+            updated3D = {ones(size(model3D.wvt.Ap));2*ones(size(model3D.wvt.Am));3*ones(size(model3D.wvt.A0))};
+            coefficients3D.updateIntegratorValues(17,updated3D);
+            testCase.verifyEqual(model3D.wvt.t,17)
+            testCase.verifyEqual(model3D.wvt.Ap,updated3D{1})
+            testCase.verifyEqual(model3D.wvt.Am,updated3D{2})
+            testCase.verifyEqual(model3D.wvt.A0,updated3D{3})
+
+            barotropicModel = TestObservingSystems.linearBarotropicModel();
+            testCase.verifyEqual(barotropicModel.eulerianObservingSystem.fieldNames,"A0")
+            coefficients2D = WVCoefficients(barotropicModel,absTolerance=2e-7);
+            testCase.verifyEqual(double(coefficients2D.nFluxComponents),1)
+            testCase.verifyEqual(coefficients2D.lengthOfFluxComponents(),numel(barotropicModel.wvt.A0))
+            testCase.verifyEqual(coefficients2D.initialConditions(),{barotropicModel.wvt.A0})
+            updatedA0 = {4*ones(size(barotropicModel.wvt.A0))};
+            coefficients2D.updateIntegratorValues(19,updatedA0);
+            testCase.verifyEqual(barotropicModel.wvt.t,19)
+            testCase.verifyEqual(barotropicModel.wvt.A0,updatedA0{1})
+        end
+
+        function particleAndTracerFacadesExposeCurrentState(testCase)
+            model3D = TestObservingSystems.linearModel3D();
+            model3D.wvt.initWithInertialMotions(@(z)0.1*ones(size(z)),@(z)zeros(size(z)));
+            x0 = [500 1500];
+            y0 = [400 1200];
+            z0 = [-250 -750];
+            model3D.setFloatPositions(x0,y0,z0,'u',absToleranceXY=3e-4,absToleranceZ=7e-5);
+            floats = model3D.fluxedObservingSystemWithName("float");
+            testCase.verifyEqual(floats.absToleranceXY,3e-4)
+            testCase.verifyEqual(floats.absToleranceZ,7e-5)
+            testCase.verifyEqual(floats.lengthOfFluxComponents(),[2;2;2])
+            testCase.verifyEqual(floats.initialConditions(),{x0,y0,z0})
+            testCase.verifyEqual(floats.absErrorTolerance(),{3e-4,3e-4,7e-5})
+
+            floatFlux = floats.fluxAtTime(0,{x0,y0,z0});
+            testCase.verifyEqual(floatFlux{1},0.1*ones(size(x0)),AbsTol=1e-12)
+            testCase.verifyEqual(floatFlux{2},zeros(size(y0)),AbsTol=1e-12)
+            testCase.verifyEqual(floatFlux{3},zeros(size(z0)),AbsTol=1e-12)
+
+            x1 = x0 + 20;
+            y1 = y0 - 10;
+            floats.updateIntegratorValues(20,{x1,y1,z0});
+            model3D.wvt.t = 20;
+            [x,y,z,tracked] = model3D.floatPositions();
+            testCase.verifyEqual(x,x1)
+            testCase.verifyEqual(y,y1)
+            testCase.verifyEqual(z,z0)
+            expectedU = model3D.wvt.variableAtPositionWithName(x1,y1,z0,'u');
+            testCase.verifyEqual(tracked.u,expectedU)
+
+            barotropicModel = TestObservingSystems.linearBarotropicModel();
+            barotropicModel.setDrifterPositions([0 100],[0 200],[],'u',absToleranceXY=9e-4);
+            drifters = barotropicModel.fluxedObservingSystemWithName("drifter");
+            testCase.verifyTrue(drifters.isXYOnly)
+            testCase.verifyEqual(drifters.absToleranceXY,9e-4)
+            testCase.verifyEqual(drifters.lengthOfFluxComponents(),[2;2])
+            testCase.verifyEqual(drifters.absErrorTolerance(),{9e-4,9e-4})
+
+            phi0 = reshape(1:prod(barotropicModel.wvt.spatialMatrixSize),barotropicModel.wvt.spatialMatrixSize);
+            barotropicModel.addTracer(phi0,"dye");
+            tracer = barotropicModel.fluxedObservingSystemWithName("dye");
+            testCase.verifyTrue(tracer.isXYOnly)
+            testCase.verifyEqual(tracer.lengthOfFluxComponents(),numel(phi0))
+            testCase.verifyEqual(tracer.initialConditions(),{phi0})
+            testCase.verifyEqual(tracer.absErrorTolerance(),{tracer.absTolerance})
+            tracer.updateIntegratorValues(0,{2*phi0});
+            testCase.verifyEqual(barotropicModel.tracer("dye"),2*phi0)
+        end
+
+        function mooringsUsePeriodicOneBasedLowerCellIndices(testCase)
+            model = TestObservingSystems.linearModel3D();
+            dx = model.wvt.x(2)-model.wvt.x(1);
+            dy = model.wvt.y(2)-model.wvt.y(1);
+            x = [0 dx/2 dx model.wvt.Lx-dx/2 model.wvt.Lx model.wvt.Lx+dx -dx/2];
+            y = [0 dy/2 dy model.wvt.Ly-dy/2 model.wvt.Ly -dy model.wvt.Ly+dy];
+            mooring = WVMooring(model,name="test mooring",x=x,y=y,trackedFieldNames={'u'});
+
+            expectedX = mod(x,model.wvt.Lx);
+            expectedY = mod(y,model.wvt.Ly);
+            testCase.verifyEqual(mooring.x,expectedX)
+            testCase.verifyEqual(mooring.y,expectedY)
+            testCase.verifyEqual(mooring.x_index,floor(expectedX/dx)+1)
+            testCase.verifyEqual(mooring.y_index,floor(expectedY/dy)+1)
+            testCase.verifyGreaterThanOrEqual(mooring.x_index,1)
+            testCase.verifyLessThanOrEqual(mooring.x_index,model.wvt.Nx)
+            testCase.verifyGreaterThanOrEqual(mooring.y_index,1)
+            testCase.verifyLessThanOrEqual(mooring.y_index,model.wvt.Ny)
+            testCase.verifyEqual(mooring.x_index([1 5]),[1 1])
+            testCase.verifyEqual(mooring.x_index([3 6]),[2 2])
+            testCase.verifyEqual(mooring.y_index([1 5]),[1 1])
+            testCase.verifyEqual(mooring.y_index([3 7]),[2 2])
+        end
+
+        function mooringsRejectUnsupportedGeometryAndFields(testCase)
+            model3D = TestObservingSystems.linearModel3D();
+            testCase.verifyError(@()WVMooring(model3D,x=0,y=0,trackedFieldNames={'not-a-field'}),'')
+
+            barotropicModel = TestObservingSystems.linearBarotropicModel();
+            testCase.verifyError(@()WVMooring(barotropicModel,x=0,y=0,trackedFieldNames={'u'}),'')
+        end
+
+        function stableIntegratorsAdvanceParticlesAndTracerAnalytically(testCase,integratorType)
+            [model,x0,y0,z0,phi0,U] = TestObservingSystems.observerIntegrationModel();
+            finalTime = 600;
+            if integratorType == "fixed"
+                model.setupIntegrator(integratorType="fixed",deltaT=10);
+            else
+                model.setupIntegrator(integratorType="adaptive",relTolerance=1e-10);
+            end
+
+            model.integrateToTime(finalTime,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            [x,y,z,tracked] = model.floatPositions();
+            phi = model.tracer("dye");
+
+            omega = abs(model.wvt.f);
+            deltaX = U*sin(omega*finalTime)/omega;
+            deltaY = U*(cos(omega*finalTime)-1)/omega;
+            expectedPhi = sin(2*pi*(model.wvt.X-deltaX)/model.wvt.Lx);
+
+            testCase.verifyEqual(model.wvt.t,finalTime)
+            testCase.verifyEqual(x,x0+deltaX,AbsTol=2e-5)
+            testCase.verifyEqual(y,y0+deltaY,AbsTol=2e-5)
+            testCase.verifyEqual(z,z0,AbsTol=1e-12)
+            testCase.verifyNotEqual(x,x0)
+            testCase.verifyNotEqual(y,y0)
+            testCase.verifyEqual(phi,expectedPhi,AbsTol=5e-5)
+            testCase.verifyNotEqual(phi,phi0)
+            testCase.verifyEqual(tracked.u,U*cos(omega*finalTime)*ones(size(x0)),AbsTol=1e-10)
+        end
+    end
+
+    methods (Static, Access = private)
+        function model = linearModel3D()
+            wvt = WVTransformConstantStratification([4000 3000 1000],[8 6 5],N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=false);
+            model = WVModel(wvt,shouldUseLinearDynamics=true);
+        end
+
+        function model = linearBarotropicModel()
+            wvt = WVTransformBarotropicQG([4000 3000],[8 6],latitude=45,shouldAntialias=false);
+            model = WVModel(wvt,shouldUseLinearDynamics=true);
+        end
+
+        function particles = particles(model,name,xOffset)
+            particles = WVLagrangianParticles(model,name=name,x=xOffset,y=0,z=-500,trackedFieldNames={});
+        end
+
+        function verifyRegistry(testCase,model,expectedSystems,expectedIndices)
+            testCase.verifyEqual(numel(model.fluxedObservingSystems),numel(expectedSystems))
+            testCase.verifyEqual(numel(model.indicesForFluxedSystem),numel(expectedIndices))
+            expectedNFlux = 0;
+            for iSystem = 1:numel(expectedSystems)
+                testCase.verifyTrue(model.fluxedObservingSystems(iSystem) == expectedSystems(iSystem))
+                testCase.verifyEqual(double(model.indicesForFluxedSystem{iSystem}),expectedIndices{iSystem}(:))
+                expectedNFlux = expectedNFlux + double(expectedSystems(iSystem).nFluxComponents);
+            end
+            testCase.verifyEqual(double(model.nFluxComponents),expectedNFlux)
+        end
+
+        function [model,x0,y0,z0,phi0,U] = observerIntegrationModel()
+            model = TestObservingSystems.linearModel3D();
+            U = 0.1;
+            model.wvt.initWithInertialMotions(@(z)U*ones(size(z)),@(z)zeros(size(z)));
+            x0 = [500 1500];
+            y0 = [400 1200];
+            z0 = [-250 -750];
+            model.setFloatPositions(x0,y0,z0,'u',absToleranceXY=1e-8,absToleranceZ=1e-8);
+            phi0 = sin(2*pi*model.wvt.X/model.wvt.Lx);
+            model.addTracer(phi0,"dye");
+        end
+    end
+end

--- a/WVModelOutputGroup.m
+++ b/WVModelOutputGroup.m
@@ -114,21 +114,44 @@ classdef WVModelOutputGroup < handle & matlab.mixin.Heterogeneous & CAAnnotatedC
                 error('Storage already initialized! You cannot add a new observing system after the storage has been initialized.');
             end
 
+            registeredSystems = self.observingSystems;
+            fluxedSystems = WVObservingSystem.empty(1,0);
+            coefficientSystems = {};
+            coefficientTolerances = {};
             for iObs = 1:length(observingSystem)
-                anObservingSystem = observingSystem(iObs);
-                if anObservingSystem.wvt ~= self.model.wvt
-                    error('This observing system was not initialized with the same wvt that it is being added to!')
+                observer = observingSystem(iObs);
+                if observer.model ~= self.model
+                    error('The observing system %s was not initialized for this output group''s model.',observer.name);
                 end
-
-                if ~isempty(find(strcmp({self.observingSystems.name}, anObservingSystem.name), 1))
-                    error('An observing system named %s already exists.\n',anObservingSystem.name)
+                if isa(observer,'WVCoefficients')
+                    % Model construction creates the canonical coefficient observer
+                    % before persisted output groups are restored.
+                    canonicalCoefficients = self.model.wvCoefficientFluxedObservingSystem();
+                    if ~isempty(canonicalCoefficients) && canonicalCoefficients ~= observer
+                        coefficientSystems{end+1} = canonicalCoefficients;
+                        coefficientTolerances{end+1} = observer.absTolerance;
+                        observer = canonicalCoefficients;
+                    end
                 end
-
-                self.observingSystems(end+1) = anObservingSystem;
-                if anObservingSystem.nFluxComponents > 0
-                    self.model.addFluxedObservingSystem(anObservingSystem);
+                if any(strcmp(string({registeredSystems.name}),string(observer.name)))
+                    error('An observing system named %s already exists in this output group.',observer.name);
+                end
+                if isempty(registeredSystems)
+                    registeredSystems = observer;
+                else
+                    registeredSystems(end+1) = observer;
+                end
+                if observer.nFluxComponents > 0
+                    fluxedSystems(end+1) = observer;
                 end
             end
+            if ~isempty(fluxedSystems)
+                self.model.addFluxedObservingSystem(fluxedSystems);
+            end
+            for iCoefficient = 1:length(coefficientSystems)
+                coefficientSystems{iCoefficient}.absTolerance = coefficientTolerances{iCoefficient};
+            end
+            self.observingSystems = registeredSystems;
         end
 
         function removeObservingSystem(self, observingSystem)
@@ -140,40 +163,43 @@ classdef WVModelOutputGroup < handle & matlab.mixin.Heterogeneous & CAAnnotatedC
                 observingSystem WVObservingSystem
             end
 
+            registeredSystems = self.observingSystems;
+            removeMask = false(size(registeredSystems));
+            fluxedSystems = WVObservingSystem.empty(1,0);
             for iObs = 1:length(observingSystem)
-                anObservingSystem = observingSystem(iObs);
-
-                % Verify that the observing system belongs to the same wvt
-                if anObservingSystem.wvt ~= self
-                    error('This observing system does not belong to the same wvt!');
+                observer = observingSystem(iObs);
+                if observer.model ~= self.model
+                    error('The observing system %s was not initialized for this output group''s model.',observer.name);
                 end
-
-                % Find index of the observing system with the matching name
-                idx = find(strcmp({self.observingSystems.name}, anObservingSystem.name));
-                if isempty(idx)
-                    error('No observing system named %s exists to remove.', anObservingSystem.name);
+                sameHandle = cellfun(@(existing) existing == observer,num2cell(registeredSystems));
+                if ~any(sameHandle)
+                    error('The observing system %s is not registered with this output group.',observer.name);
                 end
-
-                % Remove the observing system from the collection
-                self.observingSystems(idx) = [];
-
-                % If the system includes flux components, remove it from the fluxed systems in the model
-                if anObservingSystem.nFluxComponents > 0
-                    self.model.removeFluxedObservingSystem(anObservingSystem);
+                removeMask = removeMask | sameHandle;
+                if observer.nFluxComponents > 0
+                    fluxedSystems(end+1) = observer;
                 end
             end
+            if ~isempty(fluxedSystems)
+                self.model.removeFluxedObservingSystem(fluxedSystems);
+            end
+            registeredSystems(removeMask) = [];
+            self.observingSystems = registeredSystems;
         end
 
         function observingSystem = observingSystemWithName(self,name)
             % retrieve an observing system by name
             %
             % - Topic: Observing systems
-            idx = find(strcmp({self.observingSystems.name}, name),1);
-            if isempty(idx)
-                error('No observing system named %s exists to remove.', anObservingSystem.name);
-            else
-                observingSystem = self.observingSystems(idx);
+            arguments
+                self WVModelOutputGroup {mustBeNonempty}
+                name {mustBeText}
             end
+            idx = find(strcmp(string({self.observingSystems.name}),string(name)),1);
+            if isempty(idx)
+                error('No observing system named %s is registered with this output group.',name);
+            end
+            observingSystem = self.observingSystems(idx);
         end
 
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Closes #40

Summary:
- make model and output-group observer registration identity-based and atomic
- preserve the canonical coefficient observer across composition and restart restoration
- correct linear-time observer flux evaluation, particle facade state, and periodic mooring indices
- add deterministic coverage for all stable observing systems and both stable integrators

Verification:
- focused observing-system tests: 10 passed
- smoke: 127 passed
- full: 528 passed, repeated twice
- exhaustive: 2440 passed
- MATLAB analysis, whitespace, scope, metadata, and artifact checks completed