### PR TITLE
Cover stable forcing lifecycle and persistence

### DIFF
--- a/@WVTransform/WVTransform.m
+++ b/@WVTransform/WVTransform.m
@@ -310,8 +310,8 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
                 self WVTransform {mustBeNonempty}
                 force WVForcing
             end
-            self.removeAllForcing();
-            self.addForcing(force);
+            [spatialForcing,spectralForcing,amplitudeForcing,nameMap] = self.stagedForcingRegistry(force);
+            self.commitForcingRegistry(spatialForcing,spectralForcing,amplitudeForcing,nameMap);
         end
 
         function addForcing(self,force)
@@ -320,48 +320,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
                 force WVForcing
             end
 
-            didAddForcing = false;
-            for iForce = 1:length(force)
-                aForce = force(iForce);
-                if aForce.wvt ~= self
-                    error('This force was not initialized with the same wvt that it is being added to!')
-                end
-                if isKey(self.forcingNameMap,aForce.name)
-                    otherForce = self.forcingNameMap{aForce.name};
-                    if ~aForce.isequal(otherForce)
-                        sprintf('A forcing named %s already exists. It will be removed and replaced.\n',aForce.name)
-                        self.removeForcing(otherForce);
-                    else
-                        warning("You have attempted to add the forcing named '%s', but this forcing is already added to the WVTransform. This will be ignored.",aForce.name);
-                        return
-                    end
-                end
-                if ismember(intersect(aForce.forcingType,self.forcingType),WVForcing.spatialFluxTypes())
-                    self.spatialFluxForcing(end+1) = aForce;
-                    [~, idx] = sort([self.spatialFluxForcing.priority]);
-                    self.spatialFluxForcing = self.spatialFluxForcing(idx);
-                    self.forcingNameMap{aForce.name} = aForce;
-                    didAddForcing = true;
-                end
-                if ismember(intersect(aForce.forcingType,self.forcingType),WVForcing.spectralFluxTypes)
-                    self.spectralFluxForcing(end+1) = aForce;
-                    [~, idx] = sort([self.spectralFluxForcing.priority]);
-                    self.spectralFluxForcing = self.spectralFluxForcing(idx);
-                    self.forcingNameMap{aForce.name} = aForce;
-                    didAddForcing = true;
-                end
-                if ismember(intersect(aForce.forcingType,self.forcingType),WVForcing.spectralAmplitudeTypes)
-                    self.spectralAmplitudeForcing(end+1) = aForce;
-                    [~, idx] = sort([self.spectralAmplitudeForcing.priority]);
-                    self.spectralAmplitudeForcing = self.spectralAmplitudeForcing(idx);
-                    self.forcingNameMap{aForce.name} = aForce;
-                    didAddForcing = true;
-                end
-            end
-            if didAddForcing == false
-                error("This WVTransform does not support this type of forcing!!!");
-            end
-            notify(self,'forcingDidChange');
+            requestedForcing = [self.forcing reshape(force,1,[])];
+            [spatialForcing,spectralForcing,amplitudeForcing,nameMap] = self.stagedForcingRegistry(requestedForcing);
+            self.commitForcingRegistry(spatialForcing,spectralForcing,amplitudeForcing,nameMap);
         end
 
         function removeForcing(self,force)
@@ -371,13 +332,17 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
             end
             for iForce = 1:length(force)
                 aForce = force(iForce);
-                self.spatialFluxForcing = setdiff(self.spatialFluxForcing,aForce,'stable');
-                self.spectralFluxForcing = setdiff(self.spectralFluxForcing,aForce,'stable');
-                self.spectralAmplitudeForcing = setdiff(self.spectralAmplitudeForcing,aForce,'stable');
-                self.forcingNameMap = self.forcingNameMap.remove(aForce.name);
-                aForce.didGetRemovedFromTransform(self);
+                if ~isKey(self.forcingNameMap,aForce.name) || self.forcingNameMap{aForce.name} ~= aForce
+                    error("The requested forcing is not registered with this transform.")
+                end
             end
-            notify(self,'forcingDidChange');
+
+            retainedForcing = self.forcing;
+            for iForce = 1:length(force)
+                retainedForcing(retainedForcing == force(iForce)) = [];
+            end
+            [spatialForcing,spectralForcing,amplitudeForcing,nameMap] = self.stagedForcingRegistry(retainedForcing);
+            self.commitForcingRegistry(spatialForcing,spectralForcing,amplitudeForcing,nameMap);
         end
 
         function forcing = get.forcing(self)
@@ -421,7 +386,14 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
             arguments (Output)
                 forcing WVForcing
             end
-            forcing = [self.forcingNameMap{name}];
+            forcing = WVForcing.empty(1,0);
+            for iName = 1:length(name)
+                requestedName = name{iName};
+                if ~isKey(self.forcingNameMap,requestedName)
+                    error("No forcing named '%s' is registered with this transform.",requestedName)
+                end
+                forcing(end+1) = self.forcingNameMap{requestedName};
+            end
         end
 
         function restoreForcingAmplitudes(self)
@@ -810,6 +782,73 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         [varargout] = spectralVariableWithResolution(self,wvtX2,varargin)
     end
 
+    methods (Access=private)
+        function [spatialForcing,spectralForcing,amplitudeForcing,nameMap] = stagedForcingRegistry(self,forcing)
+            spatialForcing = WVForcing.empty(1,0);
+            spectralForcing = WVForcing.empty(1,0);
+            amplitudeForcing = WVForcing.empty(1,0);
+            nameMap = configureDictionary("string","cell");
+
+            for iForce = 1:length(forcing)
+                aForce = forcing(iForce);
+                if aForce.wvt ~= self
+                    error("Every forcing must be initialized with the transform receiving it.")
+                end
+
+                compatibleTypes = intersect(aForce.forcingType,self.forcingType);
+                isSpatial = any(ismember(compatibleTypes,WVForcing.spatialFluxTypes()));
+                isSpectral = any(ismember(compatibleTypes,WVForcing.spectralFluxTypes()));
+                isAmplitude = any(ismember(compatibleTypes,WVForcing.spectralAmplitudeTypes()));
+                if sum([isSpatial isSpectral isAmplitude]) ~= 1
+                    error("The transform does not support exactly one forcing category for '%s'.",aForce.name)
+                end
+
+                if isKey(nameMap,aForce.name)
+                    existingForce = nameMap{aForce.name};
+                    if existingForce == aForce
+                        continue
+                    end
+                    spatialForcing(spatialForcing == existingForce) = [];
+                    spectralForcing(spectralForcing == existingForce) = [];
+                    amplitudeForcing(amplitudeForcing == existingForce) = [];
+                end
+
+                if isSpatial
+                    spatialForcing(end+1) = aForce;
+                elseif isSpectral
+                    spectralForcing(end+1) = aForce;
+                else
+                    amplitudeForcing(end+1) = aForce;
+                end
+                nameMap{aForce.name} = aForce;
+            end
+
+            spatialForcing = WVTransform.sortForcingByPriority(spatialForcing);
+            spectralForcing = WVTransform.sortForcingByPriority(spectralForcing);
+            amplitudeForcing = WVTransform.sortForcingByPriority(amplitudeForcing);
+        end
+
+        function commitForcingRegistry(self,spatialForcing,spectralForcing,amplitudeForcing,nameMap)
+            oldForcing = self.forcing;
+            newForcing = [spatialForcing spectralForcing amplitudeForcing];
+            if WVTransform.areIdenticalForcingArrays(oldForcing,newForcing)
+                return
+            end
+
+            self.spatialFluxForcing = spatialForcing;
+            self.spectralFluxForcing = spectralForcing;
+            self.spectralAmplitudeForcing = amplitudeForcing;
+            self.forcingNameMap = nameMap;
+
+            for iForce = 1:length(oldForcing)
+                if isempty(newForcing) || ~any(newForcing == oldForcing(iForce))
+                    oldForcing(iForce).didGetRemovedFromTransform(self);
+                end
+            end
+            notify(self,'forcingDidChange');
+        end
+    end
+
     methods (Access=protected)
         % protected — Access from methods in class or subclasses
         varargout = interpolatedFieldAtPosition(self,x,y,z,method,varargin);
@@ -908,6 +947,20 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
     end
 
     methods (Static, Access=private)
+        function forcing = sortForcingByPriority(forcing)
+            if length(forcing) > 1
+                [~,indices] = sort([forcing.priority],"ascend");
+                forcing = forcing(indices);
+            end
+        end
+
+        function tf = areIdenticalForcingArrays(first,second)
+            tf = length(first) == length(second);
+            if tf && ~isempty(first)
+                tf = all(first == second);
+            end
+        end
+
         function version = cachedPackageVersion()
             persistent cachedVersion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Made forcing registration identity-based, deterministic, and atomic; preserved vertical-diffusivity, fixed-amplitude, and explicit-antialias configurations through resolution changes and NetCDF restoration; and rejected vertical diffusivity on barotropic transforms.
 - Corrected observing-system ownership and composition, linear-time flux evaluation, particle tolerance and tracked-field propagation, and periodic one-based mooring indexing.
 - Added compact invariant coverage across every stable transform on even and odd grids; corrected parity-aware Nyquist and Hermitian bookkeeping, vector mode/index mappings, coefficient-preserving resolution conversion, and barotropic spatial energy and enstrophy diagnostics.
 - Generalized `summarizeDegreesOfFreedom` across every stable transform with deterministic grid metadata and primary-component mask counts.

--- a/Forcing/WVAntialiasing.m
+++ b/Forcing/WVAntialiasing.m
@@ -31,7 +31,15 @@ classdef WVAntialiasing < WVForcing
     %
     % - Topic: Initializing
     % - Declaration: WVAntialiasing < [WVForcing](/classes/forcing/wvforcing/)
-    properties
+    properties (GetAccess=public, SetAccess=protected)
+        % number of retained vertical modes used to construct the filter
+        %
+        % This value is preserved when the forcing is converted to another
+        % resolution or restored from an annotated NetCDF file.
+        %
+        % - Topic: Properties
+        Nj
+
         % spectral matrix that multiplies Ap,Am,A0 to zero out the aliased modes
         %
         % - Topic: Properties
@@ -44,7 +52,7 @@ classdef WVAntialiasing < WVForcing
             %
             % - Declaration: nlFlux = WVNonlinearFlux(wvt,options)
             % - Parameter wvt: a WVTransform instance
-            % - Parameter Nj: (optional) vertical mode above which energy will be set to zero.
+            % - Parameter Nj: (optional) number of retained vertical modes. Modes with `j >= Nj` are set to zero. Defaults to `floor(2*wvt.Nj/3)`.
             % - Returns self: a WVAntialiasing instance
             arguments
                 wvt WVTransform {mustBeNonempty}
@@ -62,6 +70,7 @@ classdef WVAntialiasing < WVForcing
             if ~isfield(options,"Nj")
                 options.Nj = floor(2*wvt.Nj/3);
             end
+            self.Nj = options.Nj;
             self.M(wvt.J > (options.Nj-1)) = 1;
         end
 
@@ -136,7 +145,7 @@ classdef WVAntialiasing < WVForcing
         end
 
         function force = forcingWithResolutionOfTransform(self,wvtX2)
-            force = WVAntialiasing(wvtX2);
+            force = WVAntialiasing(wvtX2,Nj=self.Nj);
         end
     end
     methods (Static)
@@ -146,7 +155,7 @@ classdef WVAntialiasing < WVForcing
             % - Topic: CAAnnotatedClass requirement
             % - Declaration: classRequiredPropertyNames()
             % - Returns: vars
-            vars = {};
+            vars = {"Nj"};
         end
 
         function propertyAnnotations = classDefinedPropertyAnnotations()
@@ -159,6 +168,7 @@ classdef WVAntialiasing < WVForcing
                 propertyAnnotations CAPropertyAnnotation
             end
             propertyAnnotations = CAPropertyAnnotation.empty(0,0);
+            propertyAnnotations(end+1) = CANumericProperty('Nj', {}, '1','number of retained vertical modes used to construct the filter');
         end
     end
 end

--- a/Forcing/WVFixedAmplitudeForcing.m
+++ b/Forcing/WVFixedAmplitudeForcing.m
@@ -326,23 +326,9 @@ classdef WVFixedAmplitudeForcing < WVForcing
 
         function force = forcingWithResolutionOfTransform(self,wvtX2)
             options.name = self.name;
-            Abar = zeros(self.wvt.spectralMatrixSize);
-            Abar(self.Ap_indices) = self.Apbar;
-            [AbarX2] = self.wvt.spectralVariableWithResolution(wvtX2,Abar);
-            options.Apbar = self.Apbar;
-            options.Ap_indices = find(AbarX2);
-
-            Abar = zeros(self.wvt.spectralMatrixSize);
-            Abar(self.Am_indices) = self.Ambar;
-            [AbarX2] = self.wvt.spectralVariableWithResolution(wvtX2,Abar);
-            options.Ambar = self.Ambar;
-            options.Am_indices = find(AbarX2);
-
-            Abar = zeros(self.wvt.spectralMatrixSize);
-            Abar(self.A0_indices) = self.A0bar;
-            [AbarX2] = self.wvt.spectralVariableWithResolution(wvtX2,Abar);
-            options.A0bar = self.A0bar;
-            options.A0_indices = find(AbarX2);
+            [options.Ap_indices,options.Apbar] = self.convertSelectedCoefficients(wvtX2,self.Ap_indices,self.Apbar);
+            [options.Am_indices,options.Ambar] = self.convertSelectedCoefficients(wvtX2,self.Am_indices,self.Ambar);
+            [options.A0_indices,options.A0bar] = self.convertSelectedCoefficients(wvtX2,self.A0_indices,self.A0bar);
 
             optionArgs = namedargs2cell(options);
             force = WVFixedAmplitudeForcing(wvtX2,optionArgs{:});
@@ -375,6 +361,20 @@ classdef WVFixedAmplitudeForcing < WVForcing
             end
             propertyAnnotations = self.propertyAnnotationWithName(properties);      
             writeToGroup@CAAnnotatedClass(self,group,propertyAnnotations,attributes);
+        end
+    end
+
+    methods (Access=private)
+        function [targetIndices,targetValues] = convertSelectedCoefficients(self,wvtX2,sourceIndices,sourceValues)
+            selection = zeros(self.wvt.spectralMatrixSize);
+            selection(sourceIndices) = 1;
+            targetSelection = self.wvt.spectralVariableWithResolution(wvtX2,selection);
+            targetIndices = find(targetSelection);
+
+            coefficientValues = complex(zeros(self.wvt.spectralMatrixSize));
+            coefficientValues(sourceIndices) = sourceValues;
+            targetCoefficientValues = self.wvt.spectralVariableWithResolution(wvtX2,coefficientValues);
+            targetValues = targetCoefficientValues(targetIndices);
         end
     end
 

--- a/Forcing/WVVerticalDiffusivity.m
+++ b/Forcing/WVVerticalDiffusivity.m
@@ -29,7 +29,9 @@ classdef WVVerticalDiffusivity < WVForcing
     %
     % ### Notes
     %
-    % This is currently implemented in the spatial domain.
+    % This is currently implemented in the spatial domain. It applies to
+    % three-dimensional wave and stratified-QG transforms, but not to a
+    % barotropic transform because that geometry has no vertical structure.
     %
     % - Topic: Initialization
     % - Topic: Properties
@@ -68,7 +70,11 @@ classdef WVVerticalDiffusivity < WVForcing
                 options.kappa_z double = 1e-5
                 options.shouldForceMeanDensityAnomaly = true;
             end
-            self@WVForcing(wvt,"vertical diffusivity",WVForcingType(["HydrostaticSpatial","NonhydrostaticSpatial","PVSpatial"]));
+            supportedTypes = ["HydrostaticSpatial","NonhydrostaticSpatial","PVSpatial"];
+            if isa(wvt,"WVGeometryDoublyPeriodicBarotropic")
+                supportedTypes = ["HydrostaticSpatial","NonhydrostaticSpatial"];
+            end
+            self@WVForcing(wvt,"vertical diffusivity",WVForcingType(supportedTypes));
             self.wvt = wvt;
             self.kappa_z = options.kappa_z;
             self.shouldForceMeanDensityAnomaly = options.shouldForceMeanDensityAnomaly;
@@ -103,7 +109,7 @@ classdef WVVerticalDiffusivity < WVForcing
                 self WVVerticalDiffusivity {mustBeNonempty}
                 wvtX2 WVTransform {mustBeNonempty}
             end
-            force = WVVerticalDiffusivity(wvtX2);
+            force = WVVerticalDiffusivity(wvtX2,kappa_z=self.kappa_z,shouldForceMeanDensityAnomaly=self.shouldForceMeanDensityAnomaly);
         end
     end
     methods (Static)

--- a/UnitTests/TestForcingLifecycle.m
+++ b/UnitTests/TestForcingLifecycle.m
@@ -1,0 +1,363 @@
+classdef TestForcingLifecycle < matlab.unittest.TestCase
+    properties
+        tempFolder
+    end
+
+    methods (TestMethodSetup)
+        function createTemporaryFolder(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            testCase.tempFolder = string(fixture.Folder);
+        end
+    end
+
+    methods (Test, TestTags="full")
+        function registryMutationsAreIdentityBasedAndAtomic(testCase)
+            wvt = TestForcingLifecycle.constantTransform([8 6 5]);
+            wvt.removeAllForcing();
+            spatialLate = WVTestForcing(wvt,"spatial late",WVForcingType("HydrostaticSpatial"),uint8(200),1);
+            spatialFirst = WVTestForcing(wvt,"spatial first",WVForcingType("HydrostaticSpatial"),uint8(10),2);
+            spatialTie = WVTestForcing(wvt,"spatial tie",WVForcingType("HydrostaticSpatial"),uint8(200),3);
+            spectral = WVTestForcing(wvt,"spectral",WVForcingType("Spectral"),uint8(1),4);
+            amplitude = WVTestForcing(wvt,"amplitude",WVForcingType("SpectralAmplitude"),uint8(1),5);
+
+            wvt.addForcing([spatialLate spatialFirst spatialTie spectral amplitude]);
+            testCase.verifyEqual(wvt.forcingNames,["spatial first"; "spatial late"; "spatial tie"; "spectral"; "amplitude"])
+            expected = wvt.forcing;
+
+            wvt.addForcing(spatialLate);
+            TestForcingLifecycle.verifyIdentity(testCase,wvt.forcing,expected)
+
+            replacement = WVTestForcing(wvt,"spatial late",WVForcingType("HydrostaticSpatial"),uint8(200),6);
+            wvt.addForcing(replacement);
+            testCase.verifyTrue(wvt.forcingWithName("spatial late") == replacement)
+            testCase.verifyEqual(wvt.forcingNames,["spatial first"; "spatial tie"; "spatial late"; "spectral"; "amplitude"])
+
+            firstDuplicate = WVTestForcing(wvt,"batch duplicate",WVForcingType("HydrostaticSpatial"),uint8(200),7);
+            lastDuplicate = WVTestForcing(wvt,"batch duplicate",WVForcingType("HydrostaticSpatial"),uint8(200),8);
+            wvt.addForcing([firstDuplicate lastDuplicate]);
+            testCase.verifyTrue(wvt.forcingWithName("batch duplicate") == lastDuplicate)
+
+            beforeFailure = wvt.forcing;
+            valid = WVTestForcing(wvt,"would be valid",WVForcingType("Spectral"),uint8(20),9);
+            unsupported = WVTestForcing(wvt,"unsupported",WVForcingType("PVSpectral"),uint8(20),10);
+            testCase.verifyError(@()wvt.addForcing([valid unsupported]),'')
+            TestForcingLifecycle.verifyIdentity(testCase,wvt.forcing,beforeFailure)
+            testCase.verifyFalse(wvt.hasForcingWithName("would be valid"))
+
+            otherTransform = TestForcingLifecycle.constantTransform([8 6 5]);
+            foreign = WVTestForcing(otherTransform,"spatial first",WVForcingType("HydrostaticSpatial"),uint8(10),11);
+            testCase.verifyError(@()wvt.addForcing(foreign),'')
+            testCase.verifyError(@()wvt.removeForcing(foreign),'')
+            testCase.verifyError(@()wvt.forcingWithName("missing"),'')
+            TestForcingLifecycle.verifyIdentity(testCase,wvt.forcing,beforeFailure)
+
+            testCase.verifyError(@()wvt.setForcing([valid unsupported]),'')
+            TestForcingLifecycle.verifyIdentity(testCase,wvt.forcing,beforeFailure)
+
+            wvt.removeForcing([replacement replacement]);
+            testCase.verifyFalse(wvt.hasForcingWithName("spatial late"))
+            testCase.verifyError(@()wvt.removeForcing(replacement),'')
+
+            columnForcing = reshape([WVTestForcing(wvt,"column one",WVForcingType("Spectral"),uint8(30),1) ...
+                WVTestForcing(wvt,"column two",WVForcingType("Spectral"),uint8(40),2)],[],1);
+            wvt.addForcing(columnForcing);
+            testCase.verifyTrue(all(wvt.hasForcingWithName("column one","column two")))
+        end
+
+        function suppliedForcingCoversCompatibleLifecycleAndFluxes(testCase)
+            seedRandomNumberGenerator(testCase,3811);
+            wvt = TestForcingLifecycle.boussinesqTransform([8 6 5]);
+            wvt.removeAllForcing();
+            forces = TestForcingLifecycle.waveForcingInventory(wvt);
+            wvt.addForcing(forces);
+
+            expectedClasses = ["WVNonlinearAdvection" "WVAdaptiveDamping" "WVAntialiasing" ...
+                "WVHorizontalDamping" "WVVerticalDamping" "WVVerticalDiffusivity" ...
+                "WVFixedAmplitudeForcing" "WVBottomFrictionLinear" ...
+                "WVBottomFrictionQuadratic" "WVBetaPlanePVAdvection" ...
+                "WVPseudoTopographicWaveGeneration"];
+            testCase.verifyEqual(sort(string(arrayfun(@class,wvt.forcing,UniformOutput=false))),sort(expectedClasses))
+            for iForce = 1:length(forces)
+                testCase.verifyTrue(wvt.forcingWithName(forces(iForce).name) == forces(iForce))
+            end
+
+            wvt.initWithRandomFlow(uvMax=0.01);
+            [Fp,Fm,F0] = wvt.nonlinearFlux;
+            TestForcingLifecycle.verifyFinite(testCase,Fp,Fm,F0)
+
+            adaptive = wvt.forcingWithName("adaptive damping");
+            [adaptiveFp,adaptiveFm,adaptiveF0] = adaptive.addSpectralForcing(wvt,zeros(size(wvt.Ap)),zeros(size(wvt.Am)),zeros(size(wvt.A0)));
+            testCase.verifyEqual(adaptiveFp,wvt.uvMax*adaptive.damp.*wvt.Ap)
+            testCase.verifyEqual(adaptiveFm,wvt.uvMax*adaptive.damp.*wvt.Am)
+            testCase.verifyEqual(adaptiveF0,wvt.uvMax*adaptive.damp.*wvt.A0)
+
+            antialias = wvt.forcingWithName("antialias filter");
+            onesAp = ones(size(wvt.Ap));
+            [filteredAp,filteredAm,filteredA0] = antialias.addSpectralForcing(wvt,onesAp,onesAp,onesAp);
+            testCase.verifyEqual(filteredAp,double(~antialias.M))
+            testCase.verifyEqual(filteredAm,double(~antialias.M))
+            testCase.verifyEqual(filteredA0,double(~antialias.M))
+
+            fixed = wvt.forcingWithName("fixed modes");
+            [fixedAp,fixedAm,fixedA0] = fixed.setSpectralAmplitude(wvt,zeros(size(wvt.Ap)),zeros(size(wvt.Am)),zeros(size(wvt.A0)));
+            testCase.verifyEqual(fixedAp(fixed.Ap_indices),fixed.Apbar)
+            testCase.verifyEqual(fixedAm(fixed.Am_indices),fixed.Ambar)
+            testCase.verifyEqual(fixedA0(fixed.A0_indices),fixed.A0bar)
+
+            vertical = wvt.forcingWithName("vertical diffusivity");
+            [~,~,~,Feta] = vertical.addNonhydrostaticSpatialForcing(wvt,zeros(wvt.spatialMatrixSize),zeros(wvt.spatialMatrixSize),zeros(wvt.spatialMatrixSize),zeros(wvt.spatialMatrixSize));
+            testCase.verifyEqual(Feta,vertical.kappa_z*wvt.diffZG(wvt.eta,n=2),AbsTol=1e-12)
+
+            TestForcingLifecycle.verifyBottomFriction(testCase,wvt)
+            TestForcingLifecycle.verifyNonlinearAdvection(testCase,wvt)
+
+            qg = TestForcingLifecycle.barotropicTransform([8 6]);
+            qg.removeAllForcing();
+            qgForces = [WVNonlinearAdvection(qg) WVBottomFrictionLinear(qg,r=2e-7) WVBottomFrictionQuadratic(qg,Cd=1.5e-3) ...
+                WVBetaPlanePVAdvection(qg) WVAdaptiveDamping(qg) WVAntialiasing(qg,Nj=1) ...
+                WVFixedAmplitudeForcing(qg,name="fixed qg",A0_indices=uint64(2),A0bar=3e-3)];
+            qg.addForcing(qgForces);
+            barotropicDiffusivity = WVVerticalDiffusivity(qg,kappa_z=7e-6);
+            testCase.verifyError(@()qg.addForcing(barotropicDiffusivity),'')
+            qg.A0 = complex(randn(size(qg.A0)),randn(size(qg.A0))).*qg.geostrophicComponent.maskA0;
+            F0qg = qg.nonlinearFlux;
+            TestForcingLifecycle.verifyFinite(testCase,F0qg)
+            beta = qg.forcingWithName("beta-plane advection of qgpv");
+            testCase.verifyEqual(beta.addPotentialVorticitySpatialForcing(qg,zeros(qg.spatialMatrixSize)),-qg.beta*qg.v)
+
+            stratifiedQG = WVTransformStratifiedQG([40e3 30e3 2e3],[8 6 5],N2=@(z) 2e-5*exp(z/4000),latitude=45,shouldAntialias=false);
+            stratifiedQG.removeAllForcing();
+            qgDiffusivity = WVVerticalDiffusivity(stratifiedQG,kappa_z=7e-6,shouldForceMeanDensityAnomaly=false);
+            stratifiedQG.addForcing(qgDiffusivity);
+            stratifiedQG.A0 = complex(randn(size(stratifiedQG.A0)),randn(size(stratifiedQG.A0))).*stratifiedQG.geostrophicComponent.maskA0;
+            TestForcingLifecycle.verifyFinite(testCase,stratifiedQG.nonlinearFlux)
+        end
+
+        function resolutionConversionPreservesConfigurationAndSelections(testCase)
+            source = TestForcingLifecycle.boussinesqTransform([8 6 5]);
+            source.removeAllForcing();
+            vertical = WVVerticalDiffusivity(source,kappa_z=7.25e-6,shouldForceMeanDensityAnomaly=false);
+            antialias = WVAntialiasing(source,Nj=3);
+            indices = uint64([2; 4; 6]);
+            fixed = WVFixedAmplitudeForcing(source,name="selected modes",Ap_indices=indices,Apbar=[0; 2+3i; -4i],Am_indices=indices,Ambar=[1-2i; 0; 5],A0_indices=indices,A0bar=[0; -3; 2i]);
+            source.setForcing([vertical antialias fixed]);
+
+            target = source.waveVortexTransformWithResolution([12 10 7]);
+            convertedVertical = target.forcingWithName("vertical diffusivity");
+            testCase.verifyEqual(convertedVertical.kappa_z,vertical.kappa_z)
+            testCase.verifyEqual(convertedVertical.shouldForceMeanDensityAnomaly,vertical.shouldForceMeanDensityAnomaly)
+            testCase.verifyEqual(target.forcingWithName("antialias filter").Nj,3)
+            TestForcingLifecycle.verifyConvertedFixedAmplitude(testCase,source,target,fixed)
+
+            downsampled = target.waveVortexTransformWithResolution([6 4 3]);
+            testCase.verifyEqual(downsampled.forcingWithName("vertical diffusivity").kappa_z,vertical.kappa_z)
+            testCase.verifyEqual(downsampled.forcingWithName("antialias filter").Nj,3)
+            TestForcingLifecycle.verifyConvertedFixedAmplitude(testCase,target,downsampled,target.forcingWithName("selected modes"))
+
+            inventorySource = TestForcingLifecycle.boussinesqTransform([8 6 5]);
+            inventorySource.removeAllForcing();
+            inventorySource.addForcing(TestForcingLifecycle.waveForcingInventory(inventorySource));
+            convertedInventory = inventorySource.waveVortexTransformWithResolution([12 10 7]);
+            testCase.verifyEqual(convertedInventory.forcingNames,inventorySource.forcingNames)
+            testCase.verifyEqual(string(arrayfun(@class,convertedInventory.forcing,UniformOutput=false)),string(arrayfun(@class,inventorySource.forcing,UniformOutput=false)))
+            testCase.verifyEqual(convertedInventory.forcingWithName("horizontal scalar diffusivity").nu,0.125)
+            testCase.verifyEqual(convertedInventory.forcingWithName("vertical scalar diffusivity").kappa,7.5e-5)
+            testCase.verifyEqual(convertedInventory.forcingWithName("linear bottom friction").r,2e-7)
+            testCase.verifyEqual(convertedInventory.forcingWithName("quadratic bottom friction").Cd,1.5e-3)
+            testCase.verifyEqual(convertedInventory.forcingWithName("antialias filter").Nj,3)
+            convertedInventory.initWithRandomFlow(uvMax=0.01);
+            [convertedFp,convertedFm,convertedF0] = convertedInventory.nonlinearFlux;
+            TestForcingLifecycle.verifyFinite(testCase,convertedFp,convertedFm,convertedF0)
+        end
+
+        function composedForcingMatchesIndependentContributions(testCase)
+            seedRandomNumberGenerator(testCase,3812);
+            wvt = TestForcingLifecycle.constantTransform([8 6 5]);
+            wvt.removeAllForcing();
+            horizontal = WVHorizontalDamping(wvt,nu=0.125,kappa=2.5e-5);
+            vertical = WVVerticalDamping(wvt,nu=0.375,kappa=7.5e-5);
+            adaptive = WVAdaptiveDamping(wvt);
+            [x,y] = ndgrid(wvt.x,wvt.y);
+            generation = WVPseudoTopographicWaveGeneration(wvt,topographicHeight=20*cos(2*pi*x/wvt.Lx)+10*sin(2*pi*y/wvt.Ly),barotropicVelocityAmplitude=[0.04;-0.02],frequency=1.31e-4);
+            wvt.addForcing([horizontal vertical adaptive generation]);
+            wvt.initWithRandomFlow(uvMax=0.01);
+            wvt.t = 217;
+
+            zeroField = zeros(wvt.spatialMatrixSize);
+            [horizontalFu,horizontalFv,horizontalFw,horizontalFeta] = horizontal.addNonhydrostaticSpatialForcing(wvt,zeroField,zeroField,zeroField,zeroField);
+            [verticalFu,verticalFv,verticalFw,verticalFeta] = vertical.addNonhydrostaticSpatialForcing(wvt,zeroField,zeroField,zeroField,zeroField);
+            [expectedFp,expectedFm,expectedF0] = wvt.transformUVWEtaToWaveVortex(horizontalFu+verticalFu,horizontalFv+verticalFv,horizontalFw+verticalFw,horizontalFeta+verticalFeta);
+            [expectedFp,expectedFm,expectedF0] = adaptive.addSpectralForcing(wvt,expectedFp,expectedFm,expectedF0);
+            [expectedFp,expectedFm,expectedF0] = generation.addSpectralForcing(wvt,expectedFp,expectedFm,expectedF0);
+            [actualFp,actualFm,actualF0] = wvt.nonlinearFlux;
+            testCase.verifyEqual(actualFp,expectedFp,AbsTol=1e-12)
+            testCase.verifyEqual(actualFm,expectedFm,AbsTol=1e-12)
+            testCase.verifyEqual(actualF0,expectedF0,AbsTol=1e-12)
+
+            firstFixed = WVFixedAmplitudeForcing(wvt,name="first fixed",Ap_indices=uint64(2),Apbar=1+2i);
+            secondFixed = WVFixedAmplitudeForcing(wvt,name="second fixed",Am_indices=uint64(4),Ambar=-3i,A0_indices=uint64(6),A0bar=2);
+            wvt.addForcing([firstFixed secondFixed]);
+            wvt.restoreForcingAmplitudes();
+            testCase.verifyEqual(wvt.Ap(2),1+2i)
+            testCase.verifyEqual(wvt.Am(4),-3i)
+            testCase.verifyEqual(wvt.A0(6),2)
+
+            qg = TestForcingLifecycle.barotropicTransform([8 6]);
+            qg.removeAllForcing();
+            nonlinear = WVNonlinearAdvection(qg);
+            linearBottom = WVBottomFrictionLinear(qg,r=2e-7);
+            beta = WVBetaPlanePVAdvection(qg);
+            qg.addForcing([nonlinear linearBottom beta]);
+            qg.A0 = complex(randn(size(qg.A0)),randn(size(qg.A0))).*qg.geostrophicComponent.maskA0;
+            zeroPV = zeros(qg.spatialMatrixSize);
+            independentPV = nonlinear.addPotentialVorticitySpatialForcing(qg,zeroPV) ...
+                +linearBottom.addPotentialVorticitySpatialForcing(qg,zeroPV) ...
+                +beta.addPotentialVorticitySpatialForcing(qg,zeroPV);
+            testCase.verifyEqual(qg.nonlinearFlux,qg.transformQGPVToWaveVortex(independentPV),AbsTol=1e-12)
+        end
+
+        function netCDFRoundTripPreservesForcingRegistryAndBehavior(testCase)
+            wvt = TestForcingLifecycle.boussinesqTransform([8 6 5]);
+            wvt.removeAllForcing();
+            wvt.addForcing(TestForcingLifecycle.waveForcingInventory(wvt));
+            wvt.initWithRandomFlow(uvMax=0.01);
+            wvt.t = 317;
+            [Fp,Fm,F0] = wvt.nonlinearFlux;
+            expectedNames = wvt.forcingNames;
+
+            path = fullfile(testCase.tempFolder,"stable-forcing-round-trip.nc");
+            ncfile = wvt.writeToFile(path,shouldOverwriteExisting=true);
+            cleanup = onCleanup(@()TestForcingLifecycle.closeIfOpen(ncfile));
+            ncfile.close();
+            clear cleanup
+
+            [restored,restoredFile] = WVTransform.waveVortexTransformFromFile(path);
+            restoredCleanup = onCleanup(@()TestForcingLifecycle.closeIfOpen(restoredFile));
+            testCase.verifyEqual(restored.forcingNames,expectedNames)
+            testCase.verifyEqual(restored.forcingWithName("antialias filter").Nj,3)
+            testCase.verifyEqual(restored.forcingWithName("vertical diffusivity").kappa_z,7e-6)
+            testCase.verifyFalse(restored.forcingWithName("vertical diffusivity").shouldForceMeanDensityAnomaly)
+            restored.t = wvt.t;
+            [restoredFp,restoredFm,restoredF0] = restored.nonlinearFlux;
+            testCase.verifyEqual(restoredFp,Fp,AbsTol=1e-12)
+            testCase.verifyEqual(restoredFm,Fm,AbsTol=1e-12)
+            testCase.verifyEqual(restoredF0,F0,AbsTol=1e-12)
+            restoredFile.close();
+            clear restoredCleanup
+
+            reopened = NetCDFFile(path,shouldReadOnly=true);
+            reopened.close();
+
+            qg = TestForcingLifecycle.barotropicTransform([8 6]);
+            qg.removeAllForcing();
+            qg.addForcing([WVNonlinearAdvection(qg) WVBottomFrictionLinear(qg,r=2e-7) ...
+                WVBottomFrictionQuadratic(qg,Cd=1.5e-3) WVBetaPlanePVAdvection(qg) ...
+                WVAdaptiveDamping(qg) WVAntialiasing(qg,Nj=1) ...
+                WVFixedAmplitudeForcing(qg,name="fixed qg",A0_indices=uint64(2),A0bar=3e-3)]);
+            qg.A0 = complex(reshape(1:numel(qg.A0),size(qg.A0)),reshape(numel(qg.A0):-1:1,size(qg.A0))).*qg.geostrophicComponent.maskA0;
+            expectedQGFlux = qg.nonlinearFlux;
+            qgPath = fullfile(testCase.tempFolder,"qg-forcing-round-trip.nc");
+            qgFile = qg.writeToFile(qgPath,shouldOverwriteExisting=true);
+            qgCleanup = onCleanup(@()TestForcingLifecycle.closeIfOpen(qgFile));
+            qgFile.close();
+            clear qgCleanup
+            [restoredQG,restoredQGFile] = WVTransform.waveVortexTransformFromFile(qgPath);
+            restoredQGCleanup = onCleanup(@()TestForcingLifecycle.closeIfOpen(restoredQGFile));
+            testCase.verifyEqual(restoredQG.forcingNames,qg.forcingNames)
+            testCase.verifyEqual(restoredQG.forcingWithName("antialias filter").Nj,1)
+            testCase.verifyEqual(restoredQG.forcingWithName("linear bottom friction").r,2e-7)
+            testCase.verifyEqual(restoredQG.forcingWithName("quadratic bottom friction").Cd,1.5e-3)
+            testCase.verifyEqual(restoredQG.nonlinearFlux,expectedQGFlux,AbsTol=1e-12)
+            restoredQGFile.close();
+            clear restoredQGCleanup
+        end
+    end
+
+    methods (Static, Access=private)
+        function wvt = constantTransform(resolution)
+            wvt = WVTransformConstantStratification([40e3 30e3 2e3],resolution,N0=5.2e-3,latitude=45,isHydrostatic=false,shouldAntialias=false);
+        end
+
+        function wvt = boussinesqTransform(resolution)
+            wvt = WVTransformBoussinesq([40e3 30e3 2e3],resolution,N2=@(z) 2e-5*exp(z/4000),latitude=45,shouldAntialias=false);
+        end
+
+        function wvt = barotropicTransform(resolution)
+            wvt = WVTransformBarotropicQG([40e3 30e3],resolution,latitude=45,shouldAntialias=false);
+        end
+
+        function forcing = waveForcingInventory(wvt)
+            [x,y] = ndgrid(wvt.x,wvt.y);
+            topography = 20*cos(2*pi*x/wvt.Lx)+10*sin(2*pi*y/wvt.Ly);
+            forcing = [WVNonlinearAdvection(wvt) WVAdaptiveDamping(wvt) WVAntialiasing(wvt,Nj=3) ...
+                WVHorizontalDamping(wvt,nu=0.125,kappa=2.5e-5) WVVerticalDamping(wvt,nu=0.375,kappa=7.5e-5) ...
+                WVVerticalDiffusivity(wvt,kappa_z=7e-6,shouldForceMeanDensityAnomaly=false) ...
+                WVFixedAmplitudeForcing(wvt,name="fixed modes",Ap_indices=uint64([2;4]),Apbar=[0;2+3i],Am_indices=uint64([2;4]),Ambar=[1-2i;0],A0_indices=uint64([2;4]),A0bar=[0;-3]) ...
+                WVBottomFrictionLinear(wvt,r=2e-7) WVBottomFrictionQuadratic(wvt,Cd=1.5e-3) ...
+                WVBetaPlanePVAdvection(wvt) WVPseudoTopographicWaveGeneration(wvt,topographicHeight=topography,barotropicVelocityAmplitude=[0.04;-0.02],frequency=1.31e-4,name="terrain generation")];
+        end
+
+        function verifyBottomFriction(testCase,wvt)
+            linear = wvt.forcingWithName("linear bottom friction");
+            quadratic = wvt.forcingWithName("quadratic bottom friction");
+            zerosField = zeros(wvt.spatialMatrixSize);
+            [linearFu,linearFv] = linear.addNonhydrostaticSpatialForcing(wvt,zerosField,zerosField,zerosField,zerosField);
+            testCase.verifyEqual(linearFu(:,:,1),-linear.r_scaled*wvt.u(:,:,1),AbsTol=1e-24)
+            testCase.verifyEqual(linearFv(:,:,1),-linear.r_scaled*wvt.v(:,:,1),AbsTol=1e-24)
+            testCase.verifyEqual(linearFu(:,:,2:end),zeros(size(linearFu(:,:,2:end))))
+            [quadraticFu,quadraticFv] = quadratic.addNonhydrostaticSpatialForcing(wvt,zerosField,zerosField,zerosField,zerosField);
+            speed = hypot(wvt.u(:,:,1),wvt.v(:,:,1));
+            testCase.verifyEqual(quadraticFu(:,:,1),-quadratic.cd*wvt.u(:,:,1).*speed,AbsTol=1e-24)
+            testCase.verifyEqual(quadraticFv(:,:,1),-quadratic.cd*wvt.v(:,:,1).*speed,AbsTol=1e-24)
+        end
+
+        function verifyNonlinearAdvection(testCase,wvt)
+            nonlinear = wvt.forcingWithName("nonlinear advection");
+            zerosField = zeros(wvt.spatialMatrixSize);
+            [Fu,Fv,Fw,Feta] = nonlinear.addNonhydrostaticSpatialForcing(wvt,zerosField,zerosField,zerosField,zerosField);
+            expectedFu = -(wvt.u.*wvt.diffX(wvt.u)+wvt.v.*wvt.diffY(wvt.u)+wvt.w.*wvt.diffZF(wvt.u));
+            expectedFv = -(wvt.u.*wvt.diffX(wvt.v)+wvt.v.*wvt.diffY(wvt.v)+wvt.w.*wvt.diffZF(wvt.v));
+            expectedFw = -(wvt.u.*wvt.diffX(wvt.w)+wvt.v.*wvt.diffY(wvt.w)+wvt.w.*wvt.diffZG(wvt.w));
+            expectedFeta = -(wvt.u.*wvt.diffX(wvt.eta)+wvt.v.*wvt.diffY(wvt.eta)+wvt.w.*(wvt.diffZG(wvt.eta)+wvt.eta.*nonlinear.dLnN2));
+            testCase.verifyEqual(Fu,expectedFu)
+            testCase.verifyEqual(Fv,expectedFv)
+            testCase.verifyEqual(Fw,expectedFw)
+            testCase.verifyEqual(Feta,expectedFeta)
+        end
+
+        function verifyConvertedFixedAmplitude(testCase,source,target,sourceForcing)
+            targetForcing = target.forcingWithName(sourceForcing.name);
+            coefficientNames = ["Ap" "Am" "A0"];
+            for coefficientName = coefficientNames
+                sourceValues = complex(zeros(source.spectralMatrixSize));
+                sourceIndices = sourceForcing.(coefficientName+"_indices");
+                sourceValues(sourceIndices) = sourceForcing.(coefficientName+"bar");
+                expectedValues = source.spectralVariableWithResolution(target,sourceValues);
+                sourceMask = zeros(source.spectralMatrixSize);
+                sourceMask(sourceIndices) = 1;
+                expectedMask = source.spectralVariableWithResolution(target,sourceMask);
+                expectedIndices = find(expectedMask);
+                testCase.verifyEqual(targetForcing.(coefficientName+"_indices"),uint64(expectedIndices))
+                testCase.verifyEqual(targetForcing.(coefficientName+"bar"),expectedValues(expectedIndices))
+            end
+        end
+
+        function verifyIdentity(testCase,actual,expected)
+            testCase.verifyEqual(length(actual),length(expected))
+            testCase.verifyTrue(all(actual == expected))
+        end
+
+        function verifyFinite(testCase,varargin)
+            for iValue = 1:length(varargin)
+                testCase.verifyTrue(all(isfinite(varargin{iValue}),"all"))
+            end
+        end
+
+
+        function closeIfOpen(ncfile)
+            if ~isempty(ncfile) && isvalid(ncfile) && ~isempty(ncfile.id)
+                ncfile.close();
+            end
+        end
+    end
+end

--- a/UnitTests/WVTestForcing.m
+++ b/UnitTests/WVTestForcing.m
@@ -1,0 +1,60 @@
+classdef WVTestForcing < WVForcing
+    properties (GetAccess=public, SetAccess=protected)
+        value
+    end
+
+    methods
+        function self = WVTestForcing(wvt,name,forcingType,priority,value)
+            self@WVForcing(wvt,name,forcingType);
+            self.priority = priority;
+            self.value = value;
+        end
+
+        function [Fu,Fv,Feta] = addHydrostaticSpatialForcing(self,~,Fu,Fv,Feta)
+            Fu = Fu+self.value;
+            Fv = Fv+2*self.value;
+            Feta = Feta+3*self.value;
+        end
+
+        function [Fu,Fv,Fw,Feta] = addNonhydrostaticSpatialForcing(self,~,Fu,Fv,Fw,Feta)
+            Fu = Fu+self.value;
+            Fv = Fv+2*self.value;
+            Fw = Fw+3*self.value;
+            Feta = Feta+4*self.value;
+        end
+
+        function [Fp,Fm,F0] = addSpectralForcing(self,~,Fp,Fm,F0)
+            Fp = Fp+self.value;
+            Fm = Fm+2*self.value;
+            F0 = F0+3*self.value;
+        end
+
+        function [Ap,Am,A0] = setSpectralAmplitude(self,~,Ap,Am,A0)
+            Ap(:) = self.value;
+            Am(:) = 2*self.value;
+            A0(:) = 3*self.value;
+        end
+
+        function F0 = addPotentialVorticitySpatialForcing(self,~,F0)
+            F0 = F0+self.value;
+        end
+
+        function F0 = addPotentialVorticitySpectralForcing(self,~,F0)
+            F0 = F0+self.value;
+        end
+
+        function A0 = setPotentialVorticitySpectralAmplitude(self,~,A0)
+            A0(:) = self.value;
+        end
+    end
+
+    methods (Static)
+        function vars = classRequiredPropertyNames()
+            vars = {};
+        end
+
+        function annotations = classDefinedPropertyAnnotations()
+            annotations = CAPropertyAnnotation.empty(0,0);
+        end
+    end
+end

--- a/docs/classes/forcing/closures/wvantialiasing/index.md
+++ b/docs/classes/forcing/closures/wvantialiasing/index.md
@@ -52,6 +52,7 @@ wvtAA = wvt.waveVortexTransformWithExplicitAntialiasing();
 
 ## Topics
 + Properties
+  + [`Nj`](/classes/forcing/closures/wvantialiasing/nj.html) number of retained vertical modes used to construct the filter
   + [`M`](/classes/forcing/closures/wvantialiasing/m.html) spectral matrix that multiplies Ap,Am,A0 to zero out the aliased modes
   + [`effectiveHorizontalGridResolution`](/classes/forcing/closures/wvantialiasing/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
   + [`effectiveJMax`](/classes/forcing/closures/wvantialiasing/effectivejmax.html) returns the effective highest vertical mode

--- a/docs/classes/forcing/closures/wvantialiasing/nj.md
+++ b/docs/classes/forcing/closures/wvantialiasing/nj.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Nj
+parent: WVAntialiasing
+grand_parent: Classes
+nav_order: 1
+mathjax: true
+---
+
+# Nj
+
+Number of retained vertical modes used to construct the filter.
+
+This value is preserved when the forcing is converted to another resolution or restored from an annotated NetCDF file. Modes with `j >= Nj` are filtered.

--- a/docs/classes/forcing/closures/wvantialiasing/wvantialiasing.md
+++ b/docs/classes/forcing/closures/wvantialiasing/wvantialiasing.md
@@ -20,7 +20,7 @@ initialize the WVAntialiasing
 ```
 ## Parameters
 + `wvt`  a WVTransform instance
-+ `Nj`  (optional) vertical mode above which energy will be set to zero.
++ `Nj`  (optional) number of retained vertical modes. Modes with `j >= Nj` are set to zero. Defaults to `floor(2*wvt.Nj/3)`.
 
 ## Returns
 + `self`  a WVAntialiasing instance


### PR DESCRIPTION
## Summary
- make forcing registration identity-based, deterministic, and atomic
- preserve stable forcing configuration across resolution conversion and NetCDF restoration
- add deterministic lifecycle, composition, numerical-pathway, and persistence coverage for all Stable forcings

## Verification
- focused forcing lifecycle suite
- traditional damping and pseudo-topographic production suites
- `buildtool test:smoke` (127 passed)
- `buildtool test:full` twice
- `buildtool test:exhaustive` (2440 passed)
- MATLAB analysis, whitespace, scope, and artifact checks

Closes #38