### PR TITLE
Stabilize output persistence and handle safety

### DIFF
--- a/@WVModel/WVModel.m
+++ b/@WVModel/WVModel.m
@@ -161,10 +161,14 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             % - Topic: Writing to NetCDF files
             arguments (Input)
                 self WVModel {mustBeNonempty}
-                name char {mustBeNonempty}
+                name {mustBeText,mustBeNonempty}
             end
             arguments (Output)
-                val WVModelOutputGroup
+                val WVModelOutputFile
+            end
+            name = string(name);
+            if ~isKey(self.outputFileNameMap,name)
+                error('No output file named %s is registered with this model.',name);
             end
             val = self.outputFileNameMap(name);
         end
@@ -175,7 +179,17 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             % - Topic: Writing to NetCDF files
             arguments
                 self WVModel {mustBeNonempty}
-                outputFile WVModelOutputFile
+                outputFile (1,1) WVModelOutputFile
+            end
+            if outputFile.model ~= self
+                error('The output file %s was not initialized for this model.',outputFile.filename);
+            end
+            if isKey(self.outputFileNameMap,outputFile.filename)
+                registeredFile = self.outputFileNameMap(outputFile.filename);
+                if registeredFile == outputFile
+                    return
+                end
+                error('A different output file named %s is already registered with this model.',outputFile.filename);
             end
             self.outputFileNameMap(outputFile.filename) = outputFile;
         end
@@ -714,20 +728,33 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             % arrayfun( @(outputFile) outputFile.initializeOutputFile(), self.outputFiles);
             % arrayfun( @(outputFile) outputFile.writeTimeStepToOutputFile(self.t), self.outputFiles);
 
-            self.wvt.restoreForcingAmplitudes();
-            
+            try
+                self.wvt.restoreForcingAmplitudes();
 
-            if self.nFluxComponents == 0
-                self.pseudoIntegrateToTime(finalTime);
-            elseif strcmp(self.integratorType,"adaptive")
-                self.integrateToTimeWithAdaptiveTimeStep(finalTime)
-            elseif strcmp(self.integratorType,"adaptive-cell")
-                self.integrateToTimeWithAdaptiveTimeStepCell(finalTime)
-            else
-                self.integrateToTimeWithFixedTimeStep(finalTime);
+                if self.nFluxComponents == 0
+                    self.pseudoIntegrateToTime(finalTime);
+                elseif strcmp(self.integratorType,"adaptive")
+                    self.integrateToTimeWithAdaptiveTimeStep(finalTime)
+                elseif strcmp(self.integratorType,"adaptive-cell")
+                    self.integrateToTimeWithAdaptiveTimeStepCell(finalTime)
+                else
+                    self.integrateToTimeWithFixedTimeStep(finalTime);
+                end
+
+                self.recordNetCDFFileHistory();
+            catch exception
+                self.finalIntegrationTime = [];
+                self.integrationCallback = [];
+                outputFiles_ = self.outputFiles;
+                for iFile = 1:length(outputFiles_)
+                    try
+                        outputFiles_(iFile).closeNetCDFFile();
+                    catch closeException
+                        exception = addCause(exception,closeException);
+                    end
+                end
+                rethrow(exception)
             end
-
-            self.recordNetCDFFileHistory();            
         end
 
 
@@ -994,7 +1021,7 @@ classdef WVModel < handle & WVModelAdapativeTimeStepMethods & WVModelFixedTimeSt
             for iFile = 1:length(outputFiles_)
                 integratorTimes = cat(1,integratorTimes,outputFiles_(iFile).outputTimesForIntegrationPeriod(initialTime,finalTime));
             end
-            integratorTimes = sort(uniquetol(integratorTimes));
+            integratorTimes = unique(integratorTimes,"sorted");
             if isempty(integratorTimes) || integratorTimes(1) ~= self.t
                 integratorTimes = cat(1,self.t,integratorTimes);
             end

--- a/@WVModel/modelFromFile.m
+++ b/@WVModel/modelFromFile.m
@@ -2,8 +2,14 @@ function model = modelFromFile(path)
 % Initialize a model from an existing file
 %
 % A WVModel will be initialized from the specified path. The model will
-% have this file designated as its outputFile. Integrating the model will
-% thus write to this file.
+% have this file designated as its only output file. All groups in that
+% file are restored, but other files previously written by the same model
+% are not reconstructed. The file must contain one complete coefficient
+% stream. Linear versus nonlinear dynamics is restored when the model
+% metadata is present; older files retain the nonlinear default.
+%
+% Runtime integrator objects are not persisted. Configure the desired
+% fixed or adaptive integrator before continuing the restored model.
 %
 % - Topic: Initialization
 % - Declaration: model = modelFromFile(path)
@@ -12,8 +18,15 @@ function model = modelFromFile(path)
         path char {mustBeFile}
     end
 
-    wvt = WVTransform.waveVortexTransformFromFile(path,iTime=Inf,shouldReadOnly=true);
-    model = WVModel(wvt);
+    [wvt,reader] = WVTransform.waveVortexTransformFromFile(path,iTime=Inf,shouldReadOnly=true);
+    readerCleanup = onCleanup(@()closeNetCDFFileIfOpen(reader));
+    isDynamicsLinear = false;
+    if isKey(reader.attributes,'WVModelIsDynamicsLinear')
+        isDynamicsLinear = logical(reader.attributes('WVModelIsDynamicsLinear'));
+    end
+    model = WVModel(wvt,shouldUseLinearDynamics=isDynamicsLinear);
+    reader.close();
+    clear readerCleanup
     ncfile = NetCDFFile(path,shouldReadOnly=false);
     try
         outputFile = WVModelOutputFile.modelOutputFileFromFile(ncfile,model);
@@ -23,5 +36,12 @@ function model = modelFromFile(path)
             ncfile.close();
         end
         rethrow(exception)
+    end
+end
+
+
+function closeNetCDFFileIfOpen(ncfile)
+    if ~isempty(ncfile) && isvalid(ncfile) && ~isempty(ncfile.id)
+        ncfile.close();
     end
 end

--- a/@WVTransform/initFromNetCDFFile.m
+++ b/@WVTransform/initFromNetCDFFile.m
@@ -36,11 +36,30 @@ end
 
 wvt.t0 = ncfile.readVariables('t0');
 
+coefficientNames = {};
+if wvt.hasWaveComponent
+    coefficientNames = {'Ap','Am'};
+end
+if wvt.hasPVComponent
+    coefficientNames{end+1} = 'A0';
+end
+stateVariableNames = {};
+if ~isempty(coefficientNames) && all(ncfile.hasVariableWithName(coefficientNames{:}))
+    stateVariableNames = coefficientNames;
+elseif all(ncfile.hasVariableWithName('u','v','eta'))
+    stateVariableNames = {'u','v','eta'};
+elseif ncfile.hasVariableWithName('A0')
+    stateVariableNames = {'A0'};
+end
+stateGroup = ncfile;
+if ~isempty(stateVariableNames)
+    stateGroup = commonVariableGroup(ncfile,stateVariableNames);
+end
+
 hasTimeDimension = 0;
-if ncfile.hasDimensionWithName('t')
+if stateGroup.hasDimensionWithName('t') && stateGroup.hasVariableWithName('t')
     hasTimeDimension = 1;
-    varPaths =cellstr(ncfile.variablePathsWithName('t'));
-    tDim = ncfile.readVariables(varPaths{:});
+    tDim = stateGroup.readVariables('t');
     if isinf(options.iTime)
         iTime = length(tDim);
     elseif options.iTime > length(tDim)
@@ -50,33 +69,33 @@ if ncfile.hasDimensionWithName('t')
     end
     wvt.t = tDim(iTime);
 else
-    wvt.t = ncfile.readVariables('t');
+    wvt.t = stateGroup.readVariables('t');
 end
 
-if all(ncfile.hasVariableWithName('Ap','Am','A0'))
+if all(ismember({'Ap','Am','A0'},stateVariableNames))
     if hasTimeDimension == 1
-        [wvt.A0,wvt.Ap,wvt.Am] = ncfile.readVariablesAtIndexAlongDimension('t',iTime,'A0','Ap','Am');
+        [wvt.A0,wvt.Ap,wvt.Am] = stateGroup.readVariablesAtIndexAlongDimension('t',iTime,'A0','Ap','Am');
     else
-        [wvt.A0,wvt.Ap,wvt.Am] = ncfile.readVariables('A0','Ap','Am');
+        [wvt.A0,wvt.Ap,wvt.Am] = stateGroup.readVariables('A0','Ap','Am');
     end
     if options.shouldDisplayInit == 1
         fprintf('%s initialized from Ap, Am, A0.\n',ncfile.attributes('WVTransform'));
     end
-elseif all(ncfile.hasVariableWithName('u','v','eta'))
+elseif all(ismember({'u','v','eta'},stateVariableNames))
     if hasTimeDimension == 1
-        [u,v,eta] = ncfile.readVariablesAtIndexAlongDimension('t',iTime,'u','v','eta');
+        [u,v,eta] = stateGroup.readVariablesAtIndexAlongDimension('t',iTime,'u','v','eta');
     else
-        [u,v,eta] = ncfile.readVariables('u','v','eta');
+        [u,v,eta] = stateGroup.readVariables('u','v','eta');
     end
     [wvt.Ap,wvt.Am,wvt.A0] = wvt.transformUVEtaToWaveVortex(u,v,eta);
     if options.shouldDisplayInit == 1
         fprintf('%s initialized from u, u, eta.\n',ncfile.attributes('WVTransform'));
     end
-elseif all(ncfile.hasVariableWithName('A0'))
+elseif isequal(stateVariableNames,{'A0'})
     if hasTimeDimension == 1
-        wvt.A0 = reshape(ncfile.readVariablesAtIndexAlongDimension('t',iTime,'A0'),wvt.spectralMatrixSize);
+        wvt.A0 = reshape(stateGroup.readVariablesAtIndexAlongDimension('t',iTime,'A0'),wvt.spectralMatrixSize);
     else
-        wvt.A0 = ncfile.readVariables('A0');
+        wvt.A0 = stateGroup.readVariables('A0');
     end
     if options.shouldDisplayInit == 1
         fprintf('%s initialized from A0.\n',ncfile.attributes('AnnotatedClass'));
@@ -85,4 +104,24 @@ else
     warning('%s initialized without data.\n',ncfile.attributes('AnnotatedClass'));
 end
 
+end
+
+function group = commonVariableGroup(ncfile,variableNames)
+variables = cell(1,length(variableNames));
+for iVariable = 1:length(variableNames)
+    paths = ncfile.variablePathsWithName(variableNames{iVariable});
+    if length(paths) ~= 1
+        error('A restart file must contain exactly one %s state variable, but %d were found.',variableNames{iVariable},length(paths));
+    end
+    variables{iVariable} = ncfile.variableWithName(char(paths));
+end
+group = variables{1}.group;
+for iVariable = 2:length(variables)
+    if variables{iVariable}.group ~= group
+        error('The restart state variables must be stored together in one NetCDF group.');
+    end
+end
+if ~group.hasVariableWithName('t')
+    error('The NetCDF group containing the restart state does not contain time.');
+end
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Stabilized model-output scheduling and NetCDF restart across multiple files and groups; preserved linear dynamics and shared observing systems; and made initialization, writing, restoration, and handle ownership exception-safe.
 - Made operation registration, replacement, and removal atomic and identity-based; corrected multiple-output lookup; and made cache invalidation follow each operation's declared time and coefficient dependencies.
 - Made forcing registration identity-based, deterministic, and atomic; preserved vertical-diffusivity, fixed-amplitude, and explicit-antialias configurations through resolution changes and NetCDF restoration; and rejected vertical diffusivity on barotropic transforms.
 - Corrected observing-system ownership and composition, linear-time flux evaluation, particle tolerance and tracked-field propagation, and periodic one-based mooring indexing.

--- a/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file-advanced.md
+++ b/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file-advanced.md
@@ -9,31 +9,37 @@ has_toc: true
 
 #  Reading and writing to file, advanced topics
 
-The `WVModel` supports a number of advanced features for writing to file, including
-- multiple output files
-- groups within files with different output intervals
-- groups that start and stop at different time points
+The `WVModel` supports multiple output files, groups with different output intervals, and groups that start and stop at different model times.
 
 With these features, it is possible to setup up numerical simulations that "observe" the ocean in different ways, at different intervals. For example, you might place moorings in your simulation that sample the velocity field at a high frequency. You might setup a series of drifter experiments, that deploy and retrieve drifters every five days.
 
-There are three classes that work together to write to file,
-- `WVModelObservingSystem` - classes that describe different ways of observing the fluid, may or may not require integration
-- `WVModelOutputFile` - a representation of a file to be written to disk; has one more output groups
-- `WVModelOutputGroup` - a netcdf group that writes to file at certain output times; has one or more observing systems
+There are three classes that work together to write to file:
 
-Any `WVModelObservingSystem` instances that require integration, will also be held onto the model, which will integrate the observign system as necessary.
+- `WVObservingSystem` describes a way of observing the fluid and may or may not require integration.
+- `WVModelOutputFile` represents one file on disk and owns one or more output groups.
+- `WVModelOutputGroup` writes one or more observing systems at its scheduled output times.
+
+Any `WVObservingSystem` that requires integration is also held by the model. The same integrated observer handle may be written by multiple groups, including groups with different sampling intervals.
 
 
-## WVModelObservingSystem
+## WVObservingSystem
 
 Observing systems include, e.g., the wave-vortex coefficients, Eulerian fields, Lagrangian particles, tracers, mooring, and satellite along-track data.
 
-Subclasses of `WVModelObservingSystem` describe whether or not the observing system needs to be integrated (fluxed) in time by the model, and how to write to a group (an instance of `WVModelOutputGroup`) if desired. Some observing seems are only fluxed (e.g., the `WVCoefficients` system is used to integrate the wave-vortex coefficients) and do not write to file, while other observing system are not fluxed (e.g., `WVMooring`) but do write to file. Some of the observing systems require a specific subclasses of `WVModelOutputGroup` in order to write to file and set `requiresCustomOutputTimes` to `true`. For example, the `WVAlongTrackObservingSystem` can only write to the `WVModelOutputGroupAlongTrack` because it requires specific output times that are tied to the details of the satellite oribits.
+Subclasses of `WVObservingSystem` describe whether the observing system needs to be integrated in time and how it writes to a `WVModelOutputGroup`. `WVCoefficients` participates in model integration while coefficient storage is provided by the Eulerian field observer. `WVMooring` writes sampled fields without adding integrated state. `WVLagrangianParticles` and `WVTracer` both add integrated state and write their latest state to output.
 
 ## WVModelOutputFile
 
-After you create a `WVModel` instance, you may add one more `WVModelOutputFile`. Output files are conceptually very simple as they simply represent files on disk. Importantly, they hold onto one or more output groups, instances of `WVModelOutputGroup`, and internally they orchestrate pausing the model and writing to groups.
+After creating a `WVModel`, you may add one or more `WVModelOutputFile` instances. The model combines their requested output times so coincident times are integrated once and delivered to every file and group that requested them.
+
+Each file is an independent restart boundary. `WVModel.modelFromFile(path)` restores the supplied file and all of its groups; it does not reconstruct other files that the original model may also have written. A restart-capable file must contain exactly one group with the complete coefficient stream (`Ap`, `Am`, and `A0` for wave-bearing transforms, or `A0` for QG transforms). Other groups may store fields and observing systems without duplicating that complete coefficient stream.
+
+The file records whether the model used linear or nonlinear dynamics. Files written before that metadata was introduced retain the historical nonlinear restart default. Integrator objects are runtime configuration and must be configured again after restoration.
 
 ## WVModelOutputGroup
 
-The most useful `WVModelOutputGroup` subclass is the `WVModelOutputGroupEvenlySpaced`, which outputs at a fixed interval, but with user specified initial and final times. 
+The most useful `WVModelOutputGroup` subclass is `WVModelOutputGroupEvenlySpaced`, which writes on the lattice `initialTime + k*outputInterval` within the inclusive initial and final bounds. Repeated and segmented integrations remain anchored to that original lattice, and an already written time is not written again.
+
+When an integrated observer is shared by multiple groups, restoration reconnects those groups to one canonical observer handle. At least one of the groups must contain that observer at the coefficient restart time; otherwise the file does not contain a consistent restart state.
+
+Output initialization is transactional. If a group cannot initialize, WaveVortexModel closes and removes the newly created partial file and resets the output objects so the operation can be retried. If a later time-step write fails, all model-owned file handles are closed and the existing file is preserved for inspection. NetCDF does not provide transactional rollback of a partially written time record, so such a file should not be treated as a valid restart until inspected.

--- a/ObservingSystems/WVEulerianFields.m
+++ b/ObservingSystems/WVEulerianFields.m
@@ -39,7 +39,7 @@ classdef WVEulerianFields < WVObservingSystem
             % group.
             if ~isfield(options,"fieldNames")
                 options.fieldNames = {};
-            elseif isa(options.fieldNames,"string")
+            elseif ischar(options.fieldNames) || isstring(options.fieldNames)
                 options.fieldNames = cellstr(options.fieldNames);
             end
             self@WVObservingSystem(model,"eulerian fields");

--- a/ObservingSystems/WVLagrangianParticles.m
+++ b/ObservingSystems/WVLagrangianParticles.m
@@ -52,7 +52,7 @@ classdef WVLagrangianParticles < WVObservingSystem
             self@WVObservingSystem(model,options.name);
             if ~isfield(options,"trackedFieldNames")
                 options.trackedFieldNames = {};
-            elseif isa(options.trackedFieldNames,"string")
+            elseif ischar(options.trackedFieldNames) || isstring(options.trackedFieldNames)
                 options.trackedFieldNames = cellstr(options.trackedFieldNames);
             end
 
@@ -73,9 +73,9 @@ classdef WVLagrangianParticles < WVObservingSystem
                 end
             end
 
-            self.x = options.x;
-            self.y = options.y;
-            self.z = options.z;
+            self.x = reshape(options.x,1,[]);
+            self.y = reshape(options.y,1,[]);
+            self.z = reshape(options.z,1,[]);
             self.isXYOnly = options.isXYOnly;
             self.trackedFieldNamesCell = options.trackedFieldNames;
             self.trackedVarInterpolation = options.trackedVarInterpolation;
@@ -263,6 +263,8 @@ classdef WVLagrangianParticles < WVObservingSystem
             vars.y = parentGroup.readVariablesAtIndexAlongDimension('t',nPoints,vars.name+"_y");
             if ~isequal(model.wvt.spatialDimensionNames,{'x','y'})
                 vars.z = parentGroup.readVariablesAtIndexAlongDimension('t',nPoints,vars.name+"_z");
+            else
+                vars.z = [];
             end
 
             options = namedargs2cell(vars);

--- a/ObservingSystems/WVMooring.m
+++ b/ObservingSystems/WVMooring.m
@@ -41,7 +41,7 @@ classdef WVMooring < WVObservingSystem
 
             if ~isfield(options,"trackedFieldNames")
                 options.trackedFieldNames = {"u","v","w","eta","rho_e"};
-            elseif isa(options.trackedFieldNames,"string")
+            elseif ischar(options.trackedFieldNames) || isstring(options.trackedFieldNames)
                 options.trackedFieldNames = cellstr(options.trackedFieldNames);
             end
             % Confirm that we really can track these variables.

--- a/UnitTests/TestNetCDFHandleOwnership.m
+++ b/UnitTests/TestNetCDFHandleOwnership.m
@@ -118,6 +118,67 @@ classdef TestNetCDFHandleOwnership < matlab.unittest.TestCase
             ncfile.close();
             clear fileCleanup cleanup
         end
+
+        function initializationFailureRollsBackAndAllowsRetry(testCase)
+            path = fullfile(testCase.tempFolder,"initialization-failure.nc");
+            model = WVModel(TestNetCDFHandleOwnership.newTransform(),shouldUseLinearDynamics=true);
+            outputFile = model.createNetCDFFileForModelOutput(path,outputInterval=1,shouldOverwriteExisting=true);
+            outputGroup = outputFile.outputGroups(1);
+            failingObserver = WVFailingObservingSystem(model,failurePhase="initialize");
+            outputGroup.addObservingSystem(failingObserver);
+
+            testCase.verifyError(@()model.integrateToTime(1,shouldShowIntegrationDiagnostics=false,callback=@(~)[]),'')
+            testCase.verifyFalse(isfile(path))
+            testCase.verifyFalse(outputFile.didInitializeStorage)
+            testCase.verifyEmpty(outputFile.ncfile)
+            testCase.verifyFalse(outputGroup.didInitializeStorage)
+            testCase.verifyEmpty(outputGroup.group)
+            testCase.verifyEqual(outputGroup.incrementsWrittenToGroup,uint64(0))
+            testCase.verifyEqual(outputGroup.timeOfLastIncrementWrittenToGroup,-Inf)
+
+            outputGroup.removeObservingSystem(failingObserver);
+            model.integrateToTime(1,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            model.closeNetCDFFile();
+            testCase.verifyTrue(isfile(path))
+            TestNetCDFHandleOwnership.verifyWritableOpen(testCase,path);
+        end
+
+        function writeFailureClosesAndPreservesFile(testCase)
+            path = fullfile(testCase.tempFolder,"write-failure.nc");
+            model = WVModel(TestNetCDFHandleOwnership.newTransform(),shouldUseLinearDynamics=true);
+            outputFile = model.createNetCDFFileForModelOutput(path,outputInterval=1,shouldOverwriteExisting=true);
+            outputFile.outputGroups(1).addObservingSystem(WVFailingObservingSystem(model,failurePhase="write"));
+
+            testCase.verifyError(@()model.integrateToTime(1,shouldShowIntegrationDiagnostics=false,callback=@(~)[]),'')
+            testCase.verifyTrue(isfile(path))
+            testCase.verifyEmpty(outputFile.ncfile)
+            TestNetCDFHandleOwnership.verifyWritableOpen(testCase,path);
+        end
+
+        function observerRestorationFailureClosesWriter(testCase)
+            path = fullfile(testCase.tempFolder,"restoration-failure.nc");
+            model = WVModel(TestNetCDFHandleOwnership.newTransform(),shouldUseLinearDynamics=true);
+            model.createNetCDFFileForModelOutput(path,outputInterval=1,shouldOverwriteExisting=true);
+            model.integrateToTime(1,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            model.closeNetCDFFile();
+
+            ncfile = NetCDFFile(path,shouldReadOnly=false);
+            cleanup = onCleanup(@()TestNetCDFHandleOwnership.closeIfOpen(ncfile));
+            observerGroup = TestNetCDFHandleOwnership.groupWithAnnotatedClass(ncfile,'WVEulerianFields');
+            testCase.assertNotEmpty(observerGroup)
+            observerGroup.addAttribute('AnnotatedClass','UnavailableObservingSystem');
+            ncfile.close();
+            clear cleanup
+
+            didThrow = false;
+            try
+                WVModel.modelFromFile(char(path));
+            catch
+                didThrow = true;
+            end
+            testCase.verifyTrue(didThrow)
+            TestNetCDFHandleOwnership.verifyWritableOpen(testCase,path);
+        end
     end
 
     methods (Static, Access=private)
@@ -156,6 +217,21 @@ classdef TestNetCDFHandleOwnership < matlab.unittest.TestCase
         function closeIfOpen(ncfile)
             if ~isempty(ncfile) && isvalid(ncfile) && ~isempty(ncfile.id)
                 ncfile.close();
+            end
+        end
+
+        function matchingGroup = groupWithAnnotatedClass(group,className)
+            matchingGroup = NetCDFGroup.empty(0,0);
+            for iGroup = 1:length(group.groups)
+                candidate = group.groups(iGroup);
+                if isKey(candidate.attributes,'AnnotatedClass') && strcmp(candidate.attributes('AnnotatedClass'),className)
+                    matchingGroup = candidate;
+                    return
+                end
+                matchingGroup = TestNetCDFHandleOwnership.groupWithAnnotatedClass(candidate,className);
+                if ~isempty(matchingGroup)
+                    return
+                end
             end
         end
     end

--- a/UnitTests/TestWVModelOutputPersistence.m
+++ b/UnitTests/TestWVModelOutputPersistence.m
@@ -1,0 +1,313 @@
+classdef TestWVModelOutputPersistence < matlab.unittest.TestCase
+    properties (TestParameter)
+        integratorType = struct(fixed="fixed",adaptive="adaptive")
+    end
+
+    properties
+        tempFolder string
+    end
+
+    methods (TestMethodSetup)
+        function createTemporaryFolder(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            testCase.tempFolder = string(fixture.Folder);
+        end
+    end
+
+    methods (Test, TestTags="full")
+        function outputRegistrationIsIdentityBasedAndAtomic(testCase)
+            model = TestWVModelOutputPersistence.linearModel();
+            otherModel = TestWVModelOutputPersistence.linearModel();
+            path = fullfile(testCase.tempFolder,"registered.nc");
+            outputFile = WVModelOutputFile(model,path);
+            model.addOutputFile(outputFile);
+            model.addOutputFile(outputFile);
+            testCase.verifyTrue(model.outputFileWithName("registered.nc") == outputFile)
+
+            duplicateFile = WVModelOutputFile(model,fullfile(testCase.tempFolder,"other","registered.nc"));
+            foreignFile = WVModelOutputFile(otherModel,fullfile(testCase.tempFolder,"foreign.nc"));
+            testCase.verifyError(@()model.addOutputFile(duplicateFile),'')
+            testCase.verifyError(@()model.addOutputFile(foreignFile),'')
+            testCase.verifyEqual(model.outputFileNames,"registered.nc")
+
+            outputGroup = WVModelOutputGroupEvenlySpaced(model,name="group",outputInterval=1);
+            outputFile.addOutputGroup(outputGroup);
+            outputFile.addOutputGroup(outputGroup);
+            testCase.verifyTrue(outputFile.outputGroupWithName("group") == outputGroup)
+            duplicateGroup = WVModelOutputGroupEvenlySpaced(model,name="group",outputInterval=2);
+            foreignGroup = WVModelOutputGroupEvenlySpaced(otherModel,name="foreign",outputInterval=1);
+            testCase.verifyError(@()outputFile.addOutputGroup(duplicateGroup),'')
+            testCase.verifyError(@()outputFile.addOutputGroup(foreignGroup),'')
+            testCase.verifyEqual(outputFile.outputGroupNames,"group")
+            testCase.verifyError(@()model.outputFileWithName("missing"),'')
+            testCase.verifyError(@()outputFile.outputGroupWithName("missing"),'')
+        end
+
+        function schedulesRemainAnchoredAcrossFilesGroupsAndCalls(testCase)
+            model = TestWVModelOutputPersistence.linearModel();
+            pathA = fullfile(testCase.tempFolder,"schedule-a.nc");
+            pathB = fullfile(testCase.tempFolder,"schedule-b.nc");
+
+            fileA = model.addNewOutputFile(pathA,shouldOverwriteExisting=true);
+            groupA = fileA.addNewEvenlySpacedOutputGroup("bounded",initialTime=0.2,finalTime=1.1,outputInterval=0.3);
+            groupA.addObservingSystem(WVEulerianFields(model,fieldNames={'u'}));
+            groupB = fileA.addNewEvenlySpacedOutputGroup("coincident",initialTime=0,finalTime=0.8,outputInterval=0.2);
+            groupB.addObservingSystem(WVEulerianFields(model,fieldNames={'v'}));
+
+            fileB = model.addNewOutputFile(pathB,shouldOverwriteExisting=true);
+            groupC = fileB.addNewEvenlySpacedOutputGroup("second-file",initialTime=0.1,finalTime=1.1,outputInterval=0.5);
+            groupC.addObservingSystem(WVEulerianFields(model,fieldNames={'u'}));
+
+            model.integrateToTime(0.55,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            model.integrateToTime(1.1,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            model.closeNetCDFFile();
+
+            testCase.verifyEqual(TestWVModelOutputPersistence.readVariable(pathA,'bounded/t'),0.2+(0:3).'*0.3)
+            testCase.verifyEqual(TestWVModelOutputPersistence.readVariable(pathA,'coincident/t'),(0:4).'*0.2)
+            testCase.verifyEqual(TestWVModelOutputPersistence.readVariable(pathB,'second-file/t'),0.1+(0:2).'*0.5)
+            TestWVModelOutputPersistence.verifyTimeVector(testCase,TestWVModelOutputPersistence.readVariable(pathA,'bounded/t'),0.2,1.1)
+            TestWVModelOutputPersistence.verifyTimeVector(testCase,TestWVModelOutputPersistence.readVariable(pathA,'coincident/t'),0,0.8)
+            TestWVModelOutputPersistence.verifyTimeVector(testCase,TestWVModelOutputPersistence.readVariable(pathB,'second-file/t'),0.1,1.1)
+        end
+
+        function stableObserversRoundTripWithSharedIntegratedHandles(testCase)
+            path = fullfile(testCase.tempFolder,"all-observers.nc");
+            model = TestWVModelOutputPersistence.nonlinearModel();
+            outputFile = model.createNetCDFFileForModelOutput(path,outputInterval=1,shouldOverwriteExisting=true);
+            model.eulerianObservingSystem.addNetCDFOutputVariables('u');
+            model.setFloatPositions([500 1500],[400 1200],[-250 -750],'u',advectionInterpolation="spline",trackedVarInterpolation="linear",absToleranceXY=3e-4,absToleranceZ=7e-5);
+            model.addTracer(reshape(1:prod(model.wvt.spatialMatrixSize),model.wvt.spatialMatrixSize),"dye");
+            defaultGroup = outputFile.outputGroupWithName(model.defaultOutputGroupName());
+            mooring = WVMooring(model,name="mooring",x=[0 1000],y=[0 900],trackedFieldNames={'u'});
+            defaultGroup.addObservingSystem(mooring);
+            particles = model.fluxedObservingSystemWithName("float");
+            tracer = model.fluxedObservingSystemWithName("dye");
+            sharedGroup = outputFile.addNewEvenlySpacedOutputGroup("shared",outputInterval=1);
+            sharedGroup.addObservingSystem([particles tracer]);
+
+            model.setupIntegrator(integratorType="fixed",deltaT=1);
+            model.wvCoefficientFluxedObservingSystem().absTolerance = 3e-8;
+            model.integrateToTime(2,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            expectedU = model.wvt.u;
+            expectedMooringU = zeros(model.wvt.Nz,length(mooring.x));
+            for iMooring = 1:length(mooring.x)
+                expectedMooringU(:,iMooring) = expectedU(mooring.x_index(iMooring),mooring.y_index(iMooring),:);
+            end
+            expectedParticles = particles.initialConditions();
+            expectedTracer = tracer.phi;
+            model.closeNetCDFFile();
+
+            storedU = TestWVModelOutputPersistence.readVariable(path,'wave-vortex/u');
+            storedMooringU = TestWVModelOutputPersistence.readVariable(path,'wave-vortex/mooring_u');
+            testCase.verifyEqual(storedU(:,:,:,end),expectedU)
+            testCase.verifyEqual(storedMooringU(:,:,end),expectedMooringU)
+
+            TestWVModelOutputPersistence.verifySchema(testCase,path);
+            restored = WVModel.modelFromFile(char(path));
+            cleanup = onCleanup(@()restored.closeNetCDFFile());
+
+            testCase.verifyFalse(restored.isDynamicsLinear)
+            testCase.verifyEqual(restored.wvt.t,2)
+            testCase.verifyClass(restored.wvt.forcingWithName("adaptive damping"),"WVAdaptiveDamping")
+            testCase.verifyEqual(sort(restored.outputFileNames),"all-observers.nc")
+            restoredFile = restored.outputFileWithName("all-observers.nc");
+            restoredGroupNames = restoredFile.outputGroupNames();
+            testCase.verifyEqual(sort(restoredGroupNames(:)),sort(["wave-vortex"; "shared"]))
+            restoredDefault = restoredFile.outputGroupWithName("wave-vortex");
+            restoredShared = restoredFile.outputGroupWithName("shared");
+            testCase.verifyEqual(restoredDefault.outputInterval,1)
+            testCase.verifyEqual(restoredDefault.initialTime,0)
+            testCase.verifyEqual(restoredDefault.finalTime,Inf)
+            testCase.verifyEqual(restoredDefault.incrementsWrittenToGroup,uint64(3))
+            testCase.verifyEqual(restoredDefault.timeOfLastIncrementWrittenToGroup,2)
+            testCase.verifyEqual(restoredShared.incrementsWrittenToGroup,uint64(3))
+
+            restoredEulerian = restoredDefault.observingSystemWithName("eulerian fields");
+            testCase.verifyEqual(sort(restoredEulerian.fieldNames),sort(["A0" "Am" "Ap" "u"]))
+            restoredCoefficients = restoredDefault.observingSystemWithName("wave-vortex coefficient flux");
+            testCase.verifyTrue(restoredCoefficients == restored.wvCoefficientFluxedObservingSystem())
+            testCase.verifyEqual(restoredCoefficients.absTolerance,3e-8)
+
+            restoredParticles = restoredDefault.observingSystemWithName("float");
+            sharedParticles = restoredShared.observingSystemWithName("float");
+            testCase.verifyTrue(restoredParticles == sharedParticles)
+            testCase.verifyEqual(restoredParticles.initialConditions(),expectedParticles)
+            testCase.verifyEqual(restoredParticles.advectionInterpolation,'spline')
+            testCase.verifyEqual(restoredParticles.trackedVarInterpolation,'linear')
+            testCase.verifyEqual(restoredParticles.absToleranceXY,3e-4)
+            testCase.verifyEqual(restoredParticles.absToleranceZ,7e-5)
+            testCase.verifyEqual(restoredParticles.trackedFieldNames,"u")
+
+            restoredTracer = restoredDefault.observingSystemWithName("dye");
+            testCase.verifyTrue(restoredTracer == restoredShared.observingSystemWithName("dye"))
+            testCase.verifyEqual(restoredTracer.phi,expectedTracer)
+            restoredMooring = restoredDefault.observingSystemWithName("mooring");
+            testCase.verifyEqual(restoredMooring.x,[0 1000])
+            testCase.verifyEqual(restoredMooring.y,[0 900])
+            testCase.verifyEqual(restoredMooring.x_index,[1 3])
+            testCase.verifyEqual(restoredMooring.y_index,[1 2])
+            testCase.verifyEqual(restoredMooring.trackedFieldNames,"u")
+
+            restored.closeNetCDFFile();
+            clear cleanup
+            TestWVModelOutputPersistence.verifyWritableOpen(path);
+        end
+
+        function barotropicParticlesAndTracerRoundTrip(testCase)
+            path = fullfile(testCase.tempFolder,"barotropic.nc");
+            wvt = WVTransformBarotropicQG([4000 3000],[8 6],latitude=45,shouldAntialias=false);
+            model = WVModel(wvt,shouldUseLinearDynamics=true);
+            model.createNetCDFFileForModelOutput(path,outputInterval=1,shouldOverwriteExisting=true);
+            model.setDrifterPositions([0 100],[0 200],[],'u',absToleranceXY=9e-4);
+            phi = reshape(1:prod(wvt.spatialMatrixSize),wvt.spatialMatrixSize);
+            model.addTracer(phi,"dye");
+            model.setupIntegrator(integratorType="fixed",deltaT=1);
+            model.integrateToTime(1,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            model.closeNetCDFFile();
+
+            restored = WVModel.modelFromFile(char(path));
+            cleanup = onCleanup(@()restored.closeNetCDFFile());
+            testCase.verifyTrue(restored.isDynamicsLinear)
+            testCase.verifyFalse(any(arrayfun(@(observer)isa(observer,'WVCoefficients'),restored.fluxedObservingSystems)))
+            drifter = restored.fluxedObservingSystemWithName("drifter");
+            testCase.verifyTrue(drifter.isXYOnly)
+            testCase.verifyEmpty(drifter.z)
+            testCase.verifyEqual(drifter.x,[0 100])
+            testCase.verifyEqual(drifter.y,[0 200])
+            testCase.verifyEqual(drifter.absToleranceXY,9e-4)
+            testCase.verifyEqual(restored.fluxedObservingSystemWithName("dye").phi,phi)
+            restored.closeNetCDFFile();
+            clear cleanup
+        end
+
+        function eachOutputFileRestoresOnlyItsOwnGraph(testCase)
+            model = TestWVModelOutputPersistence.nonlinearModel();
+            pathA = fullfile(testCase.tempFolder,"restart-a.nc");
+            pathB = fullfile(testCase.tempFolder,"restart-b.nc");
+            model.createNetCDFFileForModelOutput(pathA,outputInterval=1,shouldOverwriteExisting=true);
+            model.createNetCDFFileForModelOutput(pathB,outputInterval=1,shouldOverwriteExisting=true);
+            model.setupIntegrator(integratorType="fixed",deltaT=1);
+            model.integrateToTime(1,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            model.closeNetCDFFile();
+
+            restoredA = WVModel.modelFromFile(char(pathA));
+            cleanupA = onCleanup(@()restoredA.closeNetCDFFile());
+            restoredB = WVModel.modelFromFile(char(pathB));
+            cleanupB = onCleanup(@()restoredB.closeNetCDFFile());
+            testCase.verifyEqual(restoredA.outputFileNames,"restart-a.nc")
+            testCase.verifyEqual(restoredB.outputFileNames,"restart-b.nc")
+            testCase.verifyEqual(restoredA.wvt.t,1)
+            testCase.verifyEqual(restoredB.wvt.t,1)
+            restoredA.closeNetCDFFile();
+            restoredB.closeNetCDFFile();
+            clear cleanupA cleanupB
+        end
+
+        function restartedObserversMatchUninterruptedControl(testCase,integratorType)
+            checkpointTime = 300;
+            finalTime = 600;
+            uninterrupted = TestWVModelOutputPersistence.observerIntegrationModel();
+            checkpoint = TestWVModelOutputPersistence.observerIntegrationModel();
+            TestWVModelOutputPersistence.configureIntegrator(uninterrupted,integratorType);
+            TestWVModelOutputPersistence.configureIntegrator(checkpoint,integratorType);
+            path = fullfile(testCase.tempFolder,"observer-restart-"+integratorType+".nc");
+            checkpoint.createNetCDFFileForModelOutput(path,outputInterval=checkpointTime,shouldOverwriteExisting=true);
+
+            uninterrupted.integrateToTime(finalTime,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            checkpoint.integrateToTime(checkpointTime,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+            checkpoint.closeNetCDFFile();
+
+            resumed = WVModel.modelFromFile(char(path));
+            cleanup = onCleanup(@()resumed.closeNetCDFFile());
+            testCase.verifyTrue(resumed.isDynamicsLinear)
+            TestWVModelOutputPersistence.configureIntegrator(resumed,integratorType);
+            resumed.integrateToTime(finalTime,shouldShowIntegrationDiagnostics=false,callback=@(~)[]);
+
+            [actualX,actualY,actualZ,actualTracked] = resumed.floatPositions();
+            [expectedX,expectedY,expectedZ,expectedTracked] = uninterrupted.floatPositions();
+            testCase.verifyEqual(resumed.wvt.t,finalTime)
+            testCase.verifyEqual(actualX,expectedX,AbsTol=2e-6)
+            testCase.verifyEqual(actualY,expectedY,AbsTol=2e-6)
+            testCase.verifyEqual(actualZ,expectedZ,AbsTol=2e-10)
+            testCase.verifyEqual(actualTracked.u,expectedTracked.u,AbsTol=2e-10)
+            testCase.verifyEqual(resumed.tracer("dye"),uninterrupted.tracer("dye"),AbsTol=5e-6)
+            testCase.verifyEqual(resumed.wvt.totalEnergy,uninterrupted.wvt.totalEnergy,RelTol=1e-12)
+            resumed.closeNetCDFFile();
+            clear cleanup
+            testCase.verifyEqual(TestWVModelOutputPersistence.readVariable(path,'wave-vortex/t'),[0; checkpointTime; finalTime])
+        end
+    end
+
+    methods (Static, Access=private)
+        function model = linearModel()
+            wvt = WVTransformConstantStratification([4000 3000 1000],[8 6 5],N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=false);
+            wvt.initWithInertialMotions(@(z)0.1*ones(size(z)),@(z)zeros(size(z)));
+            model = WVModel(wvt,shouldUseLinearDynamics=true);
+        end
+
+        function model = nonlinearModel()
+            wvt = WVTransformConstantStratification([4000 3000 1000],[8 6 5],N0=sqrt(2e-5),latitude=45,isHydrostatic=false,shouldAntialias=false);
+            wvt.addForcing(WVAdaptiveDamping(wvt));
+            model = WVModel(wvt);
+        end
+
+        function model = observerIntegrationModel()
+            model = TestWVModelOutputPersistence.linearModel();
+            model.setFloatPositions([500 1500],[400 1200],[-250 -750],'u',absToleranceXY=1e-8,absToleranceZ=1e-8);
+            phi = sin(2*pi*model.wvt.X/model.wvt.Lx);
+            model.addTracer(phi,"dye");
+        end
+
+        function configureIntegrator(model,integratorType)
+            if integratorType == "fixed"
+                model.setupIntegrator(integratorType="fixed",deltaT=10);
+            else
+                model.setupIntegrator(integratorType="adaptive",relTolerance=1e-10);
+            end
+        end
+
+        function value = readVariable(path,name)
+            ncfile = NetCDFFile(path,shouldReadOnly=true);
+            cleanup = onCleanup(@()TestWVModelOutputPersistence.closeIfOpen(ncfile));
+            value = ncfile.readVariables(name);
+            ncfile.close();
+            clear cleanup
+        end
+
+        function verifyTimeVector(testCase,t,initialTime,finalTime)
+            testCase.verifyEqual(t,sort(t))
+            testCase.verifyEqual(length(t),length(unique(t)))
+            testCase.verifyGreaterThanOrEqual(t,initialTime)
+            testCase.verifyLessThanOrEqual(t,finalTime)
+        end
+
+        function verifySchema(testCase,path)
+            ncfile = NetCDFFile(path,shouldReadOnly=true);
+            cleanup = onCleanup(@()TestWVModelOutputPersistence.closeIfOpen(ncfile));
+            testCase.verifyEqual(ncfile.attributes('WVModelIsDynamicsLinear'),uint8(0))
+            group = ncfile.groupWithName('wave-vortex');
+            testCase.verifyEqual(group.attributes('AnnotatedClass'),'WVModelOutputGroupEvenlySpaced')
+            timeVariable = group.variableWithName('t');
+            testCase.verifyEqual(timeVariable.attributes('axis'),'T')
+            testCase.verifyEqual(timeVariable.attributes('calendar'),'standard')
+            testCase.verifyEqual(timeVariable.attributes('units'),'seconds since 1970-01-01 00:00:00')
+            testCase.verifyTrue(all(group.hasVariableWithName('Ap','Am','A0','u','float_x','float_y','float_z','float_u','dye','mooring_x','mooring_y','mooring_u')))
+            testCase.verifyEqual(group.dimensionWithName('t').nPoints,3)
+            ncfile.close();
+            clear cleanup
+        end
+
+        function verifyWritableOpen(path)
+            ncfile = NetCDFFile(path,shouldReadOnly=false);
+            cleanup = onCleanup(@()TestWVModelOutputPersistence.closeIfOpen(ncfile));
+            ncfile.close();
+            clear cleanup
+        end
+
+        function closeIfOpen(ncfile)
+            if ~isempty(ncfile) && isvalid(ncfile) && ~isempty(ncfile.id)
+                ncfile.close();
+            end
+        end
+    end
+end

--- a/UnitTests/WVFailingObservingSystem.m
+++ b/UnitTests/WVFailingObservingSystem.m
@@ -1,0 +1,42 @@
+classdef WVFailingObservingSystem < WVObservingSystem
+    properties (SetAccess=private)
+        failurePhase string
+    end
+
+    methods
+        function self = WVFailingObservingSystem(model,options)
+            arguments
+                model WVModel
+                options.name (1,1) string = "failing observer"
+                options.failurePhase (1,1) string {mustBeMember(options.failurePhase,["initialize","write"])} = "initialize"
+            end
+            self@WVObservingSystem(model,options.name);
+            self.failurePhase = options.failurePhase;
+        end
+
+        function initializeStorage(self,group)
+            if self.failurePhase == "initialize"
+                error('The test observing system failed during storage initialization.');
+            end
+            group.addVariable(self.name,{'t'},type="double",isComplex=false);
+        end
+
+        function writeTimeStepToFile(self,~,~)
+            if self.failurePhase == "write"
+                error('The test observing system failed while writing a time step.');
+            end
+        end
+    end
+
+    methods (Static)
+        function vars = classRequiredPropertyNames()
+            vars = {'name','failurePhase'};
+        end
+
+        function propertyAnnotations = classDefinedPropertyAnnotations()
+            propertyAnnotations = CAPropertyAnnotation.empty(0,0);
+            propertyAnnotations(end+1) = CAPropertyAnnotation('name','name of the deliberately failing observing system');
+            propertyAnnotations(end+1) = CAPropertyAnnotation('failurePhase','output phase in which the test observer throws');
+        end
+    end
+end

--- a/WVModelOutputFile.m
+++ b/WVModelOutputFile.m
@@ -166,10 +166,14 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
             % - Topic: Output groups
             arguments (Input)
                 self WVModelOutputFile {mustBeNonempty}
-                name char {mustBeNonempty}
+                name {mustBeText,mustBeNonempty}
             end
             arguments (Output)
                 val WVModelOutputGroup
+            end
+            name = string(name);
+            if ~isKey(self.outputGroupNameMap,name)
+                error('No output group named %s is registered with this file.',name);
             end
             val = self.outputGroupNameMap(name);
         end
@@ -180,7 +184,17 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
             % - Topic: Output groups
             arguments
                 self WVModelOutputFile {mustBeNonempty}
-                outputGroup WVModelOutputGroup
+                outputGroup (1,1) WVModelOutputGroup
+            end
+            if outputGroup.model ~= self.model
+                error('The output group %s was not initialized for this output file''s model.',outputGroup.name);
+            end
+            if isKey(self.outputGroupNameMap,outputGroup.name)
+                registeredGroup = self.outputGroupNameMap(outputGroup.name);
+                if registeredGroup == outputGroup
+                    return
+                end
+                error('A different output group named %s is already registered with this file.',outputGroup.name);
             end
             self.outputGroupNameMap(outputGroup.name) = outputGroup;
         end
@@ -251,7 +265,7 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
                 self.outputGroupNameOutputTimeMap{outputGroups_(iGroup).name} = t_group;
                 t = cat(1,t,t_group);
             end
-            t = sort(uniquetol(t));
+            t = unique(t,"sorted");
             if self.didInitializeStorage == false && ~isempty(t)
                 self.tInitialize = t(1);
             end
@@ -272,25 +286,30 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
                 t (1,1) double
             end
 
-            % 1) initialize the netcdf file if necessary
-            if self.didInitializeStorage == false && abs(t - self.tInitialize) < eps
-                self.initializeOutputFile();
-            end
-
-            % 2) inform the appropriate groups that they need to write a time step.
-            outputGroupNames = self.outputGroupNameOutputTimeMap.keys;
-            didWriteToFile = false;
-            for i = 1:length(outputGroupNames)
-                t_group = self.outputGroupNameOutputTimeMap{outputGroupNames(i)};
-                if ~isempty(t_group) && abs(t - t_group(1)) < eps
-                    self.outputGroupWithName(outputGroupNames(i)).writeTimeStepToNetCDFFile(self.ncfile,t);
-                    t_group(1) = [];
-                    self.outputGroupNameOutputTimeMap{outputGroupNames(i)} = t_group;
-                    didWriteToFile = true;
+            try
+                % 1) initialize the netcdf file if necessary
+                if self.didInitializeStorage == false && t == self.tInitialize
+                    self.initializeOutputFile();
                 end
-            end
-            if didWriteToFile
-                self.ncfile.sync();
+
+                % 2) inform the appropriate groups that they need to write a time step.
+                outputGroupNames = self.outputGroupNameOutputTimeMap.keys;
+                didWriteToFile = false;
+                for i = 1:length(outputGroupNames)
+                    t_group = self.outputGroupNameOutputTimeMap{outputGroupNames(i)};
+                    if ~isempty(t_group) && t == t_group(1)
+                        self.outputGroupWithName(outputGroupNames(i)).writeTimeStepToNetCDFFile(self.ncfile,t);
+                        t_group(1) = [];
+                        self.outputGroupNameOutputTimeMap{outputGroupNames(i)} = t_group;
+                        didWriteToFile = true;
+                    end
+                end
+                if didWriteToFile
+                    self.ncfile.sync();
+                end
+            catch exception
+                self.closeNetCDFFile();
+                rethrow(exception)
             end
         end
 
@@ -305,6 +324,10 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
             % writing the wave-vortex coefficients, we can neglect writing
             % those to file.
             %
+            % Initialization is transactional. If any group or observing
+            % system fails, the new file is closed and deleted and every
+            % storage object returns to its uninitialized state.
+            %
             % - Topic: Internal
             if self.observingSystemWillWriteWaveVortexCoefficients == true
                 properties = setdiff(self.wvt.requiredProperties,{'Ap','Am','A0','t'});
@@ -315,10 +338,34 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
             if isfile(self.path)
                 error('A file already exists at this path.');
             end
-            self.ncfile = self.wvt.writeToFile(self.path,properties{:},shouldOverwriteExisting=false,shouldAddRequiredProperties=false);
+            newFile = NetCDFFile.empty(0,0);
+            try
+                newFile = self.wvt.writeToFile(self.path,properties{:},shouldOverwriteExisting=false,shouldAddRequiredProperties=false);
+                newFile.addAttribute('WVModelIsDynamicsLinear',uint8(self.model.isDynamicsLinear));
+                outputGroups_ = self.outputGroups;
+                for iGroup = 1:length(outputGroups_)
+                    outputGroups_(iGroup).initializeOutputGroup(newFile);
+                end
+            catch exception
+                outputGroups_ = self.outputGroups;
+                for iGroup = 1:length(outputGroups_)
+                    outputGroups_(iGroup).group = NetCDFGroup.empty(0,0);
+                    outputGroups_(iGroup).incrementsWrittenToGroup = 0;
+                    outputGroups_(iGroup).timeOfLastIncrementWrittenToGroup = -Inf;
+                    outputGroups_(iGroup).didInitializeStorage = false;
+                end
+                if ~isempty(newFile) && isvalid(newFile) && ~isempty(newFile.id)
+                    newFile.close();
+                end
+                self.ncfile = NetCDFFile.empty(0,0);
+                self.didInitializeStorage = false;
+                if isfile(self.path)
+                    delete(self.path);
+                end
+                rethrow(exception)
+            end
+            self.ncfile = newFile;
             self.didInitializeStorage = true;
-
-            arrayfun( @(outputGroup) outputGroup.initializeOutputGroup(self.ncfile), self.outputGroups);
         end
 
         function bool = observingSystemWillWriteWaveVortexCoefficients(self)
@@ -355,13 +402,20 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
         function closeNetCDFFile(self)
             % closes the netcdf file after informing the output groups
             %
+            % The file handle is released even if an output-group cleanup
+            % notification fails.
+            %
             % - Topic: Internal
             if ~isempty(self.ncfile)
-                arrayfun( @(outputGroup) outputGroup.closeNetCDFFile(), self.outputGroups);
-                if ~isempty(self.ncfile.id)
-                    self.ncfile.close();
-                end
+                ownedFile = self.ncfile;
                 self.ncfile = NetCDFFile.empty(0,0);
+                cleanup = onCleanup(@()WVModelOutputFile.closeIfOpen(ownedFile));
+                outputGroups_ = self.outputGroups;
+                for iGroup = 1:length(outputGroups_)
+                    outputGroups_(iGroup).closeNetCDFFile();
+                end
+                WVModelOutputFile.closeIfOpen(ownedFile);
+                clear cleanup
             end
         end
 
@@ -384,6 +438,97 @@ classdef WVModelOutputFile < handle & matlab.mixin.Heterogeneous
                     className = group.attributes('AnnotatedClass');
                     if exist(className,'class') && ismember("WVModelOutputGroup",superclasses(className))
                         outputFile.addOutputGroup(WVModelOutputGroup.modelOutputGroupFromGroup(group,model));                        
+                    end
+                end
+            end
+            WVModelOutputFile.canonicalizeIntegratedObservingSystems(outputFile);
+        end
+    end
+
+    methods (Static, Access=private)
+        function closeIfOpen(ncfile)
+            if ~isempty(ncfile) && isvalid(ncfile) && ~isempty(ncfile.id)
+                ncfile.close();
+            end
+        end
+
+        function canonicalizeIntegratedObservingSystems(outputFile)
+            outputGroups_ = outputFile.outputGroups;
+            processedNames = configureDictionary("string","logical");
+            for iGroup = 1:length(outputGroups_)
+                for iObserver = 1:length(outputGroups_(iGroup).observingSystems)
+                    observer = outputGroups_(iGroup).observingSystems(iObserver);
+                    observerName = string(observer.name);
+                    if observer.nFluxComponents == 0 || isKey(processedNames,observerName)
+                        continue
+                    end
+                    processedNames(observerName) = true;
+
+                    [candidates,candidateGroups] = WVModelOutputFile.integratedObserverCandidates(outputGroups_,observerName);
+                    WVModelOutputFile.validateEquivalentObserverConfigurations(candidates);
+                    if isa(observer,'WVCoefficients')
+                        canonicalObserver = outputFile.model.wvCoefficientFluxedObservingSystem();
+                        if isempty(canonicalObserver)
+                            error('The restored output contains coefficients, but the model is configured for linear dynamics.');
+                        end
+                        canonicalObserver.absTolerance = candidates{1}.absTolerance;
+                    else
+                        candidateTimes = cellfun(@(group) group.timeOfLastIncrementWrittenToGroup,candidateGroups);
+                        timeTolerance = 8*eps(max(1,abs(outputFile.model.t)));
+                        currentStateIndices = find(abs(candidateTimes-outputFile.model.t) <= timeTolerance);
+                        if isempty(currentStateIndices)
+                            error('The integrated observing system %s has no saved state at the model restart time t=%g.',observerName,outputFile.model.t);
+                        end
+                        canonicalObserver = candidates{currentStateIndices(1)};
+                        canonicalState = canonicalObserver.initialConditions();
+                        for iCandidate = reshape(currentStateIndices(2:end),1,[])
+                            if ~isequaln(candidates{iCandidate}.initialConditions(),canonicalState)
+                                error('The output groups contain inconsistent saved states for observing system %s at t=%g.',observerName,outputFile.model.t);
+                            end
+                        end
+                        outputFile.model.addFluxedObservingSystem(canonicalObserver);
+                    end
+
+                    for iCandidate = 1:length(candidates)
+                        candidateGroup = candidateGroups{iCandidate};
+                        candidateIndex = find(arrayfun(@(existing) existing == candidates{iCandidate},candidateGroup.observingSystems),1);
+                        candidateGroup.observingSystems(candidateIndex) = canonicalObserver;
+                    end
+                end
+            end
+        end
+
+        function [candidates,candidateGroups] = integratedObserverCandidates(outputGroups,observerName)
+            maximumCandidateCount = sum(arrayfun(@(group)length(group.observingSystems),outputGroups));
+            candidates = cell(1,maximumCandidateCount);
+            candidateGroups = cell(1,maximumCandidateCount);
+            candidateCount = 0;
+            for iGroup = 1:length(outputGroups)
+                for iObserver = 1:length(outputGroups(iGroup).observingSystems)
+                    candidate = outputGroups(iGroup).observingSystems(iObserver);
+                    if candidate.nFluxComponents > 0 && string(candidate.name) == observerName
+                        candidateCount = candidateCount+1;
+                        candidates{candidateCount} = candidate;
+                        candidateGroups{candidateCount} = outputGroups(iGroup);
+                    end
+                end
+            end
+            candidates = candidates(1:candidateCount);
+            candidateGroups = candidateGroups(1:candidateCount);
+        end
+
+        function validateEquivalentObserverConfigurations(candidates)
+            reference = candidates{1};
+            requiredProperties = feval(strcat(class(reference),'.classRequiredPropertyNames'));
+            for iCandidate = 2:length(candidates)
+                candidate = candidates{iCandidate};
+                if ~strcmp(class(candidate),class(reference))
+                    error('Integrated observing systems named %s must have the same class in every output group.',reference.name);
+                end
+                for iProperty = 1:length(requiredProperties)
+                    propertyName = requiredProperties{iProperty};
+                    if ~isequaln(candidate.(propertyName),reference.(propertyName))
+                        error('Integrated observing systems named %s have inconsistent persisted configuration for %s.',reference.name,propertyName);
                     end
                 end
             end

--- a/WVModelOutputGroup.m
+++ b/WVModelOutputGroup.m
@@ -241,21 +241,29 @@ classdef WVModelOutputGroup < handle & matlab.mixin.Heterogeneous & CAAnnotatedC
             if self.didInitializeStorage
                 error('Storage already initialized!');
             end
-            self.group = ncfile.addGroup(self.name);
-            self.writeToGroup(self.group,self.propertyAnnotationWithName(self.requiredProperties));
+            try
+                self.group = ncfile.addGroup(self.name);
+                self.writeToGroup(self.group,self.propertyAnnotationWithName(self.requiredProperties));
 
-            varAnnotation = self.model.wvt.propertyAnnotationWithName('t');
-            varAnnotation.attributes('units') = varAnnotation.units;
-            varAnnotation.attributes('long_name') = varAnnotation.description;
-            varAnnotation.attributes('standard_name') = 'time';
-            varAnnotation.attributes('long_name') = 'time';
-            varAnnotation.attributes('units') = 'seconds since 1970-01-01 00:00:00';
-            varAnnotation.attributes('axis') = 'T';
-            varAnnotation.attributes('calendar') = 'standard';
-            self.group.addDimension(varAnnotation.name,length=Inf,type="double",attributes=varAnnotation.attributes);
+                varAnnotation = self.model.wvt.propertyAnnotationWithName('t');
+                varAnnotation.attributes('units') = varAnnotation.units;
+                varAnnotation.attributes('long_name') = varAnnotation.description;
+                varAnnotation.attributes('standard_name') = 'time';
+                varAnnotation.attributes('long_name') = 'time';
+                varAnnotation.attributes('units') = 'seconds since 1970-01-01 00:00:00';
+                varAnnotation.attributes('axis') = 'T';
+                varAnnotation.attributes('calendar') = 'standard';
+                self.group.addDimension(varAnnotation.name,length=Inf,type="double",attributes=varAnnotation.attributes);
 
-            for iObs = 1:length(self.observingSystems)
-                self.observingSystems(iObs).initializeStorage(self.group);
+                for iObs = 1:length(self.observingSystems)
+                    self.observingSystems(iObs).initializeStorage(self.group);
+                end
+            catch exception
+                self.group = NetCDFGroup.empty(0,0);
+                self.incrementsWrittenToGroup = 0;
+                self.timeOfLastIncrementWrittenToGroup = -Inf;
+                self.didInitializeStorage = false;
+                rethrow(exception)
             end
 
             self.incrementsWrittenToGroup = 0;
@@ -343,7 +351,7 @@ classdef WVModelOutputGroup < handle & matlab.mixin.Heterogeneous & CAAnnotatedC
 
             f = @(className,group) feval(strcat(className,'.observingSystemFromGroup'),group, self.model, self);
             vars = CAAnnotatedClass.propertyValuesFromGroup(outputGroup,{"observingSystems"},classConstructor=f);
-            self.addObservingSystem(vars.observingSystems);
+            self.observingSystems = vars.observingSystems;
         end
 
     end

--- a/WVModelOutputGroupEvenlySpaced.m
+++ b/WVModelOutputGroupEvenlySpaced.m
@@ -82,6 +82,14 @@ classdef WVModelOutputGroupEvenlySpaced < WVModelOutputGroup
         end
 
         function t = outputTimesForIntegrationPeriod(self,initialTime,finalTime)
+            % Return unwritten output times on the group's fixed time lattice.
+            %
+            % Times are generated from `initialTime + k*outputInterval`,
+            % bounded by the group and integration windows, and strictly
+            % later than the last written increment. Anchoring every call
+            % to the original lattice prevents segmented-run timing drift.
+            %
+            % - Topic: Integration
             arguments (Input)
                 self WVModelOutputGroup
                 initialTime (1,1) double
@@ -90,16 +98,40 @@ classdef WVModelOutputGroupEvenlySpaced < WVModelOutputGroup
             arguments (Output)
                 t (:,1) double
             end
-            % Two possibilities here either:
-            % 1) nothing is initialize, or 2) we already wrote to file
-            if self.timeOfLastIncrementWrittenToGroup == -Inf
-                t = (self.initialTime:self.outputInterval:finalTime).';
-            else
-                t = ((self.timeOfLastIncrementWrittenToGroup+self.outputInterval):self.outputInterval:finalTime).';
+            lowerTime = max(initialTime,self.initialTime);
+            upperTime = min(finalTime,self.finalTime);
+            if upperTime < lowerTime
+                t = zeros(0,1);
+                return
             end
-            t(t<initialTime) = [];
-            t(t<self.initialTime) = [];
-            t(t>self.finalTime) = [];
+
+            lowerIndex = (lowerTime-self.initialTime)/self.outputInterval;
+            lowerIndexTolerance = 8*eps(max(1,abs(lowerIndex)));
+            if abs(lowerIndex-round(lowerIndex)) <= lowerIndexTolerance
+                lowerIndex = round(lowerIndex);
+            end
+            firstIndex = max(0,ceil(lowerIndex));
+
+            if self.timeOfLastIncrementWrittenToGroup ~= -Inf
+                lastWrittenIndex = (self.timeOfLastIncrementWrittenToGroup-self.initialTime)/self.outputInterval;
+                lastWrittenIndexTolerance = 8*eps(max(1,abs(lastWrittenIndex)));
+                if abs(lastWrittenIndex-round(lastWrittenIndex)) <= lastWrittenIndexTolerance
+                    lastWrittenIndex = round(lastWrittenIndex);
+                end
+                firstIndex = max(firstIndex,floor(lastWrittenIndex)+1);
+            end
+
+            lastIndex = (upperTime-self.initialTime)/self.outputInterval;
+            lastIndexTolerance = 8*eps(max(1,abs(lastIndex)));
+            if abs(lastIndex-round(lastIndex)) <= lastIndexTolerance
+                lastIndex = round(lastIndex);
+            end
+            lastIndex = floor(lastIndex);
+            if lastIndex < firstIndex
+                t = zeros(0,1);
+            else
+                t = self.initialTime+(firstIndex:lastIndex).'*self.outputInterval;
+            end
         end
 
     end

--- a/docs/classes/model-output/wvmodeloutputfile/initializeoutputfile.md
+++ b/docs/classes/model-output/wvmodeloutputfile/initializeoutputfile.md
@@ -23,5 +23,9 @@ tells the output groups to initialize themselves in the NetCDF file
   we need to exclude `t`. Additionally, if we happen to also be
   writing the wave-vortex coefficients, we can neglect writing
   those to file.
+
+  Initialization is transactional. If any group or observing system
+  fails, the new file is closed and deleted and every storage object
+  returns to its uninitialized state.
  
   

--- a/docs/classes/wvmodel/modelfromfile.md
+++ b/docs/classes/wvmodel/modelfromfile.md
@@ -24,7 +24,13 @@ Initialize a model from an existing file
 ## Discussion
 
   A WVModel will be initialized from the specified path. The model will
-  have this file designated as its outputFile. Integrating the model will
-  thus write to this file.
+  have this file designated as its only output file. All groups in that
+  file are restored, but other files previously written by the same model
+  are not reconstructed. The file must contain one complete coefficient
+  stream. Linear versus nonlinear dynamics is restored when the model
+  metadata is present; older files retain the nonlinear default.
+
+  Runtime integrator objects are not persisted. Configure the desired
+  fixed or adaptive integrator before continuing the restored model.
  
       

--- a/docs/users-guide/reading-and-writing-to-file-advanced.md
+++ b/docs/users-guide/reading-and-writing-to-file-advanced.md
@@ -9,31 +9,37 @@ has_toc: true
 
 #  Reading and writing to file, advanced topics
 
-The `WVModel` supports a number of advanced features for writing to file, including
-- multiple output files
-- groups within files with different output intervals
-- groups that start and stop at different time points
+The `WVModel` supports multiple output files, groups with different output intervals, and groups that start and stop at different model times.
 
 With these features, it is possible to setup up numerical simulations that "observe" the ocean in different ways, at different intervals. For example, you might place moorings in your simulation that sample the velocity field at a high frequency. You might setup a series of drifter experiments, that deploy and retrieve drifters every five days.
 
-There are three classes that work together to write to file,
-- `WVModelObservingSystem` - classes that describe different ways of observing the fluid, may or may not require integration
-- `WVModelOutputFile` - a representation of a file to be written to disk; has one more output groups
-- `WVModelOutputGroup` - a netcdf group that writes to file at certain output times; has one or more observing systems
+There are three classes that work together to write to file:
 
-Any `WVModelObservingSystem` instances that require integration, will also be held onto the model, which will integrate the observign system as necessary.
+- `WVObservingSystem` describes a way of observing the fluid and may or may not require integration.
+- `WVModelOutputFile` represents one file on disk and owns one or more output groups.
+- `WVModelOutputGroup` writes one or more observing systems at its scheduled output times.
+
+Any `WVObservingSystem` that requires integration is also held by the model. The same integrated observer handle may be written by multiple groups, including groups with different sampling intervals.
 
 
-## WVModelObservingSystem
+## WVObservingSystem
 
 Observing systems include, e.g., the wave-vortex coefficients, Eulerian fields, Lagrangian particles, tracers, mooring, and satellite along-track data.
 
-Subclasses of `WVModelObservingSystem` describe whether or not the observing system needs to be integrated (fluxed) in time by the model, and how to write to a group (an instance of `WVModelOutputGroup`) if desired. Some observing seems are only fluxed (e.g., the `WVCoefficients` system is used to integrate the wave-vortex coefficients) and do not write to file, while other observing system are not fluxed (e.g., `WVMooring`) but do write to file. Some of the observing systems require a specific subclasses of `WVModelOutputGroup` in order to write to file and set `requiresCustomOutputTimes` to `true`. For example, the `WVAlongTrackObservingSystem` can only write to the `WVModelOutputGroupAlongTrack` because it requires specific output times that are tied to the details of the satellite oribits.
+Subclasses of `WVObservingSystem` describe whether the observing system needs to be integrated in time and how it writes to a `WVModelOutputGroup`. `WVCoefficients` participates in model integration while coefficient storage is provided by the Eulerian field observer. `WVMooring` writes sampled fields without adding integrated state. `WVLagrangianParticles` and `WVTracer` both add integrated state and write their latest state to output.
 
 ## WVModelOutputFile
 
-After you create a `WVModel` instance, you may add one more `WVModelOutputFile`. Output files are conceptually very simple as they simply represent files on disk. Importantly, they hold onto one or more output groups, instances of `WVModelOutputGroup`, and internally they orchestrate pausing the model and writing to groups.
+After creating a `WVModel`, you may add one or more `WVModelOutputFile` instances. The model combines their requested output times so coincident times are integrated once and delivered to every file and group that requested them.
+
+Each file is an independent restart boundary. `WVModel.modelFromFile(path)` restores the supplied file and all of its groups; it does not reconstruct other files that the original model may also have written. A restart-capable file must contain exactly one group with the complete coefficient stream (`Ap`, `Am`, and `A0` for wave-bearing transforms, or `A0` for QG transforms). Other groups may store fields and observing systems without duplicating that complete coefficient stream.
+
+The file records whether the model used linear or nonlinear dynamics. Files written before that metadata was introduced retain the historical nonlinear restart default. Integrator objects are runtime configuration and must be configured again after restoration.
 
 ## WVModelOutputGroup
 
-The most useful `WVModelOutputGroup` subclass is the `WVModelOutputGroupEvenlySpaced`, which outputs at a fixed interval, but with user specified initial and final times. 
+The most useful `WVModelOutputGroup` subclass is `WVModelOutputGroupEvenlySpaced`, which writes on the lattice `initialTime + k*outputInterval` within the inclusive initial and final bounds. Repeated and segmented integrations remain anchored to that original lattice, and an already written time is not written again.
+
+When an integrated observer is shared by multiple groups, restoration reconnects those groups to one canonical observer handle. At least one of the groups must contain that observer at the coefficient restart time; otherwise the file does not contain a consistent restart state.
+
+Output initialization is transactional. If a group cannot initialize, WaveVortexModel closes and removes the newly created partial file and resets the output objects so the operation can be retried. If a later time-step write fails, all model-owned file handles are closed and the existing file is preserved for inspection. NetCDF does not provide transactional rollback of a partially written time record, so such a file should not be treated as a valid restart until inspected.


### PR DESCRIPTION
Closes #41

Implements deterministic output scheduling, multi-file and multi-group persistence, linear-dynamics restoration, integrated-observer canonicalization, and exception-safe NetCDF ownership. Adds comprehensive 3-D and barotropic round-trip, restart, scheduling, and failure-path coverage, along with focused documentation updates.

Verification:
- smoke: passed
- full: 548/548, passed twice
- exhaustive: 2440/2440
- focused output and handle-safety tests: passed
- MATLAB analysis and repository checks: passed