### PR TITLE
Add correctness-focused analyzer gate

### DIFF
--- a/@WVGeometryDoublyPeriodic/transformToRadialWavenumber.m
+++ b/@WVGeometryDoublyPeriodic/transformToRadialWavenumber.m
@@ -64,11 +64,7 @@ if nK == 1
     edges  = [k(1)-dk, k(1)+dk];
 else
     mid    = 0.5*(k(1:end-1) + k(2:end));
-    left   = [k(1) - (k(2)-k(1))/2, mid];
-    right  = [mid, k(end) + (k(end)-k(end-1))/2];
-    edges  = [left(1), mid, right(end)];
-    % Compact form:
-    edges  = [-Inf, mid, +Inf];         % If you prefer open-ended ends
+    edges  = [-Inf, mid, +Inf];
 end
 
 % Assign each Kh to a radial bin

--- a/FlowComponents/WVInternalGravityWaveMethods.m
+++ b/FlowComponents/WVInternalGravityWaveMethods.m
@@ -630,7 +630,6 @@ classdef WVInternalGravityWaveMethods < handle
                     for i=1:M
                         ii = mod(M-i+1, M) + 1;
                         jj = mod(N-j+1, N) + 1;
-                        waveAmp = 0; wavePhase = 0;
                         if i == ii && j == jj
                             % self-conjugate term
                             if i == 1 && j == 1

--- a/Forcing/WVPseudoTopographicWaveGeneration.m
+++ b/Forcing/WVPseudoTopographicWaveGeneration.m
@@ -589,7 +589,7 @@ classdef WVPseudoTopographicWaveGeneration < WVForcing
                 propertyName = requiredPropertyNames{iProperty};
                 isPresent = group.hasVariableWithName(propertyName) || group.hasGroupWithName(propertyName) || isKey(group.attributes,propertyName);
                 if ~isPresent
-                    missingPropertyNames(end+1) = string(propertyName); %#ok<AGROW>
+                    missingPropertyNames(end+1) = string(propertyName);
                 end
             end
             if ~isempty(missingPropertyNames)

--- a/Integrators/ode45_cell.m
+++ b/Integrators/ode45_cell.m
@@ -164,7 +164,6 @@ while true
             break
         end
 
-        prev_t = new_t;
         prev_y = new_y;
 
         % Select correct derivative at the end of the step

--- a/UnitTests/TestProductionCodeAnalyzer.m
+++ b/UnitTests/TestProductionCodeAnalyzer.m
@@ -1,0 +1,113 @@
+classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
+    properties
+        repositoryRoot
+        productionReport
+        temporaryFolder
+    end
+
+    methods (TestClassSetup)
+        function analyzeProductionSource(testCase)
+            testCase.repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(fullfile(testCase.repositoryRoot,"tools")));
+            testCase.productionReport = analyzeProductionCode(testCase.repositoryRoot,ShouldPrint=false,ShouldFail=false);
+        end
+    end
+
+    methods (TestMethodSetup)
+        function createTemporaryFolder(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            testCase.temporaryFolder = string(fixture.Folder);
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function productionInventoryIsDeterministic(testCase)
+            files = testCase.productionReport.Files;
+            testCase.verifyNumElements(files,171);
+            testCase.verifyEqual(files,sort(unique(files)));
+            testCase.verifyTrue(all(isfile(fullfile(testCase.repositoryRoot,files))));
+
+            expectedFiles = [
+                "WVOperation.m"
+                "@WVTransform/WVTransform.m"
+                "FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m"
+                "Forcing/WVNonlinearAdvection.m"
+                "ObservingSystems/WVLagrangianParticles.m"
+                "Integrators/WVModelAdaptiveTimeStepMethods.m"
+                ];
+            testCase.verifyTrue(all(ismember(expectedFiles,files)));
+        end
+
+        function authoringAndLegacyAreasAreExcluded(testCase)
+            files = testCase.productionReport.Files;
+            excludedPrefixes = [
+                "UnitTests/"
+                "tools/"
+                "Documentation/"
+                "docs/"
+                "Benchmarks/"
+                "DeveloperExperiments/"
+                "OceanKit/"
+                ".buildtool/"
+                ];
+            for prefix = excludedPrefixes'
+                testCase.verifyFalse(any(startsWith(files,prefix)),"Unexpected analyzer input under " + prefix);
+            end
+            testCase.verifyFalse(any(files == "buildfile.m"));
+        end
+
+        function productionFindingsAreClassifiedAndNonblocking(testCase)
+            findings = testCase.productionReport.Findings;
+            testCase.verifyEmpty(testCase.productionReport.BlockingFindings);
+            testCase.verifyFalse(any(startsWith(findings.Classification,"blocking")));
+            testCase.verifyTrue(any(findings.CheckID == "AGROW" & findings.Classification == "performance"));
+            testCase.verifyTrue(any(findings.CheckID == "INUSD" & findings.Classification == "style"));
+            testCase.verifyTrue(any(findings.CheckID == "CTOINW" & findings.Classification == "accepted-false-positive"));
+            testCase.verifyTrue(any(findings.CheckID == "MCNPR" & findings.Classification == "accepted-false-positive"));
+            testCase.verifyFalse(any(findings.CheckID == "NASGU"));
+        end
+
+        function reportContainsReleaseLocationsAndDiagnostics(testCase)
+            output = evalc("analyzeProductionCode(testCase.repositoryRoot,ShouldFail=false);");
+            testCase.verifySubstring(output,"MATLAB Code Analyzer: release=R");
+            testCase.verifySubstring(output,"files=171");
+            testCase.verifySubstring(output,"[AGROW, performance]");
+            testCase.verifySubstring(output,"Variable appears to change size");
+            testCase.verifyFalse(contains(output,testCase.repositoryRoot));
+        end
+
+        function unreachableStatementBlocks(testCase)
+            fixturePath = testCase.writeUnreachableFixture("unreachableCode.m",false);
+            report = analyzeProductionCode(testCase.temporaryFolder,Files=fixturePath,ShouldPrint=false,ShouldFail=false);
+            testCase.verifyEqual(report.BlockingFindings.CheckID,"UNRCH");
+            testCase.verifyEqual(report.BlockingFindings.RelativeFile,"unreachableCode.m");
+            testCase.verifyFalse(report.BlockingFindings.Suppressed);
+            testCase.verifyError(@()analyzeProductionCode(testCase.temporaryFolder,Files=fixturePath,ShouldPrint=false),"WaveVortexModel:CodeAnalyzerFailed");
+        end
+
+        function suppressedUnreachableStatementStillBlocks(testCase)
+            fixturePath = testCase.writeUnreachableFixture("suppressedUnreachableCode.m",true);
+            report = analyzeProductionCode(testCase.temporaryFolder,Files=fixturePath,ShouldPrint=false,ShouldFail=false);
+            testCase.verifyEqual(report.BlockingFindings.CheckID,"UNRCH");
+            testCase.verifyTrue(report.BlockingFindings.Suppressed);
+            testCase.verifyError(@()analyzeProductionCode(testCase.temporaryFolder,Files=fixturePath,ShouldPrint=false),"WaveVortexModel:CodeAnalyzerFailed");
+        end
+    end
+
+    methods (Access=private)
+        function fixturePath = writeUnreachableFixture(testCase,name,shouldSuppress)
+            unreachableStatement = "y = x + 1;";
+            if shouldSuppress
+                unreachableStatement = unreachableStatement + " %#ok<UNRCH>";
+            end
+            fixturePath = fullfile(testCase.temporaryFolder,name);
+            writelines([
+                "function y = " + erase(name,".m") + "(x)"
+                "y = x;"
+                "return"
+                unreachableStatement
+                "end"
+                ],fixturePath);
+        end
+    end
+end

--- a/buildfile.m
+++ b/buildfile.m
@@ -11,7 +11,18 @@ tasks = [
 
 plan = buildplan;
 plan("test") = TaskGroup(tasks,TaskNames=["smoke"; "full"; "exhaustive"; "optional"],Description="Run WaveVortexModel test categories.");
+plan("analyze") = Task(Actions=@analyzeTask,Description="Analyze production MATLAB source for correctness findings.",DisableIncremental=true);
 plan.DefaultTasks = "test:smoke";
+end
+
+function analyzeTask(~)
+repositoryRoot = fileparts(mfilename("fullpath"));
+toolsFolder = fullfile(repositoryRoot,"tools");
+originalPath = path;
+pathCleanup = onCleanup(@()path(originalPath));
+addpath(toolsFolder);
+analyzeProductionCode(repositoryRoot);
+clear pathCleanup
 end
 
 function testSmokeTask(~)

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,13 @@
+# Authoring tools
+
+The canonical production-source analysis command is:
+
+```matlab
+buildtool analyze
+```
+
+The task analyzes root runtime files, root class folders, and runtime folders declared in `resources/mpackage.json`. It excludes `UnitTests`, documentation, benchmarks, developer experiments, legacy archives, released snapshots, and authoring tools.
+
+The analyzer uses MATLAB's factory configuration and reports active and suppressed findings. Preallocation and established interface-style advice are visible but nonblocking. The centralized policy in `analyzeProductionCode.m` also records the narrowly accepted multiple-inheritance false positives. Analyzer errors, correctness findings, and unfamiliar identifiers block until reviewed and classified.
+
+Do not add `%#ok` annotations merely to make this report empty. Suppressed correctness findings remain blocking.

--- a/tools/analyzeProductionCode.m
+++ b/tools/analyzeProductionCode.m
@@ -1,0 +1,162 @@
+function report = analyzeProductionCode(repositoryRoot,options)
+% analyzeProductionCode Analyze the WaveVortexModel production runtime.
+%
+% report = analyzeProductionCode(repositoryRoot) runs MATLAB Code Analyzer
+% with its factory configuration, reports every active and suppressed
+% finding, and fails when a correctness or unclassified finding remains.
+%
+% This is an authoring tool rather than WaveVortexModel runtime API.
+
+arguments
+    repositoryRoot (1,1) string {mustBeFolder}
+    options.Files string = strings(0,1)
+    options.ShouldPrint (1,1) logical = true
+    options.ShouldFail (1,1) logical = true
+end
+
+files = reshape(options.Files,[],1);
+if isempty(files)
+    files = productionCodeFiles(repositoryRoot);
+else
+    files = sort(unique(files));
+end
+if isempty(files)
+    error("WaveVortexModel:EmptyCodeAnalyzerInventory","No MATLAB production files were selected for analysis.");
+end
+
+analysis = codeIssues(files,CodeAnalyzerConfiguration="factory");
+activeFindings = normalizedFindings(analysis.Issues,false,repositoryRoot);
+suppressedFindings = normalizedFindings(analysis.SuppressedIssues,true,repositoryRoot);
+findings = [activeFindings; suppressedFindings];
+if ~isempty(findings)
+    findings = sortrows(findings,["RelativeFile" "Line" "Column" "CheckID" "Suppressed"]);
+    [findings.Classification,findings.Rationale] = classifyFindings(findings);
+end
+
+blockingMask = startsWith(findings.Classification,"blocking");
+relativeFiles = relativePaths(string(analysis.Files),repositoryRoot);
+report = struct( ...
+    Release=string(analysis.Release), ...
+    Files=sort(relativeFiles), ...
+    Findings=findings, ...
+    BlockingFindings=findings(blockingMask,:), ...
+    NonblockingFindings=findings(~blockingMask,:));
+
+if options.ShouldPrint
+    printReport(report);
+end
+if options.ShouldFail && ~isempty(report.BlockingFindings)
+    error("WaveVortexModel:CodeAnalyzerFailed","MATLAB Code Analyzer found %d blocking production finding(s).",height(report.BlockingFindings));
+end
+end
+
+function files = productionCodeFiles(repositoryRoot)
+rootEntries = dir(fullfile(repositoryRoot,"*.m"));
+rootFiles = string(fullfile({rootEntries.folder},{rootEntries.name}))';
+rootFiles(endsWith(rootFiles,filesep+"buildfile.m")) = [];
+
+classDirectories = dir(fullfile(repositoryRoot,"@*"));
+classDirectories = classDirectories([classDirectories.isdir]);
+classFilesByDirectory = cell(numel(classDirectories),1);
+for iDirectory = 1:numel(classDirectories)
+    classFilesByDirectory{iDirectory} = matlabFilesUnder(fullfile(classDirectories(iDirectory).folder,classDirectories(iDirectory).name));
+end
+classFiles = vertcat(classFilesByDirectory{:});
+
+manifest = jsondecode(fileread(fullfile(repositoryRoot,"resources","mpackage.json")));
+runtimeFolders = string({manifest.folders.path})';
+runtimeFolders(runtimeFolders == "UnitTests") = [];
+folderFilesByDirectory = cell(numel(runtimeFolders),1);
+for iFolder = 1:numel(runtimeFolders)
+    folderFilesByDirectory{iFolder} = matlabFilesUnder(fullfile(repositoryRoot,runtimeFolders(iFolder)));
+end
+folderFiles = vertcat(folderFilesByDirectory{:});
+
+files = sort(unique([rootFiles; classFiles; folderFiles]));
+end
+
+function files = matlabFilesUnder(folder)
+entries = dir(fullfile(folder,"**","*.m"));
+files = string(fullfile({entries.folder},{entries.name}))';
+end
+
+function findings = normalizedFindings(issueTable,isSuppressed,repositoryRoot)
+if isempty(issueTable)
+    findings = table( ...
+        strings(0,1),strings(0,1),zeros(0,1),zeros(0,1),strings(0,1),strings(0,1),false(0,1),strings(0,1),strings(0,1), ...
+        VariableNames=["RelativeFile" "CheckID" "Line" "Column" "Severity" "Diagnostic" "Suppressed" "Classification" "Rationale"]);
+    return
+end
+
+relativeFile = relativePaths(string(issueTable.FullFilename),repositoryRoot);
+checkID = string(issueTable.CheckID);
+line = double(issueTable.LineStart);
+column = double(issueTable.ColumnStart);
+severity = string(issueTable.Severity);
+diagnostic = string(issueTable.Description);
+suppressed = repmat(isSuppressed,height(issueTable),1);
+classification = strings(height(issueTable),1);
+rationale = strings(height(issueTable),1);
+findings = table(relativeFile,checkID,line,column,severity,diagnostic,suppressed,classification,rationale, ...
+    VariableNames=["RelativeFile" "CheckID" "Line" "Column" "Severity" "Diagnostic" "Suppressed" "Classification" "Rationale"]);
+end
+
+function relative = relativePaths(files,repositoryRoot)
+files = reshape(files,[],1);
+rootPrefix = repositoryRoot + filesep;
+relative = files;
+insideRoot = startsWith(files,rootPrefix);
+relative(insideRoot) = extractAfter(files(insideRoot),strlength(rootPrefix));
+relative = replace(relative,filesep,"/");
+end
+
+function [classification,rationale] = classifyFindings(findings)
+classification = repmat("blocking-unclassified",height(findings),1);
+rationale = repmat("Unclassified findings require review before they can become nonblocking.",height(findings),1);
+
+performanceMask = findings.CheckID == "AGROW";
+classification(performanceMask) = "performance";
+rationale(performanceMask) = "Dynamic allocation is visible performance advice and is not a correctness failure.";
+
+styleMask = ismember(findings.CheckID,["INUSA" "INUSD" "MANU" "PROP"]);
+classification(styleMask) = "style";
+rationale(styleMask) = "Unused callback or interface inputs and property-name clarity advice are nonblocking style findings.";
+
+geostrophicConstructorMask = findings.CheckID == "CTOINW" & findings.RelativeFile == "FlowComponents/WVGeostrophicMethods.m";
+classification(geostrophicConstructorMask) = "accepted-false-positive";
+rationale(geostrophicConstructorMask) = "The mixin constructor intentionally receives the already constructed transform during multiple-inheritance initialization.";
+
+inertialPropertyMask = findings.CheckID == "MCNPR" & findings.RelativeFile == "FlowComponents/WVInertialOscillationMethods.m" & ...
+    (contains(findings.Diagnostic,"'Ap'") | contains(findings.Diagnostic,"'Am'") | contains(findings.Diagnostic,"'A0'"));
+mdaPropertyMask = findings.CheckID == "MCNPR" & findings.RelativeFile == "FlowComponents/WVMeanDensityAnomalyMethods.m" & contains(findings.Diagnostic,"'A0'");
+inheritedPropertyMask = inertialPropertyMask | mdaPropertyMask;
+classification(inheritedPropertyMask) = "accepted-false-positive";
+rationale(inheritedPropertyMask) = "Ap, Am, and A0 are supplied by the composed transform hierarchy and are not visible to analysis of the mixin alone.";
+
+errorMask = findings.Severity == "error";
+classification(errorMask) = "blocking-error";
+rationale(errorMask) = "MATLAB Code Analyzer errors always block, even when their identifier is otherwise nonblocking.";
+end
+
+function printReport(report)
+nSuppressed = nnz(report.Findings.Suppressed);
+nActive = height(report.Findings) - nSuppressed;
+fprintf("MATLAB Code Analyzer: release=%s, files=%d, active=%d, suppressed=%d, blocking=%d\n", ...
+    report.Release,numel(report.Files),nActive,nSuppressed,height(report.BlockingFindings));
+
+for iFinding = 1:height(report.Findings)
+    finding = report.Findings(iFinding,:);
+    suppressionText = "";
+    if finding.Suppressed
+        suppressionText = ", suppressed";
+    end
+    fprintf("%s:%d:%d [%s, %s%s] %s\n",finding.RelativeFile,finding.Line,finding.Column, ...
+        finding.CheckID,finding.Classification,suppressionText,finding.Diagnostic);
+end
+
+classifications = unique(report.Findings.Classification,"stable");
+for iClassification = 1:numel(classifications)
+    classification = classifications(iClassification);
+    fprintf("  %s: %d\n",classification,nnz(report.Findings.Classification == classification));
+end
+end


### PR DESCRIPTION
## Summary

- add a canonical `buildtool analyze` task over the 171-file production runtime surface
- classify style, performance, and narrowly reviewed mixin findings while failing closed on correctness and unknown identifiers
- include active and suppressed findings, remove four dead assignments, and expose the remaining preallocation advice without suppression
- add focused tests proving ordinary and suppressed unreachable code both fail the gate

## Verification

- `buildtool analyze`: 268 visible findings, 0 suppressed, 0 blocking
- focused analyzer tests: 6 passed
- `buildtool test:smoke`: 127 passed
- `buildtool test:full`: 568 passed twice
- `buildtool test:exhaustive`: 2,440 passed
- changed-file analysis, whitespace, manifest, documentation-mirror, repository-scope, generated-artifact, warning, and NetCDF-handle checks

R2024b is not installed on the local host. Verification used R2026a with APIs available at the declared R2024b compatibility floor.

Closes #56
