### PR TITLE
Cover operation registration and cache invalidation

### DIFF
--- a/@WVTransform/WVTransform.m
+++ b/@WVTransform/WVTransform.m
@@ -132,6 +132,7 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
                 end
             elseif isKey(self.operationNameMap,indexOp(1).Name)
                 op = self.operationNameMap{indexOp(1).Name};
+                varargout = cell(1,op.nVarOut);
                 [varargout{:}] = self.performOperation(op);
             else
                 error("WVTransform:UnknownVariable","The variable %s does not exist",indexOp(1).Name);
@@ -191,6 +192,7 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
 
         function updateDependentVariablesNameMap(self,~,~)
             self.timeDependentVariablesNameMap = configureDictionary("string","cell");
+            self.wvCoefficientDependentVariablesNameMap = configureDictionary("string","cell");
             annotations = self.propertyAnnotations;
             for i=1:length(annotations)
                 if isa(annotations(i),'WVVariableAnnotation')

--- a/@WVTransform/addOperation.m
+++ b/@WVTransform/addOperation.m
@@ -1,21 +1,10 @@
 function addOperation(self,operation,options)
-% add a WVOperation
+% Register one or more operations and their output variables.
 %
-% Several things happen when adding an operation.
-% 1. We check that dimensions exist for all output variables
-% produced by this operation.
-% 2. We see if there are any existing output variables with the
-% same name.
-%   2a. We remove the operation that produced the existing
-%   variables, if it exists.
-% 3. We map each new variable to this operation variableAnnotationNameMap
-% 4. Map each operation name to the operation
-%
-% In our revision,
-%   - The variableAnnotationNameMap will map the name to the
-%   variable annotation
-%   - The operationVariableNameMap will map the name to the
-%   operation
+% The complete request is validated before annotations, lookup maps, or
+% cached values are changed. Existing operations are replaced only when
+% `shouldOverwriteExisting` is true. For an operation array, replacements
+% are evaluated in caller order and the last conflicting operation wins.
 %
 % - Topic: Utility function — Metadata
 arguments
@@ -24,51 +13,127 @@ arguments
     options.shouldOverwriteExisting logical = false
     options.shouldSuppressWarning logical = false
 end
-for iOp=1:length(operation)
-    isExisting = 0;
-    for iVar=1:length(operation(iOp).outputVariables)
-        isKnownDimension = ismember(operation(iOp).outputVariables(iVar).dimensions,self.annotatedDimensionNames);
-        if any(~isKnownDimension)
-            error("Unable to find dimension (%s) for the numeric property %s",strjoin(string(operation(iOp).outputVariables(iVar).dimensions(~isKnownDimension)),","),operation(iOp).outputVariables(iVar).name);
-        end
 
-        isKnownProperty = ismember(operation(iOp).outputVariables(iVar).name,self.annotatedPropertyNames);
-        if any(isKnownProperty)
-            existingVar = self.propertyAnnotationWithName(operation(iOp).outputVariables(iVar).name);
-            if isa(existingVar,'WVVariableAnnotation')
-                isExisting = 1;
+registeredOperationNames = self.operationNameMap.keys;
+registeredOperations = cell(1,length(registeredOperationNames));
+for iOperation = 1:length(registeredOperationNames)
+    registeredOperations{iOperation} = self.operationNameMap{registeredOperationNames(iOperation)};
+end
+stagedOperations = [registeredOperations cell(1,length(operation))];
+stagedOperationCount = length(registeredOperations);
+
+for iOperation = 1:length(operation)
+    candidate = operation(iOperation);
+    outputNames = string({candidate.outputVariables.name});
+    if length(unique(outputNames)) ~= length(outputNames)
+        error("Operation '%s' declares duplicate output-variable names.",candidate.name)
+    end
+
+    for iOutput = 1:candidate.nVarOut
+        annotation = candidate.outputVariables(iOutput);
+        unknownDimensions = setdiff(string(annotation.dimensions),string(self.annotatedDimensionNames));
+        if ~isempty(unknownDimensions)
+            error("Operation '%s' output '%s' refers to unknown dimensions: %s.",candidate.name,annotation.name,join(unknownDimensions,", "))
+        end
+        if ismember(annotation.name,self.annotatedPropertyNames) && ~isKey(self.operationVariableNameMap,annotation.name)
+            existingAnnotation = self.propertyAnnotationWithName(annotation.name);
+            if ~isa(existingAnnotation,"WVVariableAnnotation")
+                error("Operation '%s' cannot replace the non-operation annotation '%s'.",candidate.name,annotation.name)
             end
         end
     end
 
-    if isExisting == 1
-        message1 = strcat(existingVar.modelOp.name,' with variables {');
-        for jVar=1:existingVar.modelOp.nVarOut
-            message1 = strcat(message1,existingVar.modelOp.outputVariables(jVar).name,',');
-        end
-        message1 = strcat(message1,'}');
-
-        message2 = strcat(operation(iOp).name,' with variables {');
-        for jVar=1:operation(iOp).nVarOut
-            message2 = strcat(message2,operation(iOp).outputVariables(jVar).name,',');
-        end
-        message2 = strcat(message2,'}');
-        if options.shouldOverwriteExisting == 0
-            error('A variable with the same name already exists! You attempted to replace the operation %s with the operation %s. If you are sure you want to do this, call wvt.addOperation(newOp,overwriteExisting=1).', message1,message2);
-        else
-            self.removeOperation(existingVar.modelOp);
-            if options.shouldSuppressWarning == false
-                fprintf('The operation %s has been removed and the operation %s has been added.\n',message1,message2);
-            end
-        end
+    conflictingIndices = false(1,stagedOperationCount);
+    for iExisting = 1:stagedOperationCount
+        existing = stagedOperations{iExisting};
+        existingOutputNames = string({existing.outputVariables.name});
+        conflictingIndices(iExisting) = strcmp(existing.name,candidate.name) || any(ismember(outputNames,existingOutputNames));
+    end
+    if any(conflictingIndices) && ~options.shouldOverwriteExisting
+        activeOperations = stagedOperations(1:stagedOperationCount);
+        conflictingNames = string(cellfun(@(existing) existing.name,activeOperations(conflictingIndices),UniformOutput=false));
+        error("Operation '%s' conflicts with registered operation(s): %s. Set shouldOverwriteExisting=true to replace them.",candidate.name,join(conflictingNames,", "))
     end
 
-    % Now go ahead and actually add the operation and its variables
-    self.addPropertyAnnotation(operation(iOp).outputVariables);
-    for iVar=1:length(operation(iOp).outputVariables)
-        self.operationVariableNameMap(operation(iOp).outputVariables(iVar).name) = operation(iOp).outputVariables(iVar);
-    end
-    self.operationNameMap{operation(iOp).name} = operation(iOp);
+    remainingOperations = stagedOperations(1:stagedOperationCount);
+    remainingOperations(conflictingIndices) = [];
+    stagedOperationCount = length(remainingOperations)+1;
+    stagedOperations(1:stagedOperationCount-1) = remainingOperations;
+    stagedOperations{stagedOperationCount} = candidate;
+end
+stagedOperations = stagedOperations(1:stagedOperationCount);
 
+removedOperations = operationsAbsentFrom(registeredOperations,stagedOperations);
+addedOperations = operationsAbsentFrom(stagedOperations,registeredOperations);
+if isempty(removedOperations) && isempty(addedOperations)
+    return
+end
+
+removedAnnotations = outputAnnotationsForOperations(removedOperations);
+if ~isempty(removedAnnotations)
+    self.removePropertyAnnotation(removedAnnotations);
+end
+for iOperation = 1:length(removedOperations)
+    removed = removedOperations{iOperation};
+    for iOutput = 1:removed.nVarOut
+        outputName = removed.outputVariables(iOutput).name;
+        if isKey(self.operationVariableNameMap,outputName)
+            self.operationVariableNameMap(outputName) = [];
+        end
+        self.removeFromVariableCache(outputName);
+    end
+    if isKey(self.operationNameMap,removed.name)
+        self.operationNameMap(removed.name) = [];
+    end
+end
+
+addedAnnotations = outputAnnotationsForOperations(addedOperations);
+if ~isempty(addedAnnotations)
+    self.addPropertyAnnotation(addedAnnotations);
+end
+for iOperation = 1:length(addedOperations)
+    added = addedOperations{iOperation};
+    for iOutput = 1:added.nVarOut
+        outputVariable = added.outputVariables(iOutput);
+        self.removeFromVariableCache(outputVariable.name);
+        self.operationVariableNameMap(outputVariable.name) = outputVariable;
+    end
+    self.operationNameMap{added.name} = added;
+end
+
+if ~options.shouldSuppressWarning && ~isempty(removedOperations)
+    removedNames = string(cellfun(@(removed) removed.name,removedOperations,UniformOutput=false));
+    addedNames = string(cellfun(@(added) added.name,addedOperations,UniformOutput=false));
+    fprintf("Replaced operation(s) {%s} with {%s}.\n",join(removedNames,", "),join(addedNames,", "))
+end
+end
+
+function absentOperations = operationsAbsentFrom(candidates,reference)
+absentOperations = cell(1,length(candidates));
+absentOperationCount = 0;
+for iCandidate = 1:length(candidates)
+    candidate = candidates{iCandidate};
+    isPresent = any(cellfun(@(other) other == candidate,reference));
+    if ~isPresent
+        absentOperationCount = absentOperationCount+1;
+        absentOperations{absentOperationCount} = candidate;
+    end
+end
+absentOperations = absentOperations(1:absentOperationCount);
+end
+
+function annotations = outputAnnotationsForOperations(operations)
+if isempty(operations)
+    annotations = WVVariableAnnotation.empty(1,0);
+    return
+end
+annotationCount = sum(cellfun(@(operation) operation.nVarOut,operations));
+annotations = repmat(operations{1}.outputVariables(1),1,annotationCount);
+nextAnnotation = 1;
+for iOperation = 1:length(operations)
+    operationAnnotations = operations{iOperation}.outputVariables;
+    annotationIndices = nextAnnotation:nextAnnotation+length(operationAnnotations)-1;
+    annotations(annotationIndices) = operationAnnotations;
+    nextAnnotation = annotationIndices(end)+1;
 end
 end

--- a/@WVTransform/operationWithName.m
+++ b/@WVTransform/operationWithName.m
@@ -9,5 +9,8 @@ end
 arguments (Output)
     val WVOperation 
 end
+if ~isKey(self.operationNameMap,name)
+    error("No operation named '%s' is registered with this transform.",name)
+end
 val = self.operationNameMap{name};
 end

--- a/@WVTransform/performOperationWithName.m
+++ b/@WVTransform/performOperationWithName.m
@@ -9,7 +9,7 @@ end
 arguments (Output,Repeating)
     varargout
 end
-modelOp = self.operationNameMap{opName};
+modelOp = self.operationWithName(opName);
 varargout = cell(1,modelOp.nVarOut);
 [varargout{:}] = self.performOperation(modelOp);
 end

--- a/@WVTransform/removeOperation.m
+++ b/@WVTransform/removeOperation.m
@@ -1,16 +1,27 @@
 function removeOperation(self,operation)
-% remove an existing WVOperation
+% Remove the exact registered operation and its cached outputs.
 %
 % - Topic: Utility function — Metadata
 arguments
     self WVTransform {mustBeNonempty}
     operation (1,1) WVOperation {mustBeNonempty}
 end
-self.removePropertyAnnotation(operation.outputVariables);
-for iVar=1:operation.nVarOut
-    self.operationVariableNameMap(operation.outputVariables(iVar).name) = [];
+
+if ~isKey(self.operationNameMap,operation.name) || self.operationNameMap{operation.name} ~= operation
+    error("The requested operation is not registered with this transform.")
 end
-self.operationNameMap{operation.name} = [];
-% brute force
-self.variableCache = configureDictionary("string","cell");
+for iOutput = 1:operation.nVarOut
+    outputName = operation.outputVariables(iOutput).name;
+    if ~isKey(self.operationVariableNameMap,outputName) || self.operationVariableNameMap(outputName).modelOp ~= operation
+        error("The registered output map for operation '%s' is inconsistent.",operation.name)
+    end
+end
+
+self.removePropertyAnnotation(operation.outputVariables);
+for iOutput = 1:operation.nVarOut
+    outputName = operation.outputVariables(iOutput).name;
+    self.operationVariableNameMap(outputName) = [];
+    self.removeFromVariableCache(outputName);
+end
+self.operationNameMap(operation.name) = [];
 end

--- a/@WVTransform/variableWithName.m
+++ b/@WVTransform/variableWithName.m
@@ -1,11 +1,9 @@
-function [varargout] = variableWithName(self, variableNames)
-% Primary method for accessing the dynamical variables
-%
-% Computes (or retrieves from cache) any known state variables.
+function varargout = variableWithName(self,variableNames)
+% Compute or retrieve one or more registered transform variables.
 %
 % - Topic: State Variables
-% - Declaration: [varargout] = variables(self, variables)
-% - Parameter variables: strings of variable names.
+% - Declaration: varargout = variableWithName(variableNames)
+% - Parameter variableNames: registered variable names
 arguments
     self WVTransform {mustBeNonempty}
 end
@@ -13,31 +11,16 @@ arguments (Repeating)
     variableNames char
 end
 
-varargout = cell(size(variableNames));
-didFetchAll = 0;
-while didFetchAll ~= 1
-    [varargout{:}] = self.fetchFromVariableCache(variableNames{:});
-
-    for iVar=1:length(varargout)
-        if isempty(varargout{iVar})
-            % now go compute it, and then try fetching from
-            % cach
-            modelVar = self.operationVariableNameMap(variableNames{iVar});
-            self.performOperationWithName(modelVar.modelOp.name);
-            didFetchAll = 0;
-            break;
-        else
-            didFetchAll = 1;
-        end
+while ~all(isKey(self.variableCache,variableNames))
+    missingIndex = find(~isKey(self.variableCache,variableNames),1);
+    missingName = variableNames{missingIndex};
+    if ~isKey(self.operationVariableNameMap,missingName)
+        error("No variable named '%s' is registered with this transform.",missingName)
     end
+    annotation = self.operationVariableNameMap(missingName);
+    self.performOperation(annotation.modelOp);
 end
 
-% % External variables may not all be supported.
-% if ~isempty(self.offgridModes) && ~isempty(self.offgridModes.k_ext)
-%     varargoutExt = cell(size(variableNames));
-%     [varargoutExt{:}] = self.externalVariableFieldsAtTime(self.t, variableNames{:});
-%     for iArg=1:length(varargout)
-%         varargout{iArg} = varargout{iArg} + varargoutExt{iArg};
-%     end
-% end
+varargout = cell(size(variableNames));
+[varargout{:}] = self.fetchFromVariableCache(variableNames{:});
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Made operation registration, replacement, and removal atomic and identity-based; corrected multiple-output lookup; and made cache invalidation follow each operation's declared time and coefficient dependencies.
 - Made forcing registration identity-based, deterministic, and atomic; preserved vertical-diffusivity, fixed-amplitude, and explicit-antialias configurations through resolution changes and NetCDF restoration; and rejected vertical diffusivity on barotropic transforms.
 - Corrected observing-system ownership and composition, linear-time flux evaluation, particle tolerance and tracked-field propagation, and periodic one-based mooring indexing.
 - Added compact invariant coverage across every stable transform on even and odd grids; corrected parity-aware Nyquist and Hermitian bookkeeping, vector mode/index mappings, coefficient-preserving resolution conversion, and barotropic spatial energy and enstrophy diagnostics.

--- a/Documentation/WebsiteDocumentation/users-guide/creating-new-state-variables.md
+++ b/Documentation/WebsiteDocumentation/users-guide/creating-new-state-variables.md
@@ -48,8 +48,14 @@ If the output variable has spatial dimension $$(x,y)$$ or $$(x,y,z)$$, then the 
 
 In the example above a function handle was used to compute the relative vorticity because it only required a single line of code. However, it is often the case that computations will be more involved. In that case, you should subclass the `WVOperation`.
 
-If a `WVOperation` produces a variable with the same name as one that already exists, it will *replace* the existing `WVOperation`. This is both useful and dangerous.
+Operation names and output-variable names must be unique. By default, `addOperation` rejects a new operation that conflicts with an existing operation and leaves the registry unchanged. To intentionally replace an operation, opt in explicitly:
 
-A `WVOperation` can return multiple variables.
+```matlab
+wvt.addOperation(replacementOperation,shouldOverwriteExisting=true);
+```
 
-All computed variables are cached, so as not to repeat unnecessary calculations.
+An operation is registered and removed as a unit. If the replacement conflicts with one output from a multiple-output operation, every output from the displaced operation is removed. When registering an array of operations with replacement enabled, conflicts are resolved in caller order and the last conflicting operation wins.
+
+A `WVOperation` can return multiple variables. Its outputs are returned in annotation order and computed together when any uncached output is requested.
+
+All computed variables are cached to avoid unnecessary calculations. Set an operation's dependency metadata before registration: `isVariableWithLinearTimeStep=true` invalidates its outputs when transform time changes, while `isDependentOnApAmA0=true` invalidates them when `Ap`, `Am`, or `A0` changes. Outputs without the relevant dependency remain cached.

--- a/UnitTests/TestOperationRegistrationAndCaching.m
+++ b/UnitTests/TestOperationRegistrationAndCaching.m
@@ -1,0 +1,199 @@
+classdef TestOperationRegistrationAndCaching < matlab.unittest.TestCase
+    methods (Test, TestTags="full")
+        function singleAndMultipleOutputsExecuteOnceAndRemainOrdered(testCase)
+            wvt = TestOperationRegistrationAndCaching.transform();
+            singleAnnotation = TestOperationRegistrationAndCaching.annotation("single");
+            single = WVCountingOperation('single',singleAnnotation,@(~) {11});
+            pairAnnotations = [TestOperationRegistrationAndCaching.annotation("pair_a") TestOperationRegistrationAndCaching.annotation("pair_b")];
+            pair = WVCountingOperation('pair',pairAnnotations,@(~) {21,22});
+            wvt.addOperation([single pair]);
+
+            testCase.verifyTrue(wvt.operationWithName('single') == single)
+            testCase.verifyTrue(wvt.operationWithName('pair') == pair)
+            testCase.verifyTrue(wvt.propertyAnnotationWithName("single").modelOp == single)
+            testCase.verifyTrue(wvt.propertyAnnotationWithName("pair_a").modelOp == pair)
+
+            testCase.verifyEqual(wvt.variableWithName('single'),11)
+            testCase.verifyEqual(wvt.single,11)
+            testCase.verifyEqual(single.callCount,1)
+
+            [first,second] = wvt.performOperationWithName('pair');
+            testCase.verifyEqual([first second],[21 22])
+            [firstAgain,secondAgain] = wvt.pair;
+            testCase.verifyEqual([firstAgain secondAgain],[21 22])
+            [requestedSecond,requestedFirst] = wvt.variableWithName('pair_b','pair_a');
+            testCase.verifyEqual([requestedSecond requestedFirst],[22 21])
+            testCase.verifyEqual(pair.callCount,1)
+            testCase.verifyTrue(all(isKey(wvt.variableCache,["single" "pair_a" "pair_b"])))
+        end
+
+        function invalidAndConflictingRegistrationsAreAtomic(testCase)
+            wvt = TestOperationRegistrationAndCaching.transform();
+            baseline = WVCountingOperation('baseline',TestOperationRegistrationAndCaching.annotation("baseline"),@(~) {31});
+            wvt.addOperation(baseline);
+            testCase.verifyEqual(wvt.baseline,31)
+            initialState = TestOperationRegistrationAndCaching.registryState(wvt);
+
+            unknownDimension = WVVariableAnnotation('unknown_dimension',{'not_a_dimension'},'1','unknown dimension output');
+            invalidDimension = WVCountingOperation('unknown_dimension',unknownDimension,@(~) {1});
+            testCase.verifyError(@()wvt.addOperation(invalidDimension),'')
+            TestOperationRegistrationAndCaching.verifyRegistryState(testCase,wvt,initialState)
+
+            protectedAnnotation = WVCountingOperation('t',TestOperationRegistrationAndCaching.annotation("t"),@(~) {1});
+            testCase.verifyError(@()wvt.addOperation(protectedAnnotation,shouldOverwriteExisting=true),'')
+            TestOperationRegistrationAndCaching.verifyRegistryState(testCase,wvt,initialState)
+
+            outputConflict = WVCountingOperation('output conflict',[TestOperationRegistrationAndCaching.annotation("baseline") TestOperationRegistrationAndCaching.annotation("conflict_extra")],@(~) {2,3});
+            operationNameConflict = WVCountingOperation('baseline',[TestOperationRegistrationAndCaching.annotation("different_output") TestOperationRegistrationAndCaching.annotation("other_output")],@(~) {3,4});
+            testCase.verifyError(@()wvt.addOperation(outputConflict),'')
+            testCase.verifyError(@()wvt.addOperation(operationNameConflict),'')
+            TestOperationRegistrationAndCaching.verifyRegistryState(testCase,wvt,initialState)
+
+            duplicateAnnotations = [TestOperationRegistrationAndCaching.annotation("duplicate") TestOperationRegistrationAndCaching.annotation("duplicate")];
+            duplicateOutputs = WVCountingOperation('duplicate outputs',duplicateAnnotations,@(~) {1,2});
+            testCase.verifyError(@()wvt.addOperation(duplicateOutputs),'')
+
+            valid = WVCountingOperation('would_be_valid',TestOperationRegistrationAndCaching.annotation("would_be_valid"),@(~) {4});
+            testCase.verifyError(@()wvt.addOperation([valid invalidDimension]),'')
+            TestOperationRegistrationAndCaching.verifyRegistryState(testCase,wvt,initialState)
+            testCase.verifyFalse(ismember("would_be_valid",wvt.variableNames))
+        end
+
+        function overwriteRemovesAllConflictsAndPreservesUnrelatedCache(testCase)
+            wvt = TestOperationRegistrationAndCaching.transform();
+            first = WVCountingOperation('first',[TestOperationRegistrationAndCaching.annotation("first_a") TestOperationRegistrationAndCaching.annotation("shared_a")],@(~) {1,2});
+            second = WVCountingOperation('second',[TestOperationRegistrationAndCaching.annotation("second_a") TestOperationRegistrationAndCaching.annotation("shared_b")],@(~) {3,4});
+            unrelated = WVCountingOperation('unrelated',TestOperationRegistrationAndCaching.annotation("unrelated"),@(~) {5});
+            wvt.addOperation([first second unrelated]);
+            wvt.performOperationWithName('first');
+            wvt.performOperationWithName('second');
+            testCase.verifyEqual(wvt.unrelated,5)
+
+            replacementAnnotations = [TestOperationRegistrationAndCaching.annotation("shared_a") TestOperationRegistrationAndCaching.annotation("shared_b")];
+            replacement = WVCountingOperation('replacement',replacementAnnotations,@(~) {12,14});
+            wvt.addOperation(replacement,shouldOverwriteExisting=true,shouldSuppressWarning=true);
+
+            testCase.verifyError(@()wvt.operationWithName('first'),'')
+            testCase.verifyError(@()wvt.operationWithName('second'),'')
+            testCase.verifyFalse(any(ismember(["first_a" "second_a"],wvt.variableNames)))
+            testCase.verifyFalse(any(isKey(wvt.variableCache,["first_a" "shared_a" "second_a" "shared_b"])))
+            testCase.verifyTrue(isKey(wvt.variableCache,"unrelated"))
+            [sharedA,sharedB] = wvt.performOperationWithName('replacement');
+            testCase.verifyEqual([sharedA sharedB],[12 14])
+            testCase.verifyEqual(replacement.callCount,1)
+            testCase.verifyEqual(unrelated.callCount,1)
+
+            early = WVCountingOperation('batch early',[TestOperationRegistrationAndCaching.annotation("batch_shared") TestOperationRegistrationAndCaching.annotation("early_only")],@(~) {20,21});
+            late = WVCountingOperation('batch late',[TestOperationRegistrationAndCaching.annotation("batch_shared") TestOperationRegistrationAndCaching.annotation("late_only")],@(~) {30,31});
+            wvt.addOperation([early late],shouldOverwriteExisting=true,shouldSuppressWarning=true);
+            testCase.verifyError(@()wvt.operationWithName('batch early'),'')
+            testCase.verifyTrue(wvt.operationWithName('batch late') == late)
+            testCase.verifyEqual(wvt.batch_shared,30)
+        end
+
+        function removalUsesIdentityAndClearsOnlyOwnedState(testCase)
+            wvt = TestOperationRegistrationAndCaching.transform();
+            removableAnnotations = [TestOperationRegistrationAndCaching.annotation("remove_a") TestOperationRegistrationAndCaching.annotation("remove_b")];
+            removable = WVCountingOperation('removable',removableAnnotations,@(~) {41,42});
+            retained = WVCountingOperation('retained',TestOperationRegistrationAndCaching.annotation("retained"),@(~) {43});
+            wvt.addOperation([removable retained]);
+            wvt.performOperationWithName('removable');
+            testCase.verifyEqual(wvt.retained,43)
+
+            foreignAnnotations = [TestOperationRegistrationAndCaching.annotation("remove_a") TestOperationRegistrationAndCaching.annotation("remove_b")];
+            foreign = WVCountingOperation('removable',foreignAnnotations,@(~) {51,52});
+            testCase.verifyError(@()wvt.removeOperation(foreign),'')
+            testCase.verifyTrue(wvt.operationWithName('removable') == removable)
+            testCase.verifyTrue(all(isKey(wvt.variableCache,["remove_a" "remove_b" "retained"])))
+
+            wvt.removeOperation(removable);
+            testCase.verifyError(@()wvt.removeOperation(removable),'')
+            testCase.verifyError(@()wvt.operationWithName('removable'),'')
+            testCase.verifyError(@()wvt.performOperationWithName('removable'),'')
+            testCase.verifyError(@()wvt.variableWithName('remove_a'),'')
+            testCase.verifyFalse(any(ismember(["remove_a" "remove_b"],wvt.variableNames)))
+            testCase.verifyFalse(any(isKey(wvt.variableCache,["remove_a" "remove_b"])))
+            testCase.verifyTrue(isKey(wvt.variableCache,"retained"))
+            testCase.verifyFalse(any(isKey(wvt.timeDependentVariablesNameMap,["remove_a" "remove_b"])))
+            testCase.verifyFalse(any(isKey(wvt.wvCoefficientDependentVariablesNameMap,["remove_a" "remove_b"])))
+        end
+
+        function dependencyMetadataInvalidatesOnlyDeclaredOutputs(testCase)
+            wvt = TestOperationRegistrationAndCaching.transform();
+            timeAnnotation = TestOperationRegistrationAndCaching.annotation("time_only");
+            timeAnnotation.isVariableWithLinearTimeStep = true;
+            timeAnnotation.isDependentOnApAmA0 = false;
+            coefficientAnnotation = TestOperationRegistrationAndCaching.annotation("coefficient_only");
+            coefficientAnnotation.isVariableWithLinearTimeStep = false;
+            coefficientAnnotation.isDependentOnApAmA0 = true;
+            pair = WVCountingOperation('dependency pair',[timeAnnotation coefficientAnnotation],@(transform) {transform.t,sum(transform.Ap(:))+sum(transform.Am(:))+sum(transform.A0(:))});
+
+            invariantAnnotation = TestOperationRegistrationAndCaching.annotation("invariant");
+            invariantAnnotation.isVariableWithLinearTimeStep = false;
+            invariantAnnotation.isDependentOnApAmA0 = false;
+            invariant = WVCountingOperation('invariant',invariantAnnotation,@(~) {61});
+            wvt.addOperation([pair invariant]);
+            wvt.performOperationWithName('dependency pair');
+            testCase.verifyEqual(wvt.invariant,61)
+            testCase.verifyEqual(pair.callCount,1)
+            testCase.verifyTrue(isKey(wvt.timeDependentVariablesNameMap,"time_only"))
+            testCase.verifyFalse(isKey(wvt.timeDependentVariablesNameMap,"coefficient_only"))
+            testCase.verifyTrue(isKey(wvt.wvCoefficientDependentVariablesNameMap,"coefficient_only"))
+            testCase.verifyFalse(isKey(wvt.wvCoefficientDependentVariablesNameMap,"time_only"))
+
+            wvt.t = wvt.t+1;
+            testCase.verifyFalse(isKey(wvt.variableCache,"time_only"))
+            testCase.verifyTrue(all(isKey(wvt.variableCache,["coefficient_only" "invariant"])))
+            testCase.verifyEqual(wvt.coefficient_only,0)
+            testCase.verifyEqual(pair.callCount,1)
+            testCase.verifyEqual(wvt.time_only,wvt.t)
+            testCase.verifyEqual(pair.callCount,2)
+
+            coefficientProperties = ["Ap" "Am" "A0"];
+            for iProperty = 1:length(coefficientProperties)
+                propertyName = coefficientProperties(iProperty);
+                values = wvt.(propertyName);
+                values(2) = values(2)+iProperty;
+                wvt.(propertyName) = values;
+                testCase.verifyFalse(isKey(wvt.variableCache,"coefficient_only"))
+                testCase.verifyTrue(all(isKey(wvt.variableCache,["time_only" "invariant"])))
+                previousCount = pair.callCount;
+                wvt.coefficient_only;
+                testCase.verifyEqual(pair.callCount,previousCount+1)
+            end
+
+            replacementAnnotation = TestOperationRegistrationAndCaching.annotation("coefficient_only");
+            replacementAnnotation.isVariableWithLinearTimeStep = true;
+            replacementAnnotation.isDependentOnApAmA0 = false;
+            replacement = WVCountingOperation('coefficient_only',replacementAnnotation,@(transform) {transform.t+100});
+            wvt.addOperation(replacement,shouldOverwriteExisting=true,shouldSuppressWarning=true);
+            testCase.verifyFalse(isKey(wvt.wvCoefficientDependentVariablesNameMap,"coefficient_only"))
+            testCase.verifyTrue(isKey(wvt.timeDependentVariablesNameMap,"coefficient_only"))
+            testCase.verifyEqual(wvt.coefficient_only,wvt.t+100)
+        end
+    end
+
+    methods (Static, Access=private)
+        function wvt = transform()
+            wvt = WVTransformConstantStratification([4e3 3e3 2e3],[8 6 5],latitude=30,shouldAntialias=false);
+        end
+
+        function annotation = annotation(name)
+            annotation = WVVariableAnnotation(char(name),{},'1','test operation output');
+        end
+
+        function state = registryState(wvt)
+            state.operationNames = sort(string(wvt.operationNameMap.keys));
+            state.variableNames = sort(string(wvt.operationVariableNameMap.keys));
+            state.annotationNames = sort(string(wvt.annotatedPropertyNames));
+            state.cacheNames = sort(string(wvt.variableCache.keys));
+            state.coefficientDependentNames = sort(string(wvt.wvCoefficientDependentVariablesNameMap.keys));
+            state.timeDependentNames = sort(string(wvt.timeDependentVariablesNameMap.keys));
+        end
+
+        function verifyRegistryState(testCase,wvt,expected)
+            actual = TestOperationRegistrationAndCaching.registryState(wvt);
+            testCase.verifyEqual(actual,expected)
+        end
+    end
+end

--- a/UnitTests/WVCountingOperation.m
+++ b/UnitTests/WVCountingOperation.m
@@ -1,0 +1,22 @@
+classdef WVCountingOperation < WVOperation
+    properties (SetAccess=private)
+        callCount (1,1) double = 0
+        valuesFunction function_handle
+    end
+
+    methods
+        function self = WVCountingOperation(name,outputVariables,valuesFunction)
+            self@WVOperation(name,outputVariables,@disp);
+            self.valuesFunction = valuesFunction;
+        end
+
+        function varargout = compute(self,wvt,varargin)
+            self.callCount = self.callCount+1;
+            values = self.valuesFunction(wvt,varargin{:});
+            if length(values) ~= self.nVarOut
+                error("The test operation returned an unexpected number of values.")
+            end
+            varargout = values;
+        end
+    end
+end

--- a/docs/classes/transforms/wvtransform/addoperation.md
+++ b/docs/classes/transforms/wvtransform/addoperation.md
@@ -9,27 +9,11 @@ mathjax: true
 
 #  addOperation
 
-add a WVOperation
+Register one or more operations and their output variables.
 
 
 ---
 
 ## Discussion
 
-  Several things happen when adding an operation.
-  1. We check that dimensions exist for all output variables
-  produced by this operation.
-  2. We see if there are any existing output variables with the
-  same name.
-    2a. We remove the operation that produced the existing
-    variables, if it exists.
-  3. We map each new variable to this operation variableAnnotationNameMap
-  4. Map each operation name to the operation
- 
-  In our revision,
-    - The variableAnnotationNameMap will map the name to the
-    variable annotation
-    - The operationVariableNameMap will map the name to the
-    operation
- 
-  
+The complete request is validated before annotations, lookup maps, or cached values are changed. Existing operations are replaced only when `shouldOverwriteExisting` is true. For an operation array, replacements are evaluated in caller order and the last conflicting operation wins.

--- a/docs/classes/transforms/wvtransform/operationwithname.md
+++ b/docs/classes/transforms/wvtransform/operationwithname.md
@@ -9,11 +9,11 @@ mathjax: true
 
 #  operationWithName
 
-retrieve a WVOperation by name
+Retrieve a registered `WVOperation` by name.
 
 
 ---
 
 ## Discussion
 
-  
+An unknown name produces a clear lookup error.

--- a/docs/classes/transforms/wvtransform/removeoperation.md
+++ b/docs/classes/transforms/wvtransform/removeoperation.md
@@ -9,11 +9,11 @@ mathjax: true
 
 #  removeOperation
 
-remove an existing WVOperation
+Remove the exact registered operation and its cached outputs.
 
 
 ---
 
 ## Discussion
 
-  
+The supplied object must be the same handle that is registered with the transform. Removing a multiple-output operation removes all of its annotations, lookup entries, and cached outputs without clearing unrelated cached variables.

--- a/docs/classes/transforms/wvtransform/variablewithname.md
+++ b/docs/classes/transforms/wvtransform/variablewithname.md
@@ -9,20 +9,18 @@ mathjax: true
 
 #  variableWithName
 
-Primary method for accessing the dynamical variables
+Compute or retrieve one or more registered transform variables.
 
 
 ---
 
 ## Declaration
 ```matlab
- [varargout] = variables(self, variables)
+ [varargout] = variableWithName(self, variableNames)
 ```
 ## Parameters
-+ `variables`  strings of variable names.
++ `variableNames` registered variable names.
 
 ## Discussion
 
-  Computes (or retrieves from cache) any known state variables.
- 
-      
+Outputs are returned in caller order. Requesting any uncached output evaluates its owning operation, including every output of a multiple-output operation, and stores the results in the transform cache. Unknown names produce a clear lookup error.

--- a/docs/users-guide/creating-new-state-variables.md
+++ b/docs/users-guide/creating-new-state-variables.md
@@ -48,8 +48,14 @@ If the output variable has spatial dimension $$(x,y)$$ or $$(x,y,z)$$, then the 
 
 In the example above a function handle was used to compute the relative vorticity because it only required a single line of code. However, it is often the case that computations will be more involved. In that case, you should subclass the `WVOperation`.
 
-If a `WVOperation` produces a variable with the same name as one that already exists, it will *replace* the existing `WVOperation`. This is both useful and dangerous.
+Operation names and output-variable names must be unique. By default, `addOperation` rejects a new operation that conflicts with an existing operation and leaves the registry unchanged. To intentionally replace an operation, opt in explicitly:
 
-A `WVOperation` can return multiple variables.
+```matlab
+wvt.addOperation(replacementOperation,shouldOverwriteExisting=true);
+```
 
-All computed variables are cached, so as not to repeat unnecessary calculations.
+An operation is registered and removed as a unit. If the replacement conflicts with one output from a multiple-output operation, every output from the displaced operation is removed. When registering an array of operations with replacement enabled, conflicts are resolved in caller order and the last conflicting operation wins.
+
+A `WVOperation` can return multiple variables. Its outputs are returned in annotation order and computed together when any uncached output is requested.
+
+All computed variables are cached to avoid unnecessary calculations. Set an operation's dependency metadata before registration: `isVariableWithLinearTimeStep=true` invalidates its outputs when transform time changes, while `isDependentOnApAmA0=true` invalidates them when `Ap`, `Am`, or `A0` changes. Outputs without the relevant dependency remain cached.


### PR DESCRIPTION
## Summary
- make operation registration, replacement, and removal deterministic and atomic
- correct multi-output lookup and dependency-aware cache invalidation
- add focused operation lifecycle and cache coverage
- update focused API and user documentation

## Verification
- focused operation and compatibility tests
- smoke suite
- full suite twice: 538/538 passed each run
- exhaustive suite: 2440/2440 passed
- MATLAB analyzer, documentation mirror, whitespace, scope, and artifact checks

Closes #39