### PR TITLE
Add extensible WaveVortex benchmark framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.asv
 *.mat
 *.nc
+Benchmarks/results/runs/
 *.nc

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,9 +1,29 @@
 # Benchmarks
 
-This folder contains manual profiling and timing scripts for package authors. It is not an automated-test root and is not included on the WaveVortexModel runtime package path.
+This folder contains authoring-only performance tools and historical profiling scripts. It is not included on the WaveVortexModel runtime package path.
 
-Benchmark results depend on the MATLAB release, available toolboxes and backends, hardware, grid configuration, and runtime state. Treat the scripts as performance investigations rather than correctness or release gates, and inspect their computational cost before running them.
+## Reproducible benchmark suites
 
-`WVTransformConstantStratificationSpeedTest` measures nonlinear-flux performance over several large constant-stratification grids and may require substantial memory and runtime.
+`runWaveVortexBenchmark` is the canonical performance and memory entry point. It measures a state-advanced `nonlinearFlux()` call while retaining ordinary production caches. State changes use the public `t`, `Ap`, `Am`, and `A0` setters; the runner never clears the variable cache explicitly.
 
-Deterministic correctness checks belong in `UnitTests`; mixed scientific investigations and historical scripts belong in `DeveloperExperiments`.
+```matlab
+addpath("Benchmarks")
+results = runWaveVortexBenchmark(suites="core-v1")
+```
+
+The registered suites are:
+
+- `smoke-v1`: small cases for every transform family; no score.
+- `core-v1`: the canonical constant-stratification nonlinear-advection score.
+- `scaling-standard-v1`: standard horizontal and vertical scaling across transform families.
+- `scaling-large-v1`: fixed large-memory scaling cases.
+
+The runner accepts more than one suite and a subset of case IDs. Suite definitions are versioned in `waveVortexBenchmarkSuites`; changing a case matrix or score definition requires a new suite version. Backends are selected independently from transform families through `waveVortexBenchmarkBackends`.
+
+Every scored case is normalized against its matching committed builtin reference. Case score 100 matches the reference. Family and suite scores use geometric means, with transform families weighted equally. Same-host builtin-to-candidate speedups are reported separately.
+
+Ordinary artifacts are written beneath the ignored `results/runs` directory. Immutable reference artifacts live beneath `results/reference`. Memory measurements use a fresh MATLAB process and report baseline, persistent, and peak-observed resident memory; these process measurements include MATLAB runtime and allocator behavior.
+
+The large suites can require substantial time and memory. A partial result is valid, but a family or suite receives no aggregate score unless every required case completes.
+
+`WVTransformConstantStratificationSpeedTest`, `ProfileableSpeedTest`, and `ForcingSpectralMaskPerformanceTest` remain historical investigation scripts. Deterministic correctness checks belong in `UnitTests`; mixed scientific investigations belong in `DeveloperExperiments`.

--- a/Benchmarks/advanceWaveVortexBenchmarkState.m
+++ b/Benchmarks/advanceWaveVortexBenchmarkState.m
@@ -1,0 +1,19 @@
+function advanceWaveVortexBenchmarkState(wvt,state,iState)
+% Advance through public state setters without explicitly clearing caches.
+arguments
+    wvt WVTransform
+    state (1,1) struct
+    iState (1,1) double {mustBeInteger,mustBeNonnegative}
+end
+theta = 0.017*iState;
+wvt.t = state.t0 + 30*iState;
+if ~isempty(state.Ap)
+    wvt.Ap = state.Ap.*exp(1i*theta);
+end
+if ~isempty(state.Am)
+    wvt.Am = state.Am.*exp(-1i*theta);
+end
+if ~isempty(state.A0)
+    wvt.A0 = state.A0.*exp(1i*theta/3);
+end
+end

--- a/Benchmarks/createWaveVortexBenchmarkTransform.m
+++ b/Benchmarks/createWaveVortexBenchmarkTransform.m
@@ -1,0 +1,32 @@
+function wvt = createWaveVortexBenchmarkTransform(benchmarkCase,backendId)
+% Construct one registered transform/backend benchmark candidate.
+arguments
+    benchmarkCase (1,1) struct
+    backendId (1,1) string = "builtin"
+end
+if backendId ~= "builtin"
+    error("WaveVortexBenchmark:UnsupportedBackend","Backend %s is not registered for transform construction.",backendId);
+end
+
+switch benchmarkCase.transformId
+    case "constant-nonhydrostatic"
+        wvt = WVTransformConstantStratification(benchmarkCase.Lxyz,benchmarkCase.Nxyz,isHydrostatic=false,shouldAntialias=benchmarkCase.shouldAntialias);
+    case "constant-hydrostatic"
+        wvt = WVTransformConstantStratification(benchmarkCase.Lxyz,benchmarkCase.Nxyz,isHydrostatic=true,shouldAntialias=benchmarkCase.shouldAntialias);
+    case "hydrostatic"
+        wvt = WVTransformHydrostatic(benchmarkCase.Lxyz,benchmarkCase.Nxyz,N2=@benchmarkN2,shouldAntialias=benchmarkCase.shouldAntialias);
+    case "boussinesq"
+        wvt = WVTransformBoussinesq(benchmarkCase.Lxyz,benchmarkCase.Nxyz,N2=@benchmarkN2,shouldAntialias=benchmarkCase.shouldAntialias);
+    case "stratified-qg"
+        wvt = WVTransformStratifiedQG(benchmarkCase.Lxyz,benchmarkCase.Nxyz,N2=@benchmarkN2,shouldAntialias=benchmarkCase.shouldAntialias);
+    case "barotropic-qg"
+        wvt = WVTransformBarotropicQG(benchmarkCase.Lxyz,benchmarkCase.Nxyz,shouldAntialias=benchmarkCase.shouldAntialias);
+    otherwise
+        error("WaveVortexBenchmark:UnknownTransform","Unknown transform ID %s.",benchmarkCase.transformId);
+end
+end
+
+function N2 = benchmarkN2(z)
+N0 = 5.2e-3;
+N2 = N0*N0*ones(size(z));
+end

--- a/Benchmarks/executeWaveVortexBenchmarkOperation.m
+++ b/Benchmarks/executeWaveVortexBenchmarkOperation.m
@@ -1,0 +1,18 @@
+function outputs = executeWaveVortexBenchmarkOperation(wvt,operationId)
+% Execute one registered benchmark operation and return comparable outputs.
+arguments
+    wvt WVTransform
+    operationId (1,1) string
+end
+switch operationId
+    case "nonlinearAdvection"
+        if isa(wvt,"WVTransformBarotropicQG") || isa(wvt,"WVTransformStratifiedQG")
+            outputs = {wvt.nonlinearFlux()};
+        else
+            [Fp,Fm,F0] = wvt.nonlinearFlux();
+            outputs = {Fp,Fm,F0};
+        end
+    otherwise
+        error("WaveVortexBenchmark:UnknownOperation","Unknown benchmark operation %s.",operationId);
+end
+end

--- a/Benchmarks/initializeWaveVortexBenchmarkState.m
+++ b/Benchmarks/initializeWaveVortexBenchmarkState.m
@@ -1,0 +1,19 @@
+function state = initializeWaveVortexBenchmarkState(wvt,seed)
+% Initialize and capture the deterministic canonical benchmark state.
+arguments
+    wvt WVTransform
+    seed (1,1) double
+end
+rng(seed,"twister");
+wvt.initWithRandomFlow(uvMax=0.01);
+state = struct("t0",wvt.t,"Ap",[],"Am",[],"A0",[]);
+if ~isempty(wvt.Ap)
+    state.Ap = wvt.Ap;
+end
+if ~isempty(wvt.Am)
+    state.Am = wvt.Am;
+end
+if ~isempty(wvt.A0)
+    state.A0 = wvt.A0;
+end
+end

--- a/Benchmarks/results/reference/core-v1-m5-max-r2026a-builtin/benchmark.json
+++ b/Benchmarks/results/reference/core-v1-m5-max-r2026a-builtin/benchmark.json
@@ -1,0 +1,324 @@
+{
+  "schemaVersion": "1.0.0",
+  "status": "complete",
+  "runId": "20260808T180426Z",
+  "environment": {
+    "os": "Darwin 25.5.0 Darwin Kernel Version 25.5.0: Tue Jun  9 22:28:34 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T6050 arm64",
+    "processor": "ABI64 ARM ARM64E",
+    "matlabVersion": "26.1.0.3312084 (R2026a) Update 4",
+    "matlabRelease": "2026a",
+    "architecture": "maca64",
+    "requestedThreads": 18,
+    "sourceCommit": "0d36eae79649c1f37e0dac4044fa5f83fb60fc1e",
+    "sourceDirty": false,
+    "physicalMemoryBytes": 5.1539607552E+10
+  },
+  "configuration": {
+    "suiteIds": "core-v1",
+    "backendIds": "builtin",
+    "correctnessTolerance": 1E-12,
+    "shouldMeasureMemory": true,
+    "caseIds": [
+      "constant-nonhydrostatic-256x256x65",
+      "constant-hydrostatic-256x256x65",
+      "constant-nonhydrostatic-512x512x129",
+      "constant-hydrostatic-512x512x129"
+    ]
+  },
+  "suites": {
+    "id": "core-v1",
+    "version": 1,
+    "description": "Canonical constant-stratification nonlinear-advection score",
+    "operation": "nonlinearAdvection",
+    "isScored": true,
+    "status": "complete",
+    "cases": [
+      {
+        "id": "constant-nonhydrostatic-256x256x65",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          65
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 2101,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.310059125,
+          "firstCallSeconds": 0.20757420833333334,
+          "sameStateCacheHitSeconds": 0.094857,
+          "rawSeconds": [
+            0.1432015,
+            0.132000375,
+            0.13622716666666668,
+            0.13010283333333333,
+            0.12871329166666667,
+            0.127057,
+            0.12886154166666666
+          ],
+          "medianSeconds": 0.13010283333333333,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.13010283333333333,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.60692736E+8,
+            "persistentBytes": 2.09682432E+9,
+            "peakBytes": 2.12303872E+9,
+            "persistentIncrementBytes": 1.336131584E+9,
+            "peakIncrementBytes": 1.362345984E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-256x256x65",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 2102,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.5052635,
+          "firstCallSeconds": 0.137880375,
+          "sameStateCacheHitSeconds": 0.072191458333333333,
+          "rawSeconds": [
+            0.11538325,
+            0.11699820833333334,
+            0.104822625,
+            0.10492541666666666,
+            0.10292783333333333,
+            0.10312408333333334,
+            0.10350870833333334
+          ],
+          "medianSeconds": 0.104822625,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.104822625,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.60741888E+8,
+            "persistentBytes": 2.042200064E+9,
+            "peakBytes": 2.069184512E+9,
+            "persistentIncrementBytes": 1.281458176E+9,
+            "peakIncrementBytes": 1.308442624E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-nonhydrostatic-512x512x129",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          512,
+          512,
+          129
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 2103,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.1096895416666666,
+          "firstCallSeconds": 1.2849771666666667,
+          "sameStateCacheHitSeconds": 0.85183604166666671,
+          "rawSeconds": [
+            1.1523589583333333,
+            1.157343875,
+            1.15664225
+          ],
+          "medianSeconds": 1.15664225,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 1.15664225,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.63265024E+8,
+            "persistentBytes": 8.491139072E+9,
+            "peakBytes": 8.684847104E+9,
+            "persistentIncrementBytes": 7.727874048E+9,
+            "peakIncrementBytes": 7.92158208E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-512x512x129",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          512,
+          512,
+          129
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 2104,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.0309864166666667,
+          "firstCallSeconds": 1.1039644166666667,
+          "sameStateCacheHitSeconds": 0.66547470833333333,
+          "rawSeconds": [
+            1.0258171666666667,
+            0.99306529166666668,
+            0.997666625
+          ],
+          "medianSeconds": 0.997666625,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.997666625,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.64346368E+8,
+            "persistentBytes": 7.962886144E+9,
+            "peakBytes": 8.158756864E+9,
+            "persistentIncrementBytes": 7.198539776E+9,
+            "peakIncrementBytes": 7.394410496E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      }
+    ],
+    "familyScores": [
+      {
+        "id": "constant-nonhydrostatic",
+        "backendId": "builtin",
+        "score": 100.00000000000004
+      },
+      {
+        "id": "constant-hydrostatic",
+        "backendId": "builtin",
+        "score": 100.00000000000004
+      }
+    ],
+    "suiteScores": {
+      "id": "core-v1",
+      "backendId": "builtin",
+      "score": 100.00000000000004
+    },
+    "referenceArtifact": "/private/tmp/wave-vortex-benchmark-worktree/Benchmarks/results/reference/core-v1-m5-max-r2026a-builtin"
+  }
+}

--- a/Benchmarks/results/reference/core-v1-m5-max-r2026a-builtin/summary.md
+++ b/Benchmarks/results/reference/core-v1-m5-max-r2026a-builtin/summary.md
@@ -1,0 +1,46 @@
+# WaveVortex benchmark
+
+- Status: `complete`
+- Run: `20260808T180426Z`
+- MATLAB: `2026a`
+- Architecture: `maca64`
+
+## Suite scores
+
+| Suite | Backend | Score |
+|---|---|---:|
+| core-v1 | builtin | 100.000 |
+
+## Family scores
+
+| Suite | Family | Backend | Score |
+|---|---|---|---:|
+| core-v1 | constant-nonhydrostatic | builtin | 100.000 |
+| core-v1 | constant-hydrostatic | builtin | 100.000 |
+
+## Timing and scores
+
+| Suite | Case | Transform | Backend | Median (ms) | Reference score | Same-host speedup | Error |
+|---|---|---|---|---:|---:|---:|---:|
+| core-v1 | constant-nonhydrostatic-256x256x65 | constant-nonhydrostatic | builtin | 130.103 | 100.000 | 1.000 | 0 |
+| core-v1 | constant-hydrostatic-256x256x65 | constant-hydrostatic | builtin | 104.823 | 100.000 | 1.000 | 0 |
+| core-v1 | constant-nonhydrostatic-512x512x129 | constant-nonhydrostatic | builtin | 1156.642 | 100.000 | 1.000 | 0 |
+| core-v1 | constant-hydrostatic-512x512x129 | constant-hydrostatic | builtin | 997.667 | 100.000 | 1.000 | 0 |
+
+## Construction and cache diagnostics
+
+| Suite | Case | Backend | Construction (s) | First call (ms) | Same-state cache hit (ms) |
+|---|---|---|---:|---:|---:|
+| core-v1 | constant-nonhydrostatic-256x256x65 | builtin | 1.310 | 207.574 | 94.857 |
+| core-v1 | constant-hydrostatic-256x256x65 | builtin | 0.505 | 137.880 | 72.191 |
+| core-v1 | constant-nonhydrostatic-512x512x129 | builtin | 1.110 | 1284.977 | 851.836 |
+| core-v1 | constant-hydrostatic-512x512x129 | builtin | 1.031 | 1103.964 | 665.475 |
+
+## Memory
+
+| Suite | Case | Backend | Persistent increment (MiB) | Peak increment (MiB) | Provider |
+|---|---|---|---:|---:|---|
+| core-v1 | constant-nonhydrostatic-256x256x65 | builtin | 1274.234 | 1299.234 | macos-ps-rss |
+| core-v1 | constant-hydrostatic-256x256x65 | builtin | 1222.094 | 1247.828 | macos-ps-rss |
+| core-v1 | constant-nonhydrostatic-512x512x129 | builtin | 7369.875 | 7554.609 | macos-ps-rss |
+| core-v1 | constant-hydrostatic-512x512x129 | builtin | 6865.062 | 7051.859 | macos-ps-rss |

--- a/Benchmarks/results/reference/scaling-large-v1-m5-max-r2026a-builtin/benchmark.json
+++ b/Benchmarks/results/reference/scaling-large-v1-m5-max-r2026a-builtin/benchmark.json
@@ -1,0 +1,562 @@
+{
+  "schemaVersion": "1.0.0",
+  "status": "partial",
+  "runId": "20260808T190619Z",
+  "environment": {
+    "os": "Darwin 25.5.0 Darwin Kernel Version 25.5.0: Tue Jun  9 22:28:34 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T6050 arm64",
+    "processor": "ABI64 ARM ARM64E",
+    "matlabVersion": "26.1.0.3312084 (R2026a) Update 4",
+    "matlabRelease": "2026a",
+    "architecture": "maca64",
+    "requestedThreads": 18,
+    "sourceCommit": "0d36eae79649c1f37e0dac4044fa5f83fb60fc1e",
+    "sourceDirty": false,
+    "physicalMemoryBytes": 5.1539607552E+10
+  },
+  "configuration": {
+    "suiteIds": "scaling-large-v1",
+    "backendIds": "builtin",
+    "correctnessTolerance": 1E-12,
+    "shouldMeasureMemory": true,
+    "caseIds": [
+      "constant-nonhydrostatic-256x256x129",
+      "constant-nonhydrostatic-512x512x257",
+      "constant-hydrostatic-256x256x129",
+      "constant-hydrostatic-512x512x257",
+      "hydrostatic-512x512x129",
+      "stratified-qg-512x512x129",
+      "barotropic-qg-2048x2048",
+      "barotropic-qg-4096x4096"
+    ]
+  },
+  "suites": {
+    "id": "scaling-large-v1",
+    "version": 1,
+    "description": "Large-memory scaling across transform families",
+    "operation": "nonlinearAdvection",
+    "isScored": true,
+    "selectionIsComplete": false,
+    "status": "partial",
+    "cases": [
+      {
+        "id": "constant-nonhydrostatic-256x256x129",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          129
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 4001,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.2966919166666666,
+          "firstCallSeconds": 0.40707191666666664,
+          "sameStateCacheHitSeconds": 0.18333625,
+          "rawSeconds": [
+            0.250996125,
+            0.25515058333333335,
+            0.25810541666666664
+          ],
+          "medianSeconds": 0.25515058333333335,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.25515058333333335,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61987072E+8,
+            "persistentBytes": 3.203923968E+9,
+            "peakBytes": 3.252289536E+9,
+            "persistentIncrementBytes": 2.441936896E+9,
+            "peakIncrementBytes": 2.490302464E+9,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-nonhydrostatic-512x512x257",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          512,
+          512,
+          257
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 4003,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.9532270833333334,
+          "firstCallSeconds": 2.5566385833333332,
+          "sameStateCacheHitSeconds": 1.947494625,
+          "rawSeconds": [
+            2.3296898333333331,
+            2.3128475416666667,
+            2.347494375
+          ],
+          "medianSeconds": 2.3296898333333331,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 2.3296898333333331,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61561088E+8,
+            "persistentBytes": 1.3990887424E+10,
+            "peakBytes": 1.7694162944E+10,
+            "persistentIncrementBytes": 1.3229326336E+10,
+            "peakIncrementBytes": 1.6932601856E+10,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-256x256x129",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          129
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 4005,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.4748965,
+          "firstCallSeconds": 0.28730858333333331,
+          "sameStateCacheHitSeconds": 0.16120204166666666,
+          "rawSeconds": [
+            0.21568820833333333,
+            0.22609958333333333,
+            0.21823729166666667
+          ],
+          "medianSeconds": 0.21823729166666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.21823729166666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61135104E+8,
+            "persistentBytes": 3.09772288E+9,
+            "peakBytes": 3.14638336E+9,
+            "persistentIncrementBytes": 2.336587776E+9,
+            "peakIncrementBytes": 2.385248256E+9,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-512x512x257",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          512,
+          512,
+          257
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 4007,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.708393125,
+          "firstCallSeconds": 2.18081525,
+          "sameStateCacheHitSeconds": 1.473488,
+          "rawSeconds": [
+            2.0564314583333334,
+            2.2816919583333335,
+            2.1524953333333334
+          ],
+          "medianSeconds": 2.1524953333333334,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 2.1524953333333334,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61544704E+8,
+            "persistentBytes": 1.5616344064E+10,
+            "peakBytes": 1.6000729088E+10,
+            "persistentIncrementBytes": 1.485479936E+10,
+            "peakIncrementBytes": 1.5239184384E+10,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "hydrostatic-512x512x129",
+        "transformId": "hydrostatic",
+        "scoreFamily": "hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          512,
+          512,
+          129
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 4010,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.6377604166666666,
+          "firstCallSeconds": 0.98597704166666666,
+          "sameStateCacheHitSeconds": 0.56736358333333337,
+          "rawSeconds": [
+            0.843147875,
+            0.85623254166666662,
+            0.89046529166666666
+          ],
+          "medianSeconds": 0.85623254166666662,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.85623254166666662,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.6038144E+8,
+            "persistentBytes": 9.114927104E+9,
+            "peakBytes": 9.335881728E+9,
+            "persistentIncrementBytes": 8.354545664E+9,
+            "peakIncrementBytes": 8.575500288E+9,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "stratified-qg-512x512x129",
+        "transformId": "stratified-qg",
+        "scoreFamily": "stratified-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          512,
+          512,
+          129
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 4016,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.61974229166666661,
+          "firstCallSeconds": 0.33515683333333335,
+          "sameStateCacheHitSeconds": 0.127158125,
+          "rawSeconds": [
+            0.34517816666666667,
+            0.350775375,
+            0.32475304166666669
+          ],
+          "medianSeconds": 0.34517816666666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.34517816666666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61888768E+8,
+            "persistentBytes": 5.220581376E+9,
+            "peakBytes": 5.315346432E+9,
+            "persistentIncrementBytes": 4.458692608E+9,
+            "peakIncrementBytes": 4.553457664E+9,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "barotropic-qg-2048x2048",
+        "transformId": "barotropic-qg",
+        "scoreFamily": "barotropic-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000
+        ],
+        "Nxyz": [
+          2048,
+          2048
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 4018,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.941505875,
+          "firstCallSeconds": 0.051141125,
+          "sameStateCacheHitSeconds": 0.015812833333333335,
+          "rawSeconds": [
+            0.032651625,
+            0.030321,
+            0.029823916666666665
+          ],
+          "medianSeconds": 0.030321,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.030321,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.60676352E+8,
+            "persistentBytes": 1.797275648E+9,
+            "peakBytes": 1.809317888E+9,
+            "persistentIncrementBytes": 1.036599296E+9,
+            "peakIncrementBytes": 1.048641536E+9,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "barotropic-qg-4096x4096",
+        "transformId": "barotropic-qg",
+        "scoreFamily": "barotropic-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000
+        ],
+        "Nxyz": [
+          4096,
+          4096
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 4019,
+        "warmupCount": 2,
+        "sampleCount": 3,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 3.543039125,
+          "firstCallSeconds": 0.17662695833333333,
+          "sameStateCacheHitSeconds": 0.057776375,
+          "rawSeconds": [
+            0.11375991666666667,
+            0.11279604166666667,
+            0.11228366666666667
+          ],
+          "medianSeconds": 0.11279604166666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.11279604166666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61479168E+8,
+            "persistentBytes": 4.417568768E+9,
+            "peakBytes": 4.46464E+9,
+            "persistentIncrementBytes": 3.6560896E+9,
+            "peakIncrementBytes": 3.703160832E+9,
+            "samplingIntervalSeconds": 0,
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      }
+    ],
+    "familyScores": [],
+    "suiteScores": [],
+    "referenceArtifact": "/private/tmp/wave-vortex-benchmark-worktree/Benchmarks/results/reference/scaling-large-v1-m5-max-r2026a-builtin"
+  }
+}

--- a/Benchmarks/results/reference/scaling-large-v1-m5-max-r2026a-builtin/summary.md
+++ b/Benchmarks/results/reference/scaling-large-v1-m5-max-r2026a-builtin/summary.md
@@ -1,0 +1,55 @@
+# WaveVortex benchmark
+
+- Status: `partial`
+- Run: `20260808T190619Z`
+- MATLAB: `2026a`
+- Architecture: `maca64`
+
+## Suite scores
+
+| Suite | Backend | Score |
+|---|---|---:|
+
+## Family scores
+
+| Suite | Family | Backend | Score |
+|---|---|---|---:|
+
+## Timing and scores
+
+| Suite | Case | Transform | Backend | Median (ms) | Reference score | Same-host speedup | Error |
+|---|---|---|---|---:|---:|---:|---:|
+| scaling-large-v1 | constant-nonhydrostatic-256x256x129 | constant-nonhydrostatic | builtin | 255.151 | 100.000 | 1.000 | 0 |
+| scaling-large-v1 | constant-nonhydrostatic-512x512x257 | constant-nonhydrostatic | builtin | 2329.690 | 100.000 | 1.000 | 0 |
+| scaling-large-v1 | constant-hydrostatic-256x256x129 | constant-hydrostatic | builtin | 218.237 | 100.000 | 1.000 | 0 |
+| scaling-large-v1 | constant-hydrostatic-512x512x257 | constant-hydrostatic | builtin | 2152.495 | 100.000 | 1.000 | 0 |
+| scaling-large-v1 | hydrostatic-512x512x129 | hydrostatic | builtin | 856.233 | 100.000 | 1.000 | 0 |
+| scaling-large-v1 | stratified-qg-512x512x129 | stratified-qg | builtin | 345.178 | 100.000 | 1.000 | 0 |
+| scaling-large-v1 | barotropic-qg-2048x2048 | barotropic-qg | builtin | 30.321 | 100.000 | 1.000 | 0 |
+| scaling-large-v1 | barotropic-qg-4096x4096 | barotropic-qg | builtin | 112.796 | 100.000 | 1.000 | 0 |
+
+## Construction and cache diagnostics
+
+| Suite | Case | Backend | Construction (s) | First call (ms) | Same-state cache hit (ms) |
+|---|---|---|---:|---:|---:|
+| scaling-large-v1 | constant-nonhydrostatic-256x256x129 | builtin | 1.297 | 407.072 | 183.336 |
+| scaling-large-v1 | constant-nonhydrostatic-512x512x257 | builtin | 1.953 | 2556.639 | 1947.495 |
+| scaling-large-v1 | constant-hydrostatic-256x256x129 | builtin | 0.475 | 287.309 | 161.202 |
+| scaling-large-v1 | constant-hydrostatic-512x512x257 | builtin | 1.708 | 2180.815 | 1473.488 |
+| scaling-large-v1 | hydrostatic-512x512x129 | builtin | 1.638 | 985.977 | 567.364 |
+| scaling-large-v1 | stratified-qg-512x512x129 | builtin | 0.620 | 335.157 | 127.158 |
+| scaling-large-v1 | barotropic-qg-2048x2048 | builtin | 0.942 | 51.141 | 15.813 |
+| scaling-large-v1 | barotropic-qg-4096x4096 | builtin | 3.543 | 176.627 | 57.776 |
+
+## Memory
+
+| Suite | Case | Backend | Persistent increment (MiB) | Peak increment (MiB) | Provider |
+|---|---|---|---:|---:|---|
+| scaling-large-v1 | constant-nonhydrostatic-256x256x129 | builtin | 2328.812 | 2374.938 | macos-ps-rss |
+| scaling-large-v1 | constant-nonhydrostatic-512x512x257 | builtin | 12616.469 | 16148.188 | macos-ps-rss |
+| scaling-large-v1 | constant-hydrostatic-256x256x129 | builtin | 2228.344 | 2274.750 | macos-ps-rss |
+| scaling-large-v1 | constant-hydrostatic-512x512x257 | builtin | 14166.641 | 14533.219 | macos-ps-rss |
+| scaling-large-v1 | hydrostatic-512x512x129 | builtin | 7967.516 | 8178.234 | macos-ps-rss |
+| scaling-large-v1 | stratified-qg-512x512x129 | builtin | 4252.141 | 4342.516 | macos-ps-rss |
+| scaling-large-v1 | barotropic-qg-2048x2048 | builtin | 988.578 | 1000.062 | macos-ps-rss |
+| scaling-large-v1 | barotropic-qg-4096x4096 | builtin | 3486.719 | 3531.609 | macos-ps-rss |

--- a/Benchmarks/results/reference/scaling-standard-v1-m5-max-r2026a-builtin/benchmark.json
+++ b/Benchmarks/results/reference/scaling-standard-v1-m5-max-r2026a-builtin/benchmark.json
@@ -1,0 +1,2444 @@
+{
+  "schemaVersion": "1.0.0",
+  "status": "complete",
+  "runId": "20260808T180708Z",
+  "environment": {
+    "os": "Darwin 25.5.0 Darwin Kernel Version 25.5.0: Tue Jun  9 22:28:34 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T6050 arm64",
+    "processor": "ABI64 ARM ARM64E",
+    "matlabVersion": "26.1.0.3312084 (R2026a) Update 4",
+    "matlabRelease": "2026a",
+    "architecture": "maca64",
+    "requestedThreads": 18,
+    "sourceCommit": "0d36eae79649c1f37e0dac4044fa5f83fb60fc1e",
+    "sourceDirty": false,
+    "physicalMemoryBytes": 5.1539607552E+10
+  },
+  "configuration": {
+    "suiteIds": "scaling-standard-v1",
+    "backendIds": "builtin",
+    "correctnessTolerance": 1E-12,
+    "shouldMeasureMemory": true,
+    "caseIds": [
+      "constant-nonhydrostatic-64x64x65",
+      "constant-nonhydrostatic-128x128x65",
+      "constant-nonhydrostatic-256x256x65",
+      "constant-nonhydrostatic-128x128x33",
+      "constant-nonhydrostatic-128x128x129",
+      "constant-nonhydrostatic-128x128x257",
+      "constant-hydrostatic-64x64x65",
+      "constant-hydrostatic-128x128x65",
+      "constant-hydrostatic-256x256x65",
+      "constant-hydrostatic-128x128x33",
+      "constant-hydrostatic-128x128x129",
+      "constant-hydrostatic-128x128x257",
+      "hydrostatic-64x64x65",
+      "hydrostatic-128x128x65",
+      "hydrostatic-256x256x65",
+      "hydrostatic-128x128x33",
+      "hydrostatic-128x128x129",
+      "hydrostatic-128x128x257",
+      "boussinesq-64x64x65",
+      "boussinesq-128x128x65",
+      "boussinesq-256x256x65",
+      "boussinesq-128x128x33",
+      "boussinesq-128x128x129",
+      "boussinesq-128x128x257",
+      "stratified-qg-64x64x65",
+      "stratified-qg-128x128x65",
+      "stratified-qg-256x256x65",
+      "stratified-qg-128x128x33",
+      "stratified-qg-128x128x129",
+      "stratified-qg-128x128x257",
+      "barotropic-qg-128x128",
+      "barotropic-qg-256x256",
+      "barotropic-qg-512x512",
+      "barotropic-qg-1024x1024"
+    ]
+  },
+  "suites": {
+    "id": "scaling-standard-v1",
+    "version": 1,
+    "description": "Standard horizontal and vertical scaling across transform families",
+    "operation": "nonlinearAdvection",
+    "isScored": true,
+    "status": "complete",
+    "cases": [
+      {
+        "id": "constant-nonhydrostatic-64x64x65",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          64,
+          64,
+          65
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3001,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.103317875,
+          "firstCallSeconds": 0.068577458333333327,
+          "sameStateCacheHitSeconds": 0.01440375,
+          "rawSeconds": [
+            0.028599208333333334,
+            0.029329208333333332,
+            0.031158791666666668,
+            0.026006041666666667,
+            0.022171666666666666,
+            0.02096125,
+            0.02062225
+          ],
+          "medianSeconds": 0.026006041666666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.026006041666666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62298368E+8,
+            "persistentBytes": 1.040891904E+9,
+            "peakBytes": 1.048477696E+9,
+            "persistentIncrementBytes": 2.78593536E+8,
+            "peakIncrementBytes": 2.86179328E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-nonhydrostatic-128x128x65",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          65
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3002,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.41453575,
+          "firstCallSeconds": 0.055587458333333332,
+          "sameStateCacheHitSeconds": 0.026460958333333333,
+          "rawSeconds": [
+            0.043247875,
+            0.042910458333333332,
+            0.039305166666666669,
+            0.038496291666666668,
+            0.03927275,
+            0.037292291666666665,
+            0.037133416666666669
+          ],
+          "medianSeconds": 0.03927275,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.03927275,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.59840768E+8,
+            "persistentBytes": 1.249378304E+9,
+            "peakBytes": 1.261830144E+9,
+            "persistentIncrementBytes": 4.89537536E+8,
+            "peakIncrementBytes": 5.01989376E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-nonhydrostatic-256x256x65",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          65
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3003,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.39559270833333332,
+          "firstCallSeconds": 0.169847125,
+          "sameStateCacheHitSeconds": 0.10070083333333334,
+          "rawSeconds": [
+            0.144281625,
+            0.14740716666666667,
+            0.14702129166666666,
+            0.14350058333333332,
+            0.1631955,
+            0.151095625,
+            0.13938529166666666
+          ],
+          "medianSeconds": 0.14702129166666666,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.14702129166666666,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.63527168E+8,
+            "persistentBytes": 2.098036736E+9,
+            "peakBytes": 2.124398592E+9,
+            "persistentIncrementBytes": 1.334509568E+9,
+            "peakIncrementBytes": 1.360871424E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-nonhydrostatic-128x128x33",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          33
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3004,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.25587333333333334,
+          "firstCallSeconds": 0.026413458333333334,
+          "sameStateCacheHitSeconds": 0.016773166666666665,
+          "rawSeconds": [
+            0.029102375,
+            0.026388375,
+            0.024080125,
+            0.024549,
+            0.02481825,
+            0.024789666666666668,
+            0.023975541666666666
+          ],
+          "medianSeconds": 0.024789666666666668,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.024789666666666668,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.65689856E+8,
+            "persistentBytes": 1.111506944E+9,
+            "peakBytes": 1.12418816E+9,
+            "persistentIncrementBytes": 3.45817088E+8,
+            "peakIncrementBytes": 3.58498304E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-nonhydrostatic-128x128x129",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          129
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3005,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.27494120833333335,
+          "firstCallSeconds": 0.092139708333333334,
+          "sameStateCacheHitSeconds": 0.044544958333333336,
+          "rawSeconds": [
+            0.077273625,
+            0.079692625,
+            0.089864958333333328,
+            0.088572833333333337,
+            0.081329291666666664,
+            0.077369833333333332,
+            0.081989958333333335
+          ],
+          "medianSeconds": 0.081329291666666664,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.081329291666666664,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61430016E+8,
+            "persistentBytes": 1.547763712E+9,
+            "peakBytes": 1.562558464E+9,
+            "persistentIncrementBytes": 7.86333696E+8,
+            "peakIncrementBytes": 8.01128448E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-nonhydrostatic-128x128x257",
+        "transformId": "constant-nonhydrostatic",
+        "scoreFamily": "constant-nonhydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          257
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3006,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.31537870833333331,
+          "firstCallSeconds": 0.19387975,
+          "sameStateCacheHitSeconds": 0.10229058333333334,
+          "rawSeconds": [
+            0.15559691666666667,
+            0.17514891666666665,
+            0.15675975,
+            0.15477445833333334,
+            0.154171375,
+            0.15592479166666667,
+            0.15922470833333333
+          ],
+          "medianSeconds": 0.15592479166666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.15592479166666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61135104E+8,
+            "persistentBytes": 2.089058304E+9,
+            "peakBytes": 2.115403776E+9,
+            "persistentIncrementBytes": 1.3279232E+9,
+            "peakIncrementBytes": 1.354268672E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-64x64x65",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          64,
+          64,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3007,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.2189375,
+          "firstCallSeconds": 0.025505083333333334,
+          "sameStateCacheHitSeconds": 0.009832125,
+          "rawSeconds": [
+            0.014491708333333334,
+            0.013557791666666666,
+            0.014088541666666666,
+            0.013749708333333333,
+            0.014291541666666666,
+            0.014771083333333334,
+            0.014501041666666667
+          ],
+          "medianSeconds": 0.014291541666666666,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.014291541666666666,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.78420224E+8,
+            "persistentBytes": 1.052459008E+9,
+            "peakBytes": 1.05988096E+9,
+            "persistentIncrementBytes": 2.74038784E+8,
+            "peakIncrementBytes": 2.81460736E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-128x128x65",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3008,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.24062816666666667,
+          "firstCallSeconds": 0.037686416666666667,
+          "sameStateCacheHitSeconds": 0.01987025,
+          "rawSeconds": [
+            0.034320083333333334,
+            0.034484583333333332,
+            0.03323670833333333,
+            0.03235925,
+            0.032053541666666664,
+            0.032559916666666668,
+            0.0317465
+          ],
+          "medianSeconds": 0.032559916666666668,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.032559916666666668,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62478592E+8,
+            "persistentBytes": 1.239482368E+9,
+            "peakBytes": 1.2488704E+9,
+            "persistentIncrementBytes": 4.77003776E+8,
+            "peakIncrementBytes": 4.86391808E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-256x256x65",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3009,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.28395504166666669,
+          "firstCallSeconds": 0.12839629166666666,
+          "sameStateCacheHitSeconds": 0.072467708333333339,
+          "rawSeconds": [
+            0.110248625,
+            0.10747491666666667,
+            0.10724825,
+            0.10762416666666667,
+            0.108319625,
+            0.10689758333333334,
+            0.10375395833333333
+          ],
+          "medianSeconds": 0.10747491666666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.10747491666666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.602176E+8,
+            "persistentBytes": 2.039758848E+9,
+            "peakBytes": 2.066481152E+9,
+            "persistentIncrementBytes": 1.279541248E+9,
+            "peakIncrementBytes": 1.306263552E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-128x128x33",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          33
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3010,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.18498504166666666,
+          "firstCallSeconds": 0.020859,
+          "sameStateCacheHitSeconds": 0.013234791666666667,
+          "rawSeconds": [
+            0.021380125,
+            0.021768458333333334,
+            0.02058375,
+            0.020609208333333334,
+            0.020442166666666668,
+            0.020385916666666667,
+            0.020051208333333334
+          ],
+          "medianSeconds": 0.02058375,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.02058375,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.63772928E+8,
+            "persistentBytes": 1.103167488E+9,
+            "peakBytes": 1.11427584E+9,
+            "persistentIncrementBytes": 3.3939456E+8,
+            "peakIncrementBytes": 3.50502912E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-128x128x129",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          129
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3011,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.22861466666666666,
+          "firstCallSeconds": 0.075473458333333326,
+          "sameStateCacheHitSeconds": 0.0333905,
+          "rawSeconds": [
+            0.060699166666666665,
+            0.061036,
+            0.071559125,
+            0.071130916666666669,
+            0.063535041666666667,
+            0.06207575,
+            0.057223833333333335
+          ],
+          "medianSeconds": 0.06207575,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.06207575,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62658816E+8,
+            "persistentBytes": 1.526054912E+9,
+            "peakBytes": 1.541029888E+9,
+            "persistentIncrementBytes": 7.63396096E+8,
+            "peakIncrementBytes": 7.78371072E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "constant-hydrostatic-128x128x257",
+        "transformId": "constant-hydrostatic",
+        "scoreFamily": "constant-hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          257
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3012,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.27090829166666669,
+          "firstCallSeconds": 0.170917,
+          "sameStateCacheHitSeconds": 0.079898208333333331,
+          "rawSeconds": [
+            0.131771875,
+            0.13035983333333334,
+            0.12884975,
+            0.1298595,
+            0.137710125,
+            0.13169104166666667,
+            0.130455625
+          ],
+          "medianSeconds": 0.130455625,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.130455625,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.60610816E+8,
+            "persistentBytes": 2.034450432E+9,
+            "peakBytes": 2.061123584E+9,
+            "persistentIncrementBytes": 1.273839616E+9,
+            "peakIncrementBytes": 1.300512768E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "hydrostatic-64x64x65",
+        "transformId": "hydrostatic",
+        "scoreFamily": "hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          64,
+          64,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3013,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.90452095833333335,
+          "firstCallSeconds": 0.066054166666666664,
+          "sameStateCacheHitSeconds": 0.0078455,
+          "rawSeconds": [
+            0.030200666666666667,
+            0.021762041666666666,
+            0.018738875,
+            0.017427875,
+            0.016855,
+            0.014549375,
+            0.014083416666666666
+          ],
+          "medianSeconds": 0.017427875,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.017427875,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61675776E+8,
+            "persistentBytes": 1.062797312E+9,
+            "peakBytes": 1.071562752E+9,
+            "persistentIncrementBytes": 3.01121536E+8,
+            "peakIncrementBytes": 3.09886976E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "hydrostatic-128x128x65",
+        "transformId": "hydrostatic",
+        "scoreFamily": "hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3014,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.47492533333333331,
+          "firstCallSeconds": 0.040391583333333335,
+          "sameStateCacheHitSeconds": 0.016694541666666667,
+          "rawSeconds": [
+            0.037386125,
+            0.029280083333333335,
+            0.029579916666666668,
+            0.028904125,
+            0.029628666666666668,
+            0.029883166666666666,
+            0.029362125
+          ],
+          "medianSeconds": 0.029579916666666668,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.029579916666666668,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61266176E+8,
+            "persistentBytes": 1.263239168E+9,
+            "peakBytes": 1.272922112E+9,
+            "persistentIncrementBytes": 5.01972992E+8,
+            "peakIncrementBytes": 5.11655936E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "hydrostatic-256x256x65",
+        "transformId": "hydrostatic",
+        "scoreFamily": "hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3015,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.51804075,
+          "firstCallSeconds": 0.117359,
+          "sameStateCacheHitSeconds": 0.058730208333333332,
+          "rawSeconds": [
+            0.099091833333333337,
+            0.099949583333333328,
+            0.097784666666666673,
+            0.09572425,
+            0.097427791666666666,
+            0.093936875,
+            0.10049466666666666
+          ],
+          "medianSeconds": 0.097784666666666673,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.097784666666666673,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61954304E+8,
+            "persistentBytes": 2.041577472E+9,
+            "peakBytes": 2.072690688E+9,
+            "persistentIncrementBytes": 1.279623168E+9,
+            "peakIncrementBytes": 1.310736384E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "hydrostatic-128x128x33",
+        "transformId": "hydrostatic",
+        "scoreFamily": "hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          33
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3016,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.40341983333333331,
+          "firstCallSeconds": 0.017941166666666668,
+          "sameStateCacheHitSeconds": 0.010854291666666667,
+          "rawSeconds": [
+            0.017292875,
+            0.016550625,
+            0.017095416666666665,
+            0.016607625,
+            0.016242208333333334,
+            0.01562275,
+            0.016616416666666668
+          ],
+          "medianSeconds": 0.016607625,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.016607625,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61102336E+8,
+            "persistentBytes": 1.124139008E+9,
+            "peakBytes": 1.135230976E+9,
+            "persistentIncrementBytes": 3.63036672E+8,
+            "peakIncrementBytes": 3.7412864E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "hydrostatic-128x128x129",
+        "transformId": "hydrostatic",
+        "scoreFamily": "hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          129
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3017,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.43490479166666668,
+          "firstCallSeconds": 0.072698541666666672,
+          "sameStateCacheHitSeconds": 0.035156083333333331,
+          "rawSeconds": [
+            0.060328,
+            0.062924375,
+            0.070083416666666662,
+            0.064229791666666661,
+            0.062690541666666669,
+            0.059689875,
+            0.060786
+          ],
+          "medianSeconds": 0.062690541666666669,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.062690541666666669,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62462208E+8,
+            "persistentBytes": 1.543405568E+9,
+            "peakBytes": 1.560707072E+9,
+            "persistentIncrementBytes": 7.8094336E+8,
+            "peakIncrementBytes": 7.98244864E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "hydrostatic-128x128x257",
+        "transformId": "hydrostatic",
+        "scoreFamily": "hydrostatic",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          257
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3018,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 1.2267920416666667,
+          "firstCallSeconds": 0.15752729166666668,
+          "sameStateCacheHitSeconds": 0.076101833333333327,
+          "rawSeconds": [
+            0.13028008333333332,
+            0.12968816666666666,
+            0.12938091666666668,
+            0.13209320833333332,
+            0.12917020833333334,
+            0.134326875,
+            0.13143608333333334
+          ],
+          "medianSeconds": 0.13028008333333332,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.13028008333333332,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.63953152E+8,
+            "persistentBytes": 2.063597568E+9,
+            "peakBytes": 2.093940736E+9,
+            "persistentIncrementBytes": 1.299644416E+9,
+            "peakIncrementBytes": 1.329987584E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "boussinesq-64x64x65",
+        "transformId": "boussinesq",
+        "scoreFamily": "boussinesq",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          64,
+          64,
+          65
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3019,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 14.14896625,
+          "firstCallSeconds": 0.12694504166666667,
+          "sameStateCacheHitSeconds": 0.01086125,
+          "rawSeconds": [
+            0.033487,
+            0.029865083333333334,
+            0.026646916666666666,
+            0.025506166666666667,
+            0.023777458333333334,
+            0.0221465,
+            0.021257583333333333
+          ],
+          "medianSeconds": 0.025506166666666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.025506166666666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.63199488E+8,
+            "persistentBytes": 1.119666176E+9,
+            "peakBytes": 1.135181824E+9,
+            "persistentIncrementBytes": 3.56466688E+8,
+            "peakIncrementBytes": 3.71982336E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "boussinesq-128x128x65",
+        "transformId": "boussinesq",
+        "scoreFamily": "boussinesq",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          65
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3020,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 47.896833416666666,
+          "firstCallSeconds": 0.068012291666666669,
+          "sameStateCacheHitSeconds": 0.026645666666666668,
+          "rawSeconds": [
+            0.056934,
+            0.054739666666666666,
+            0.054365125,
+            0.05468025,
+            0.05477166666666667,
+            0.054720625,
+            0.053904291666666666
+          ],
+          "medianSeconds": 0.054720625,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.054720625,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.59906304E+8,
+            "persistentBytes": 1.365704704E+9,
+            "peakBytes": 1.37740288E+9,
+            "persistentIncrementBytes": 6.057984E+8,
+            "peakIncrementBytes": 6.17496576E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "boussinesq-256x256x65",
+        "transformId": "boussinesq",
+        "scoreFamily": "boussinesq",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          65
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3021,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 178.31902995833335,
+          "firstCallSeconds": 0.2195895,
+          "sameStateCacheHitSeconds": 0.10050366666666667,
+          "rawSeconds": [
+            0.192131375,
+            0.19505091666666666,
+            0.19307108333333334,
+            0.19215475,
+            0.19192675,
+            0.19211445833333332,
+            0.18857575
+          ],
+          "medianSeconds": 0.192131375,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.192131375,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61331712E+8,
+            "persistentBytes": 2.347401216E+9,
+            "peakBytes": 2.382594048E+9,
+            "persistentIncrementBytes": 1.586069504E+9,
+            "peakIncrementBytes": 1.621262336E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "boussinesq-128x128x33",
+        "transformId": "boussinesq",
+        "scoreFamily": "boussinesq",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          33
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3022,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 46.327834166666669,
+          "firstCallSeconds": 0.0342565,
+          "sameStateCacheHitSeconds": 0.016155208333333334,
+          "rawSeconds": [
+            0.030223625,
+            0.029940041666666667,
+            0.02942925,
+            0.028907333333333333,
+            0.029435625,
+            0.029213583333333334,
+            0.029018958333333334
+          ],
+          "medianSeconds": 0.02942925,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.02942925,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.5964416E+8,
+            "persistentBytes": 1.176141824E+9,
+            "peakBytes": 1.18587392E+9,
+            "persistentIncrementBytes": 4.16497664E+8,
+            "peakIncrementBytes": 4.2622976E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "boussinesq-128x128x129",
+        "transformId": "boussinesq",
+        "scoreFamily": "boussinesq",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          129
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3023,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 33.106769875,
+          "firstCallSeconds": 0.1233445,
+          "sameStateCacheHitSeconds": 0.057135875,
+          "rawSeconds": [
+            0.1081015,
+            0.109070125,
+            0.11474191666666667,
+            0.11211845833333334,
+            0.11194245833333333,
+            0.11071579166666666,
+            0.11257258333333334
+          ],
+          "medianSeconds": 0.11194245833333333,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.11194245833333333,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.6169216E+8,
+            "persistentBytes": 1.856094208E+9,
+            "peakBytes": 1.875574784E+9,
+            "persistentIncrementBytes": 1.094402048E+9,
+            "peakIncrementBytes": 1.113882624E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "boussinesq-128x128x257",
+        "transformId": "boussinesq",
+        "scoreFamily": "boussinesq",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          257
+        ],
+        "isHydrostatic": false,
+        "shouldAntialias": true,
+        "seed": 3024,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 300.03775520833335,
+          "firstCallSeconds": 0.318072375,
+          "sameStateCacheHitSeconds": 0.142307625,
+          "rawSeconds": [
+            0.27317704166666668,
+            0.27860295833333332,
+            0.27245995833333331,
+            0.270491375,
+            0.27217925,
+            0.277224,
+            0.27329945833333336
+          ],
+          "medianSeconds": 0.27317704166666668,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.27317704166666668,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.63150336E+8,
+            "persistentBytes": 3.221045248E+9,
+            "peakBytes": 3.255517184E+9,
+            "persistentIncrementBytes": 2.457894912E+9,
+            "peakIncrementBytes": 2.492366848E+9,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "stratified-qg-64x64x65",
+        "transformId": "stratified-qg",
+        "scoreFamily": "stratified-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          64,
+          64,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3025,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.40863529166666668,
+          "firstCallSeconds": 0.031278791666666667,
+          "sameStateCacheHitSeconds": 0.0028059166666666666,
+          "rawSeconds": [
+            0.010552333333333334,
+            0.007251583333333333,
+            0.005742625,
+            0.005280875,
+            0.005072958333333333,
+            0.0047870416666666669,
+            0.0049039166666666667
+          ],
+          "medianSeconds": 0.005280875,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.005280875,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.64018688E+8,
+            "persistentBytes": 9.97638144E+8,
+            "peakBytes": 1.001242624E+9,
+            "persistentIncrementBytes": 2.33619456E+8,
+            "peakIncrementBytes": 2.37223936E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "stratified-qg-128x128x65",
+        "transformId": "stratified-qg",
+        "scoreFamily": "stratified-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3026,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.30456275,
+          "firstCallSeconds": 0.013950708333333334,
+          "sameStateCacheHitSeconds": 0.0045187916666666666,
+          "rawSeconds": [
+            0.0139935,
+            0.012686458333333333,
+            0.018422958333333333,
+            0.01312775,
+            0.012875375,
+            0.011751,
+            0.011934291666666666
+          ],
+          "medianSeconds": 0.012875375,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.012875375,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62068992E+8,
+            "persistentBytes": 1.091960832E+9,
+            "peakBytes": 1.095532544E+9,
+            "persistentIncrementBytes": 3.2989184E+8,
+            "peakIncrementBytes": 3.33463552E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "stratified-qg-256x256x65",
+        "transformId": "stratified-qg",
+        "scoreFamily": "stratified-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          256,
+          256,
+          65
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3027,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.291405375,
+          "firstCallSeconds": 0.043264333333333335,
+          "sameStateCacheHitSeconds": 0.013918041666666667,
+          "rawSeconds": [
+            0.037738333333333332,
+            0.037074125,
+            0.035441375,
+            0.035476,
+            0.037207958333333332,
+            0.035781791666666667,
+            0.035115
+          ],
+          "medianSeconds": 0.035781791666666667,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.035781791666666667,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62331136E+8,
+            "persistentBytes": 1.49676032E+9,
+            "peakBytes": 1.509900288E+9,
+            "persistentIncrementBytes": 7.34429184E+8,
+            "peakIncrementBytes": 7.47569152E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "stratified-qg-128x128x33",
+        "transformId": "stratified-qg",
+        "scoreFamily": "stratified-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          33
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3028,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.2338455,
+          "firstCallSeconds": 0.0071707083333333336,
+          "sameStateCacheHitSeconds": 0.003104875,
+          "rawSeconds": [
+            0.0076962916666666664,
+            0.0065729583333333334,
+            0.0067425416666666666,
+            0.0067547916666666668,
+            0.006725375,
+            0.007016,
+            0.006640541666666667
+          ],
+          "medianSeconds": 0.0067425416666666666,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.0067425416666666666,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.61839616E+8,
+            "persistentBytes": 1.034027008E+9,
+            "peakBytes": 1.0371072E+9,
+            "persistentIncrementBytes": 2.72187392E+8,
+            "peakIncrementBytes": 2.75267584E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "stratified-qg-128x128x129",
+        "transformId": "stratified-qg",
+        "scoreFamily": "stratified-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          129
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3029,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.20940154166666666,
+          "firstCallSeconds": 0.021589208333333332,
+          "sameStateCacheHitSeconds": 0.00661875,
+          "rawSeconds": [
+            0.018998375,
+            0.018986083333333334,
+            0.024407791666666668,
+            0.021994333333333334,
+            0.020625833333333333,
+            0.019762083333333333,
+            0.020960666666666666
+          ],
+          "medianSeconds": 0.020625833333333333,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.020625833333333333,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.60922112E+8,
+            "persistentBytes": 1.255981056E+9,
+            "peakBytes": 1.263681536E+9,
+            "persistentIncrementBytes": 4.95058944E+8,
+            "peakIncrementBytes": 5.02759424E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "stratified-qg-128x128x257",
+        "transformId": "stratified-qg",
+        "scoreFamily": "stratified-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000,
+          1300
+        ],
+        "Nxyz": [
+          128,
+          128,
+          257
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3030,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.936655125,
+          "firstCallSeconds": 0.052059333333333332,
+          "sameStateCacheHitSeconds": 0.01355,
+          "rawSeconds": [
+            0.048861833333333334,
+            0.04835,
+            0.048353625,
+            0.049212708333333334,
+            0.048067875,
+            0.047397125,
+            0.048375458333333336
+          ],
+          "medianSeconds": 0.048353625,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.048353625,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62167296E+8,
+            "persistentBytes": 1.527447552E+9,
+            "peakBytes": 1.540636672E+9,
+            "persistentIncrementBytes": 7.65280256E+8,
+            "peakIncrementBytes": 7.78469376E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "barotropic-qg-128x128",
+        "transformId": "barotropic-qg",
+        "scoreFamily": "barotropic-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000
+        ],
+        "Nxyz": [
+          128,
+          128
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3031,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.17822616666666666,
+          "firstCallSeconds": 0.037912291666666667,
+          "sameStateCacheHitSeconds": 0.0017695416666666667,
+          "rawSeconds": [
+            0.00695875,
+            0.0043125416666666668,
+            0.00342175,
+            0.00224575,
+            0.0036981666666666669,
+            0.0056695,
+            0.0029846666666666667
+          ],
+          "medianSeconds": 0.0036981666666666669,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.0036981666666666669,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62363904E+8,
+            "persistentBytes": 9.22763264E+8,
+            "peakBytes": 9.24286976E+8,
+            "persistentIncrementBytes": 1.6039936E+8,
+            "peakIncrementBytes": 1.61923072E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "barotropic-qg-256x256",
+        "transformId": "barotropic-qg",
+        "scoreFamily": "barotropic-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000
+        ],
+        "Nxyz": [
+          256,
+          256
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3032,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.080570625,
+          "firstCallSeconds": 0.0040759166666666669,
+          "sameStateCacheHitSeconds": 0.0010143333333333332,
+          "rawSeconds": [
+            0.0033119583333333334,
+            0.0029676666666666666,
+            0.0073745,
+            0.0030152083333333333,
+            0.0023031666666666665,
+            0.0023125,
+            0.0022060416666666665
+          ],
+          "medianSeconds": 0.0029676666666666666,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.0029676666666666666,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.59529472E+8,
+            "persistentBytes": 9.2798976E+8,
+            "peakBytes": 9.29824768E+8,
+            "persistentIncrementBytes": 1.68460288E+8,
+            "peakIncrementBytes": 1.70295296E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "barotropic-qg-512x512",
+        "transformId": "barotropic-qg",
+        "scoreFamily": "barotropic-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000
+        ],
+        "Nxyz": [
+          512,
+          512
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3033,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.07926883333333333,
+          "firstCallSeconds": 0.0043558333333333331,
+          "sameStateCacheHitSeconds": 0.0018065,
+          "rawSeconds": [
+            0.003786875,
+            0.0036317916666666668,
+            0.0037762083333333332,
+            0.0036433333333333335,
+            0.0037506666666666665,
+            0.0045284583333333331,
+            0.004143875
+          ],
+          "medianSeconds": 0.0037762083333333332,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.0037762083333333332,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.62052608E+8,
+            "persistentBytes": 9.74716928E+8,
+            "peakBytes": 9.78763776E+8,
+            "persistentIncrementBytes": 2.1266432E+8,
+            "peakIncrementBytes": 2.16711168E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      },
+      {
+        "id": "barotropic-qg-1024x1024",
+        "transformId": "barotropic-qg",
+        "scoreFamily": "barotropic-qg",
+        "operation": "nonlinearAdvection",
+        "Lxyz": [
+          15000,
+          15000
+        ],
+        "Nxyz": [
+          1024,
+          1024
+        ],
+        "isHydrostatic": true,
+        "shouldAntialias": true,
+        "seed": 3034,
+        "warmupCount": 2,
+        "sampleCount": 7,
+        "status": "complete",
+        "failure": {
+          "identifier": "",
+          "message": "",
+          "stack": []
+        },
+        "backends": {
+          "id": "builtin",
+          "status": "complete",
+          "constructionSeconds": 0.19835054166666666,
+          "firstCallSeconds": 0.015293416666666667,
+          "sameStateCacheHitSeconds": 0.004419625,
+          "rawSeconds": [
+            0.0083225,
+            0.008523375,
+            0.0082797916666666662,
+            0.0084434166666666668,
+            0.0084414166666666665,
+            0.008289625,
+            0.008571625
+          ],
+          "medianSeconds": 0.0084414166666666665,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "referenceMedianSeconds": 0.0084414166666666665,
+          "caseScore": 100,
+          "sameHostSpeedup": 1,
+          "memory": {
+            "status": "complete",
+            "provider": "macos-ps-rss",
+            "baselineBytes": 7.6177408E+8,
+            "persistentBytes": 1.139408896E+9,
+            "peakBytes": 1.144635392E+9,
+            "persistentIncrementBytes": 3.77634816E+8,
+            "peakIncrementBytes": 3.82861312E+8,
+            "samplingIntervalSeconds": [],
+            "failure": {
+              "identifier": "",
+              "message": "",
+              "stack": []
+            }
+          },
+          "failure": {
+            "identifier": "",
+            "message": "",
+            "stack": []
+          }
+        }
+      }
+    ],
+    "familyScores": [
+      {
+        "id": "constant-nonhydrostatic",
+        "backendId": "builtin",
+        "score": 100.00000000000013
+      },
+      {
+        "id": "constant-hydrostatic",
+        "backendId": "builtin",
+        "score": 100.00000000000013
+      },
+      {
+        "id": "hydrostatic",
+        "backendId": "builtin",
+        "score": 100.00000000000013
+      },
+      {
+        "id": "boussinesq",
+        "backendId": "builtin",
+        "score": 100.00000000000013
+      },
+      {
+        "id": "stratified-qg",
+        "backendId": "builtin",
+        "score": 100.00000000000013
+      },
+      {
+        "id": "barotropic-qg",
+        "backendId": "builtin",
+        "score": 100.00000000000004
+      }
+    ],
+    "suiteScores": {
+      "id": "scaling-standard-v1",
+      "backendId": "builtin",
+      "score": 100.00000000000013
+    },
+    "referenceArtifact": "/private/tmp/wave-vortex-benchmark-worktree/Benchmarks/results/reference/scaling-standard-v1-m5-max-r2026a-builtin"
+  }
+}

--- a/Benchmarks/results/reference/scaling-standard-v1-m5-max-r2026a-builtin/summary.md
+++ b/Benchmarks/results/reference/scaling-standard-v1-m5-max-r2026a-builtin/summary.md
@@ -1,0 +1,140 @@
+# WaveVortex benchmark
+
+- Status: `complete`
+- Run: `20260808T180708Z`
+- MATLAB: `2026a`
+- Architecture: `maca64`
+
+## Suite scores
+
+| Suite | Backend | Score |
+|---|---|---:|
+| scaling-standard-v1 | builtin | 100.000 |
+
+## Family scores
+
+| Suite | Family | Backend | Score |
+|---|---|---|---:|
+| scaling-standard-v1 | constant-nonhydrostatic | builtin | 100.000 |
+| scaling-standard-v1 | constant-hydrostatic | builtin | 100.000 |
+| scaling-standard-v1 | hydrostatic | builtin | 100.000 |
+| scaling-standard-v1 | boussinesq | builtin | 100.000 |
+| scaling-standard-v1 | stratified-qg | builtin | 100.000 |
+| scaling-standard-v1 | barotropic-qg | builtin | 100.000 |
+
+## Timing and scores
+
+| Suite | Case | Transform | Backend | Median (ms) | Reference score | Same-host speedup | Error |
+|---|---|---|---|---:|---:|---:|---:|
+| scaling-standard-v1 | constant-nonhydrostatic-64x64x65 | constant-nonhydrostatic | builtin | 26.006 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x65 | constant-nonhydrostatic | builtin | 39.273 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-nonhydrostatic-256x256x65 | constant-nonhydrostatic | builtin | 147.021 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x33 | constant-nonhydrostatic | builtin | 24.790 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x129 | constant-nonhydrostatic | builtin | 81.329 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x257 | constant-nonhydrostatic | builtin | 155.925 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-hydrostatic-64x64x65 | constant-hydrostatic | builtin | 14.292 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x65 | constant-hydrostatic | builtin | 32.560 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-hydrostatic-256x256x65 | constant-hydrostatic | builtin | 107.475 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x33 | constant-hydrostatic | builtin | 20.584 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x129 | constant-hydrostatic | builtin | 62.076 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x257 | constant-hydrostatic | builtin | 130.456 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | hydrostatic-64x64x65 | hydrostatic | builtin | 17.428 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | hydrostatic-128x128x65 | hydrostatic | builtin | 29.580 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | hydrostatic-256x256x65 | hydrostatic | builtin | 97.785 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | hydrostatic-128x128x33 | hydrostatic | builtin | 16.608 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | hydrostatic-128x128x129 | hydrostatic | builtin | 62.691 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | hydrostatic-128x128x257 | hydrostatic | builtin | 130.280 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | boussinesq-64x64x65 | boussinesq | builtin | 25.506 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | boussinesq-128x128x65 | boussinesq | builtin | 54.721 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | boussinesq-256x256x65 | boussinesq | builtin | 192.131 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | boussinesq-128x128x33 | boussinesq | builtin | 29.429 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | boussinesq-128x128x129 | boussinesq | builtin | 111.942 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | boussinesq-128x128x257 | boussinesq | builtin | 273.177 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | stratified-qg-64x64x65 | stratified-qg | builtin | 5.281 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | stratified-qg-128x128x65 | stratified-qg | builtin | 12.875 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | stratified-qg-256x256x65 | stratified-qg | builtin | 35.782 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | stratified-qg-128x128x33 | stratified-qg | builtin | 6.743 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | stratified-qg-128x128x129 | stratified-qg | builtin | 20.626 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | stratified-qg-128x128x257 | stratified-qg | builtin | 48.354 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | barotropic-qg-128x128 | barotropic-qg | builtin | 3.698 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | barotropic-qg-256x256 | barotropic-qg | builtin | 2.968 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | barotropic-qg-512x512 | barotropic-qg | builtin | 3.776 | 100.000 | 1.000 | 0 |
+| scaling-standard-v1 | barotropic-qg-1024x1024 | barotropic-qg | builtin | 8.441 | 100.000 | 1.000 | 0 |
+
+## Construction and cache diagnostics
+
+| Suite | Case | Backend | Construction (s) | First call (ms) | Same-state cache hit (ms) |
+|---|---|---|---:|---:|---:|
+| scaling-standard-v1 | constant-nonhydrostatic-64x64x65 | builtin | 1.103 | 68.577 | 14.404 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x65 | builtin | 0.415 | 55.587 | 26.461 |
+| scaling-standard-v1 | constant-nonhydrostatic-256x256x65 | builtin | 0.396 | 169.847 | 100.701 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x33 | builtin | 0.256 | 26.413 | 16.773 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x129 | builtin | 0.275 | 92.140 | 44.545 |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x257 | builtin | 0.315 | 193.880 | 102.291 |
+| scaling-standard-v1 | constant-hydrostatic-64x64x65 | builtin | 0.219 | 25.505 | 9.832 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x65 | builtin | 0.241 | 37.686 | 19.870 |
+| scaling-standard-v1 | constant-hydrostatic-256x256x65 | builtin | 0.284 | 128.396 | 72.468 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x33 | builtin | 0.185 | 20.859 | 13.235 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x129 | builtin | 0.229 | 75.473 | 33.390 |
+| scaling-standard-v1 | constant-hydrostatic-128x128x257 | builtin | 0.271 | 170.917 | 79.898 |
+| scaling-standard-v1 | hydrostatic-64x64x65 | builtin | 0.905 | 66.054 | 7.846 |
+| scaling-standard-v1 | hydrostatic-128x128x65 | builtin | 0.475 | 40.392 | 16.695 |
+| scaling-standard-v1 | hydrostatic-256x256x65 | builtin | 0.518 | 117.359 | 58.730 |
+| scaling-standard-v1 | hydrostatic-128x128x33 | builtin | 0.403 | 17.941 | 10.854 |
+| scaling-standard-v1 | hydrostatic-128x128x129 | builtin | 0.435 | 72.699 | 35.156 |
+| scaling-standard-v1 | hydrostatic-128x128x257 | builtin | 1.227 | 157.527 | 76.102 |
+| scaling-standard-v1 | boussinesq-64x64x65 | builtin | 14.149 | 126.945 | 10.861 |
+| scaling-standard-v1 | boussinesq-128x128x65 | builtin | 47.897 | 68.012 | 26.646 |
+| scaling-standard-v1 | boussinesq-256x256x65 | builtin | 178.319 | 219.589 | 100.504 |
+| scaling-standard-v1 | boussinesq-128x128x33 | builtin | 46.328 | 34.257 | 16.155 |
+| scaling-standard-v1 | boussinesq-128x128x129 | builtin | 33.107 | 123.344 | 57.136 |
+| scaling-standard-v1 | boussinesq-128x128x257 | builtin | 300.038 | 318.072 | 142.308 |
+| scaling-standard-v1 | stratified-qg-64x64x65 | builtin | 0.409 | 31.279 | 2.806 |
+| scaling-standard-v1 | stratified-qg-128x128x65 | builtin | 0.305 | 13.951 | 4.519 |
+| scaling-standard-v1 | stratified-qg-256x256x65 | builtin | 0.291 | 43.264 | 13.918 |
+| scaling-standard-v1 | stratified-qg-128x128x33 | builtin | 0.234 | 7.171 | 3.105 |
+| scaling-standard-v1 | stratified-qg-128x128x129 | builtin | 0.209 | 21.589 | 6.619 |
+| scaling-standard-v1 | stratified-qg-128x128x257 | builtin | 0.937 | 52.059 | 13.550 |
+| scaling-standard-v1 | barotropic-qg-128x128 | builtin | 0.178 | 37.912 | 1.770 |
+| scaling-standard-v1 | barotropic-qg-256x256 | builtin | 0.081 | 4.076 | 1.014 |
+| scaling-standard-v1 | barotropic-qg-512x512 | builtin | 0.079 | 4.356 | 1.806 |
+| scaling-standard-v1 | barotropic-qg-1024x1024 | builtin | 0.198 | 15.293 | 4.420 |
+
+## Memory
+
+| Suite | Case | Backend | Persistent increment (MiB) | Peak increment (MiB) | Provider |
+|---|---|---|---:|---:|---|
+| scaling-standard-v1 | constant-nonhydrostatic-64x64x65 | builtin | 265.688 | 272.922 | macos-ps-rss |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x65 | builtin | 466.859 | 478.734 | macos-ps-rss |
+| scaling-standard-v1 | constant-nonhydrostatic-256x256x65 | builtin | 1272.688 | 1297.828 | macos-ps-rss |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x33 | builtin | 329.797 | 341.891 | macos-ps-rss |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x129 | builtin | 749.906 | 764.016 | macos-ps-rss |
+| scaling-standard-v1 | constant-nonhydrostatic-128x128x257 | builtin | 1266.406 | 1291.531 | macos-ps-rss |
+| scaling-standard-v1 | constant-hydrostatic-64x64x65 | builtin | 261.344 | 268.422 | macos-ps-rss |
+| scaling-standard-v1 | constant-hydrostatic-128x128x65 | builtin | 454.906 | 463.859 | macos-ps-rss |
+| scaling-standard-v1 | constant-hydrostatic-256x256x65 | builtin | 1220.266 | 1245.750 | macos-ps-rss |
+| scaling-standard-v1 | constant-hydrostatic-128x128x33 | builtin | 323.672 | 334.266 | macos-ps-rss |
+| scaling-standard-v1 | constant-hydrostatic-128x128x129 | builtin | 728.031 | 742.312 | macos-ps-rss |
+| scaling-standard-v1 | constant-hydrostatic-128x128x257 | builtin | 1214.828 | 1240.266 | macos-ps-rss |
+| scaling-standard-v1 | hydrostatic-64x64x65 | builtin | 287.172 | 295.531 | macos-ps-rss |
+| scaling-standard-v1 | hydrostatic-128x128x65 | builtin | 478.719 | 487.953 | macos-ps-rss |
+| scaling-standard-v1 | hydrostatic-256x256x65 | builtin | 1220.344 | 1250.016 | macos-ps-rss |
+| scaling-standard-v1 | hydrostatic-128x128x33 | builtin | 346.219 | 356.797 | macos-ps-rss |
+| scaling-standard-v1 | hydrostatic-128x128x129 | builtin | 744.766 | 761.266 | macos-ps-rss |
+| scaling-standard-v1 | hydrostatic-128x128x257 | builtin | 1239.438 | 1268.375 | macos-ps-rss |
+| scaling-standard-v1 | boussinesq-64x64x65 | builtin | 339.953 | 354.750 | macos-ps-rss |
+| scaling-standard-v1 | boussinesq-128x128x65 | builtin | 577.734 | 588.891 | macos-ps-rss |
+| scaling-standard-v1 | boussinesq-256x256x65 | builtin | 1512.594 | 1546.156 | macos-ps-rss |
+| scaling-standard-v1 | boussinesq-128x128x33 | builtin | 397.203 | 406.484 | macos-ps-rss |
+| scaling-standard-v1 | boussinesq-128x128x129 | builtin | 1043.703 | 1062.281 | macos-ps-rss |
+| scaling-standard-v1 | boussinesq-128x128x257 | builtin | 2344.031 | 2376.906 | macos-ps-rss |
+| scaling-standard-v1 | stratified-qg-64x64x65 | builtin | 222.797 | 226.234 | macos-ps-rss |
+| scaling-standard-v1 | stratified-qg-128x128x65 | builtin | 314.609 | 318.016 | macos-ps-rss |
+| scaling-standard-v1 | stratified-qg-256x256x65 | builtin | 700.406 | 712.938 | macos-ps-rss |
+| scaling-standard-v1 | stratified-qg-128x128x33 | builtin | 259.578 | 262.516 | macos-ps-rss |
+| scaling-standard-v1 | stratified-qg-128x128x129 | builtin | 472.125 | 479.469 | macos-ps-rss |
+| scaling-standard-v1 | stratified-qg-128x128x257 | builtin | 729.828 | 742.406 | macos-ps-rss |
+| scaling-standard-v1 | barotropic-qg-128x128 | builtin | 152.969 | 154.422 | macos-ps-rss |
+| scaling-standard-v1 | barotropic-qg-256x256 | builtin | 160.656 | 162.406 | macos-ps-rss |
+| scaling-standard-v1 | barotropic-qg-512x512 | builtin | 202.812 | 206.672 | macos-ps-rss |
+| scaling-standard-v1 | barotropic-qg-1024x1024 | builtin | 360.141 | 365.125 | macos-ps-rss |

--- a/Benchmarks/runWaveVortexBenchmark.m
+++ b/Benchmarks/runWaveVortexBenchmark.m
@@ -1,0 +1,367 @@
+function results = runWaveVortexBenchmark(options)
+% Run versioned WaveVortex performance and memory benchmark suites.
+%
+% This authoring benchmark measures state-advanced nonlinear-advection
+% evaluations while retaining production caches. Ordinary runs are written
+% beneath Benchmarks/results/runs. Reference generation is explicit.
+arguments
+    options.suites (1,:) string = "core-v1"
+    options.backends (1,:) string = "builtin"
+    options.caseIds (1,:) string = strings(1,0)
+    options.outputDirectory (1,1) string = ""
+    options.referenceDirectory (1,1) string = ""
+    options.shouldMeasureMemory (1,1) logical = true
+    options.shouldWriteArtifacts (1,1) logical = true
+    options.shouldCreateReference (1,1) logical = false
+    options.correctnessTolerance (1,1) double {mustBePositive} = 1e-12
+    options.runId (1,1) string = ""
+end
+
+benchmarkFolder = fileparts(mfilename("fullpath"));
+repositoryRoot = fileparts(benchmarkFolder);
+originalDirectory = pwd;
+originalPath = path;
+originalRng = rng;
+stateCleanup = onCleanup(@()restoreState(originalDirectory,originalPath,originalRng));
+addRepositoryPaths(repositoryRoot,benchmarkFolder);
+
+suites = waveVortexBenchmarkSuites(options.suites);
+if ~isempty(options.caseIds)
+    suites = filterSuiteCases(suites,options.caseIds);
+end
+backends = waveVortexBenchmarkBackends(options.backends);
+if options.runId == ""
+    options.runId = string(datetime("now","TimeZone","UTC","Format","yyyyMMdd'T'HHmmss'Z'"));
+end
+if options.referenceDirectory == ""
+    options.referenceDirectory = fullfile(benchmarkFolder,"results","reference");
+end
+if options.outputDirectory == ""
+    options.outputDirectory = fullfile(benchmarkFolder,"results","runs",options.runId + "-" + computer("arch") + "-" + version("-release"));
+end
+
+results = struct("schemaVersion","1.0.0","status","complete","runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",options.suites,"backendIds",options.backends,"caseIds",options.caseIds,"correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",options.shouldMeasureMemory),"suites",emptySuiteResults());
+for iSuite = 1:numel(suites)
+    suiteResult = runSuite(suites(iSuite),backends,options,benchmarkFolder,repositoryRoot);
+    results.suites(end+1) = suiteResult;
+    if suiteResult.status ~= "complete"
+        results.status = "partial";
+    end
+end
+
+if options.shouldWriteArtifacts
+    writeRunArtifacts(results,options.outputDirectory);
+end
+clear stateCleanup
+end
+
+function suiteResult = runSuite(suite,backends,options,benchmarkFolder,repositoryRoot)
+suiteResult = struct("id",suite.id,"version",suite.version,"description",suite.description,"operation",suite.operation,"isScored",suite.isScored,"selectionIsComplete",suite.selectionIsComplete,"status","complete","cases",emptyCaseResults(),"familyScores",emptyScores(),"suiteScores",emptyScores(),"referenceArtifact","");
+for iCase = 1:numel(suite.cases)
+    try
+        caseResult = runCase(suite.cases(iCase),backends,options,benchmarkFolder,repositoryRoot);
+    catch exception
+        caseResult = failedCaseResult(suite.cases(iCase),exception);
+        suiteResult.status = "partial";
+    end
+    suiteResult.cases(end+1) = caseResult;
+end
+if ~suite.selectionIsComplete
+    suiteResult.status = "partial";
+end
+
+referencePath = referenceArtifactPath(options.referenceDirectory,suite.id);
+suiteResult.referenceArtifact = referencePath;
+if options.shouldCreateReference
+    suiteResult = applySelfReferenceScores(suiteResult);
+else
+    suiteResult = applyReferenceScores(suiteResult,referencePath);
+end
+suiteResult = calculateAggregateScores(suiteResult);
+
+if options.shouldCreateReference
+    referenceResults = struct("schemaVersion","1.0.0","status",suiteResult.status,"runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",suite.id,"backendIds","builtin","correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",options.shouldMeasureMemory),"suites",suiteResult);
+    writeRunArtifacts(referenceResults,referencePath);
+end
+end
+
+function caseResult = runCase(benchmarkCase,backends,options,benchmarkFolder,repositoryRoot)
+backendResults = emptyBackendResults();
+models = cell(1,numel(backends));
+states = cell(1,numel(backends));
+for iBackend = 1:numel(backends)
+    constructionTimer = tic;
+    models{iBackend} = createWaveVortexBenchmarkTransform(benchmarkCase,backends(iBackend).id);
+    constructionSeconds = toc(constructionTimer);
+    states{iBackend} = initializeWaveVortexBenchmarkState(models{iBackend},benchmarkCase.seed);
+    advanceWaveVortexBenchmarkState(models{iBackend},states{iBackend},0);
+    firstTimer = tic;
+    executeWaveVortexBenchmarkOperation(models{iBackend},benchmarkCase.operation);
+    firstCallSeconds = toc(firstTimer);
+    backendResults(end+1) = baseBackendResult(backends(iBackend).id,constructionSeconds,firstCallSeconds,benchmarkCase.sampleCount); %#ok<AGROW>
+end
+
+for iWarmup = 1:benchmarkCase.warmupCount
+    for iBackend = 1:numel(backends)
+        advanceWaveVortexBenchmarkState(models{iBackend},states{iBackend},iWarmup);
+        executeWaveVortexBenchmarkOperation(models{iBackend},benchmarkCase.operation);
+    end
+end
+
+for iSample = 1:benchmarkCase.sampleCount
+    sampleOutputs = cell(1,numel(backends));
+    startIndex = mod(iSample-1,numel(backends))+1;
+    executionOrder = [startIndex:numel(backends),1:startIndex-1];
+    for iOrder = executionOrder
+        advanceWaveVortexBenchmarkState(models{iOrder},states{iOrder},benchmarkCase.warmupCount+iSample);
+        sampleTimer = tic;
+        sampleOutputs{iOrder} = executeWaveVortexBenchmarkOperation(models{iOrder},benchmarkCase.operation);
+        backendResults(iOrder).rawSeconds(iSample) = toc(sampleTimer);
+    end
+    builtinIndex = find(string({backends.id}) == "builtin",1);
+    if ~isempty(builtinIndex)
+        for iBackend = 1:numel(backends)
+            backendResults(iBackend).relativeError = max(backendResults(iBackend).relativeError,waveVortexBenchmarkRelativeError(sampleOutputs{builtinIndex},sampleOutputs{iBackend}));
+        end
+    end
+end
+
+for iBackend = 1:numel(backends)
+    backendResults(iBackend).medianSeconds = median(backendResults(iBackend).rawSeconds);
+    cacheTimer = tic;
+    executeWaveVortexBenchmarkOperation(models{iBackend},benchmarkCase.operation);
+    backendResults(iBackend).sameStateCacheHitSeconds = toc(cacheTimer);
+    backendResults(iBackend).correctnessPassed = backendResults(iBackend).relativeError <= options.correctnessTolerance;
+    if options.shouldMeasureMemory
+        backendResults(iBackend).memory = measureCaseMemory(benchmarkCase,backends(iBackend).id,benchmarkFolder,repositoryRoot);
+    end
+end
+caseResult = struct("id",benchmarkCase.id,"transformId",benchmarkCase.transformId,"scoreFamily",benchmarkCase.scoreFamily,"operation",benchmarkCase.operation,"Lxyz",benchmarkCase.Lxyz,"Nxyz",benchmarkCase.Nxyz,"isHydrostatic",benchmarkCase.isHydrostatic,"shouldAntialias",benchmarkCase.shouldAntialias,"seed",benchmarkCase.seed,"warmupCount",benchmarkCase.warmupCount,"sampleCount",benchmarkCase.sampleCount,"status","complete","failure",emptyFailure(),"backends",backendResults);
+clear models
+end
+
+function result = baseBackendResult(backendId,constructionSeconds,firstCallSeconds,sampleCount)
+result = struct("id",backendId,"status","complete","constructionSeconds",constructionSeconds,"firstCallSeconds",firstCallSeconds,"sameStateCacheHitSeconds",NaN,"rawSeconds",NaN(1,sampleCount),"medianSeconds",NaN,"relativeError",0,"correctnessPassed",false,"referenceMedianSeconds",NaN,"caseScore",NaN,"sameHostSpeedup",NaN,"memory",emptyMemory(),"failure",emptyFailure());
+end
+
+function caseResult = failedCaseResult(benchmarkCase,exception)
+caseResult = struct("id",benchmarkCase.id,"transformId",benchmarkCase.transformId,"scoreFamily",benchmarkCase.scoreFamily,"operation",benchmarkCase.operation,"Lxyz",benchmarkCase.Lxyz,"Nxyz",benchmarkCase.Nxyz,"isHydrostatic",benchmarkCase.isHydrostatic,"shouldAntialias",benchmarkCase.shouldAntialias,"seed",benchmarkCase.seed,"warmupCount",benchmarkCase.warmupCount,"sampleCount",benchmarkCase.sampleCount,"status","failed","failure",exceptionFailure(exception),"backends",emptyBackendResults());
+end
+
+function suiteResult = applySelfReferenceScores(suiteResult)
+for iCase = 1:numel(suiteResult.cases)
+    for iBackend = 1:numel(suiteResult.cases(iCase).backends)
+        backend = suiteResult.cases(iCase).backends(iBackend);
+        if backend.id == "builtin" && backend.status == "complete"
+            suiteResult.cases(iCase).backends(iBackend).referenceMedianSeconds = backend.medianSeconds;
+            suiteResult.cases(iCase).backends(iBackend).caseScore = 100;
+            suiteResult.cases(iCase).backends(iBackend).sameHostSpeedup = 1;
+        end
+    end
+end
+end
+
+function suiteResult = applyReferenceScores(suiteResult,referencePath)
+referenceFile = fullfile(referencePath,"benchmark.json");
+if ~isfile(referenceFile)
+    return
+end
+reference = jsondecode(fileread(referenceFile));
+referenceSuite = reference.suites(1);
+for iCase = 1:numel(suiteResult.cases)
+    referenceCaseIndex = find(string({referenceSuite.cases.id}) == suiteResult.cases(iCase).id,1);
+    if isempty(referenceCaseIndex)
+        continue
+    end
+    referenceBuiltinIndex = find(string({referenceSuite.cases(referenceCaseIndex).backends.id}) == "builtin",1);
+    currentBuiltinIndex = find(string({suiteResult.cases(iCase).backends.id}) == "builtin",1);
+    if isempty(referenceBuiltinIndex)
+        continue
+    end
+    referenceMedian = referenceSuite.cases(referenceCaseIndex).backends(referenceBuiltinIndex).medianSeconds;
+    currentBuiltinMedian = NaN;
+    if ~isempty(currentBuiltinIndex)
+        currentBuiltinMedian = suiteResult.cases(iCase).backends(currentBuiltinIndex).medianSeconds;
+    end
+    for iBackend = 1:numel(suiteResult.cases(iCase).backends)
+        medianSeconds = suiteResult.cases(iCase).backends(iBackend).medianSeconds;
+        suiteResult.cases(iCase).backends(iBackend).referenceMedianSeconds = referenceMedian;
+        suiteResult.cases(iCase).backends(iBackend).caseScore = 100*referenceMedian/medianSeconds;
+        suiteResult.cases(iCase).backends(iBackend).sameHostSpeedup = currentBuiltinMedian/medianSeconds;
+    end
+end
+end
+
+function suiteResult = calculateAggregateScores(suiteResult)
+if ~suiteResult.isScored || ~suiteResult.selectionIsComplete
+    return
+end
+backendIds = strings(1,0);
+for iCase = 1:numel(suiteResult.cases)
+    backendIds = union(backendIds,string({suiteResult.cases(iCase).backends.id}),"stable");
+end
+families = unique(string({suiteResult.cases.scoreFamily}),"stable");
+for backendId = backendIds
+    familyValues = NaN(1,numel(families));
+    for iFamily = 1:numel(families)
+        caseMask = string({suiteResult.cases.scoreFamily}) == families(iFamily);
+        scores = NaN(1,nnz(caseMask));
+        selectedCases = suiteResult.cases(caseMask);
+        for iCase = 1:numel(selectedCases)
+            backendIndex = find(string({selectedCases(iCase).backends.id}) == backendId,1);
+            if ~isempty(backendIndex)
+                scores(iCase) = selectedCases(iCase).backends(backendIndex).caseScore;
+            end
+        end
+        if all(isfinite(scores))
+            familyValues(iFamily) = exp(mean(log(scores)));
+            suiteResult.familyScores(end+1) = struct("id",families(iFamily),"backendId",backendId,"score",familyValues(iFamily));
+        end
+    end
+    if all(isfinite(familyValues))
+        suiteResult.suiteScores(end+1) = struct("id",suiteResult.id,"backendId",backendId,"score",exp(mean(log(familyValues))));
+    end
+end
+end
+
+function memory = measureCaseMemory(benchmarkCase,backendId,benchmarkFolder,repositoryRoot)
+memory = emptyMemory();
+configPath = string(tempname) + ".json";
+outputPath = string(tempname) + ".json";
+config = struct("benchmarkCase",benchmarkCase,"backendId",backendId,"repositoryRoot",repositoryRoot,"benchmarkFolder",benchmarkFolder);
+writeText(configPath,jsonencode(config));
+cleanup = onCleanup(@()deleteTemporaryFiles(configPath,outputPath));
+matlabExecutable = fullfile(matlabroot,"bin","matlab");
+statement = "addpath('" + replace(benchmarkFolder,"'","''") + "'); waveVortexBenchmarkMemoryWorker('" + replace(configPath,"'","''") + "','" + replace(outputPath,"'","''") + "')";
+command = sprintf('"%s" -batch "%s"',matlabExecutable,replace(statement,'"','\"'));
+[exitCode,commandOutput] = system(command);
+if exitCode ~= 0 || ~isfile(outputPath)
+    memory.status = "failed";
+    memory.failure = struct("identifier","WaveVortexBenchmark:MemoryWorkerFailed","message",string(commandOutput),"stack",strings(0,1));
+    return
+end
+memory = jsondecode(fileread(outputPath));
+clear cleanup
+end
+
+function writeRunArtifacts(results,outputDirectory)
+if ~isfolder(outputDirectory)
+    mkdir(outputDirectory);
+end
+writeText(fullfile(outputDirectory,"benchmark.json"),jsonencode(results,PrettyPrint=true));
+writeText(fullfile(outputDirectory,"summary.md"),benchmarkSummary(results));
+end
+
+function summary = benchmarkSummary(results)
+summary = waveVortexBenchmarkSummary(results);
+end
+
+function environment = benchmarkEnvironment(repositoryRoot)
+[~,commit] = system(sprintf('git -C "%s" rev-parse HEAD',repositoryRoot));
+[~,dirty] = system(sprintf('git -C "%s" status --porcelain',repositoryRoot));
+environment = struct("os",string(system_dependent("getos")),"processor",string(system_dependent("getcpu")),"physicalMemoryBytes",physicalMemoryBytes(),"matlabVersion",string(version),"matlabRelease",string(version("-release")),"architecture",string(computer("arch")),"requestedThreads",maxNumCompThreads,"sourceCommit",strtrim(string(commit)),"sourceDirty",strlength(strtrim(string(dirty))) > 0);
+end
+
+function bytes = physicalMemoryBytes()
+bytes = NaN;
+if ispc
+    [~,systemMemory] = memory;
+    bytes = double(systemMemory.PhysicalMemory.Total);
+elseif ismac
+    [status,output] = system("sysctl -n hw.memsize");
+    if status == 0
+        bytes = str2double(strtrim(output));
+    end
+elseif isunix && isfile("/proc/meminfo")
+    text = fileread("/proc/meminfo");
+    token = regexp(text,"MemTotal:\s+(\d+)\s+kB","tokens","once");
+    if ~isempty(token)
+        bytes = 1024*str2double(token{1});
+    end
+end
+end
+
+function path = referenceArtifactPath(referenceDirectory,suiteId)
+path = fullfile(referenceDirectory,suiteId + "-m5-max-r2026a-builtin");
+end
+
+function addRepositoryPaths(repositoryRoot,benchmarkFolder)
+addpath(repositoryRoot,benchmarkFolder);
+metadata = jsondecode(fileread(fullfile(repositoryRoot,"resources","mpackage.json")));
+for iFolder = 1:numel(metadata.folders)
+    folder = fullfile(repositoryRoot,metadata.folders(iFolder).path);
+    if isfolder(folder)
+        addpath(folder);
+    end
+end
+end
+
+function suites = filterSuiteCases(suites,caseIds)
+foundIds = strings(1,0);
+for iSuite = 1:numel(suites)
+    suiteCaseIds = string({suites(iSuite).cases.id});
+    keep = ismember(suiteCaseIds,caseIds);
+    if nnz(keep) ~= numel(suiteCaseIds)
+        suites(iSuite).selectionIsComplete = false;
+    end
+    suites(iSuite).cases = suites(iSuite).cases(keep);
+    foundIds = union(foundIds,suiteCaseIds(keep),"stable");
+end
+unknownIds = setdiff(caseIds,foundIds);
+if ~isempty(unknownIds)
+    error("WaveVortexBenchmark:UnknownCase","Unknown benchmark case: %s.",strjoin(unknownIds,", "));
+end
+suites = suites(arrayfun(@(suite)~isempty(suite.cases),suites));
+end
+
+function restoreState(originalDirectory,originalPath,originalRng)
+cd(originalDirectory);
+path(originalPath);
+rng(originalRng);
+end
+
+function writeText(pathname,contents)
+fileId = fopen(pathname,"w");
+if fileId < 0
+    error("WaveVortexBenchmark:ArtifactWriteFailed","Unable to open %s for writing.",pathname);
+end
+cleanup = onCleanup(@()fclose(fileId));
+fprintf(fileId,"%s",contents);
+clear cleanup
+end
+
+function deleteTemporaryFiles(varargin)
+for iFile = 1:numel(varargin)
+    if isfile(varargin{iFile})
+        delete(varargin{iFile});
+    end
+end
+end
+
+function failure = exceptionFailure(exception)
+failure = struct("identifier",string(exception.identifier),"message",string(exception.message),"stack",string({exception.stack.name}));
+end
+
+function failure = emptyFailure()
+failure = struct("identifier","","message","","stack",strings(0,1));
+end
+
+function memory = emptyMemory()
+memory = struct("status","not-requested","provider","","baselineBytes",NaN,"persistentBytes",NaN,"peakBytes",NaN,"persistentIncrementBytes",NaN,"peakIncrementBytes",NaN,"samplingIntervalSeconds",NaN,"failure",emptyFailure());
+end
+
+function results = emptySuiteResults()
+results = struct("id",{},"version",{},"description",{},"operation",{},"isScored",{},"selectionIsComplete",{},"status",{},"cases",{},"familyScores",{},"suiteScores",{},"referenceArtifact",{});
+end
+
+function results = emptyCaseResults()
+results = struct("id",{},"transformId",{},"scoreFamily",{},"operation",{},"Lxyz",{},"Nxyz",{},"isHydrostatic",{},"shouldAntialias",{},"seed",{},"warmupCount",{},"sampleCount",{},"status",{},"failure",{},"backends",{});
+end
+
+function results = emptyBackendResults()
+results = struct("id",{},"status",{},"constructionSeconds",{},"firstCallSeconds",{},"sameStateCacheHitSeconds",{},"rawSeconds",{},"medianSeconds",{},"relativeError",{},"correctnessPassed",{},"referenceMedianSeconds",{},"caseScore",{},"sameHostSpeedup",{},"memory",{},"failure",{});
+end
+
+function results = emptyScores()
+results = struct("id",{},"backendId",{},"score",{});
+end

--- a/Benchmarks/waveVortexBenchmarkBackends.m
+++ b/Benchmarks/waveVortexBenchmarkBackends.m
@@ -1,0 +1,12 @@
+function backends = waveVortexBenchmarkBackends(backendIds)
+% Return registered WaveVortex benchmark backend descriptors.
+arguments
+    backendIds (1,:) string = "builtin"
+end
+registry = struct("id","builtin","description","MATLAB builtin WaveVortex transform implementation");
+unknownIds = setdiff(backendIds,string({registry.id}));
+if ~isempty(unknownIds)
+    error("WaveVortexBenchmark:UnknownBackend","Unknown benchmark backend: %s.",strjoin(unknownIds,", "));
+end
+backends = registry(ismember(string({registry.id}),backendIds));
+end

--- a/Benchmarks/waveVortexBenchmarkMemoryWorker.m
+++ b/Benchmarks/waveVortexBenchmarkMemoryWorker.m
@@ -1,0 +1,92 @@
+function waveVortexBenchmarkMemoryWorker(configPath,outputPath)
+% Execute one benchmark case in a fresh MATLAB process for RSS accounting.
+arguments
+    configPath (1,1) string
+    outputPath (1,1) string
+end
+config = jsondecode(fileread(configPath));
+originalDirectory = pwd;
+originalPath = path;
+originalRng = rng;
+cleanup = onCleanup(@()restoreState(originalDirectory,originalPath,originalRng));
+result = emptyResult();
+try
+    addpath(config.repositoryRoot,config.benchmarkFolder);
+    metadata = jsondecode(fileread(fullfile(config.repositoryRoot,"resources","mpackage.json")));
+    for iFolder = 1:numel(metadata.folders)
+        folder = fullfile(config.repositoryRoot,metadata.folders(iFolder).path);
+        if isfolder(folder)
+            addpath(folder);
+        end
+    end
+    [baselineBytes,provider] = currentResidentBytes();
+    wvt = createWaveVortexBenchmarkTransform(config.benchmarkCase,config.backendId);
+    state = initializeWaveVortexBenchmarkState(wvt,config.benchmarkCase.seed);
+    for iWarmup = 1:config.benchmarkCase.warmupCount
+        advanceWaveVortexBenchmarkState(wvt,state,iWarmup);
+        executeWaveVortexBenchmarkOperation(wvt,config.benchmarkCase.operation);
+    end
+    persistentBytes = currentResidentBytes();
+    peakBytes = persistentBytes;
+    nPeakSamples = max(3,config.benchmarkCase.sampleCount);
+    for iSample = 1:nPeakSamples
+        advanceWaveVortexBenchmarkState(wvt,state,config.benchmarkCase.warmupCount+iSample);
+        outputs = executeWaveVortexBenchmarkOperation(wvt,config.benchmarkCase.operation); %#ok<NASGU>
+        peakBytes = max(peakBytes,currentResidentBytes());
+    end
+    result = struct("status","complete","provider",provider,"baselineBytes",baselineBytes,"persistentBytes",persistentBytes,"peakBytes",peakBytes,"persistentIncrementBytes",max(0,persistentBytes-baselineBytes),"peakIncrementBytes",max(0,peakBytes-baselineBytes),"samplingIntervalSeconds",0,"failure",emptyFailure());
+catch exception
+    result.status = "failed";
+    result.failure = struct("identifier",string(exception.identifier),"message",string(exception.message),"stack",string({exception.stack.name}));
+end
+writeText(outputPath,jsonencode(result,PrettyPrint=true));
+clear cleanup
+end
+
+function [bytes,provider] = currentResidentBytes()
+if ispc
+    userMemory = memory;
+    bytes = double(userMemory.MemUsedMATLAB);
+    provider = "matlab-memory";
+    return
+end
+pid = java.lang.ProcessHandle.current().pid();
+[status,output] = system("ps -o rss= -p " + pid);
+if status ~= 0
+    error("WaveVortexBenchmark:RSSUnavailable","Unable to query resident memory: %s",output);
+end
+kilobytes = str2double(strtrim(output));
+if ~isfinite(kilobytes)
+    error("WaveVortexBenchmark:RSSParseFailed","Unable to parse resident memory from: %s",output);
+end
+bytes = 1024*kilobytes;
+if ismac
+    provider = "macos-ps-rss";
+else
+    provider = "linux-ps-rss";
+end
+end
+
+function restoreState(originalDirectory,originalPath,originalRng)
+cd(originalDirectory);
+path(originalPath);
+rng(originalRng);
+end
+
+function writeText(pathname,contents)
+fileId = fopen(pathname,"w");
+if fileId < 0
+    error("WaveVortexBenchmark:ArtifactWriteFailed","Unable to open %s for writing.",pathname);
+end
+cleanup = onCleanup(@()fclose(fileId));
+fprintf(fileId,"%s",contents);
+clear cleanup
+end
+
+function result = emptyResult()
+result = struct("status","failed","provider","","baselineBytes",NaN,"persistentBytes",NaN,"peakBytes",NaN,"persistentIncrementBytes",NaN,"peakIncrementBytes",NaN,"samplingIntervalSeconds",NaN,"failure",emptyFailure());
+end
+
+function failure = emptyFailure()
+failure = struct("identifier","","message","","stack",strings(0,1));
+end

--- a/Benchmarks/waveVortexBenchmarkRelativeError.m
+++ b/Benchmarks/waveVortexBenchmarkRelativeError.m
@@ -1,0 +1,22 @@
+function relativeError = waveVortexBenchmarkRelativeError(referenceOutputs,candidateOutputs)
+% Return the maximum relative infinity error across operation outputs.
+arguments
+    referenceOutputs (1,:) cell
+    candidateOutputs (1,:) cell
+end
+if numel(referenceOutputs) ~= numel(candidateOutputs)
+    relativeError = Inf;
+    return
+end
+relativeError = 0;
+for iOutput = 1:numel(referenceOutputs)
+    reference = referenceOutputs{iOutput};
+    candidate = candidateOutputs{iOutput};
+    if ~isequal(size(reference),size(candidate))
+        relativeError = Inf;
+        return
+    end
+    denominator = max(norm(reference(:),Inf),realmin("double"));
+    relativeError = max(relativeError,norm(candidate(:)-reference(:),Inf)/denominator);
+end
+end

--- a/Benchmarks/waveVortexBenchmarkScores.m
+++ b/Benchmarks/waveVortexBenchmarkScores.m
@@ -1,0 +1,18 @@
+function scores = waveVortexBenchmarkScores(referenceSeconds,measuredSeconds,familyIds)
+% Calculate case, family, and suite benchmark scores.
+arguments
+    referenceSeconds (:,1) double {mustBePositive}
+    measuredSeconds (:,1) double {mustBePositive}
+    familyIds (:,1) string
+end
+if numel(referenceSeconds) ~= numel(measuredSeconds) || numel(referenceSeconds) ~= numel(familyIds)
+    error("WaveVortexBenchmark:ScoreSizeMismatch","Reference times, measured times, and family IDs must have equal lengths.");
+end
+caseScores = 100*referenceSeconds./measuredSeconds;
+families = unique(familyIds,"stable");
+familyScores = NaN(size(families));
+for iFamily = 1:numel(families)
+    familyScores(iFamily) = exp(mean(log(caseScores(familyIds == families(iFamily)))));
+end
+scores = struct("caseScores",caseScores,"familyIds",families,"familyScores",familyScores,"suiteScore",exp(mean(log(familyScores))));
+end

--- a/Benchmarks/waveVortexBenchmarkSuites.m
+++ b/Benchmarks/waveVortexBenchmarkSuites.m
@@ -1,0 +1,124 @@
+function suites = waveVortexBenchmarkSuites(suiteIds)
+% Return validated, versioned WaveVortex benchmark suite definitions.
+arguments
+    suiteIds (1,:) string = ["core-v1"]
+end
+
+registry = suiteRegistry();
+unknownIds = setdiff(suiteIds,string({registry.id}));
+if ~isempty(unknownIds)
+    error("WaveVortexBenchmark:UnknownSuite","Unknown benchmark suite: %s.",strjoin(unknownIds,", "));
+end
+suites = registry(ismember(string({registry.id}),suiteIds));
+for iSuite = 1:numel(suites)
+    validateSuite(suites(iSuite));
+end
+end
+
+function suites = suiteRegistry()
+suites = [smokeSuite(),coreSuite(),standardScalingSuite(),largeScalingSuite()];
+end
+
+function suite = smokeSuite()
+suite = baseSuite("smoke-v1","Small correctness and harness-validation cases",false);
+suite.cases = [ ...
+    make3DCase("smoke-constant-nonhydrostatic","constant-nonhydrostatic",[16 16 9],false,2,1,1101), ...
+    make3DCase("smoke-constant-hydrostatic","constant-hydrostatic",[16 16 9],true,2,1,1102), ...
+    make3DCase("smoke-hydrostatic","hydrostatic",[16 16 9],true,2,1,1103), ...
+    make3DCase("smoke-boussinesq","boussinesq",[16 16 9],false,2,1,1104), ...
+    make3DCase("smoke-stratified-qg","stratified-qg",[16 16 9],true,2,1,1105), ...
+    make2DCase("smoke-barotropic-qg","barotropic-qg",[32 32],2,1,1106)];
+end
+
+function suite = coreSuite()
+suite = baseSuite("core-v1","Canonical constant-stratification nonlinear-advection score",true);
+suite.cases = [ ...
+    make3DCase("constant-nonhydrostatic-256x256x65","constant-nonhydrostatic",[256 256 65],false,7,2,2101), ...
+    make3DCase("constant-hydrostatic-256x256x65","constant-hydrostatic",[256 256 65],true,7,2,2102), ...
+    make3DCase("constant-nonhydrostatic-512x512x129","constant-nonhydrostatic",[512 512 129],false,3,2,2103), ...
+    make3DCase("constant-hydrostatic-512x512x129","constant-hydrostatic",[512 512 129],true,3,2,2104)];
+end
+
+function suite = standardScalingSuite()
+suite = baseSuite("scaling-standard-v1","Standard horizontal and vertical scaling across transform families",true);
+families = ["constant-nonhydrostatic" "constant-hydrostatic" "hydrostatic" "boussinesq" "stratified-qg"];
+hydrostatic = [false true true false true];
+horizontalSizes = [64 64 65; 128 128 65; 256 256 65];
+verticalSizes = [128 128 33; 128 128 129; 128 128 257];
+cases = emptyCases();
+seed = 3000;
+for iFamily = 1:numel(families)
+    sizes = [horizontalSizes;verticalSizes];
+    for iSize = 1:size(sizes,1)
+        seed = seed + 1;
+        caseId = families(iFamily) + "-" + join(string(sizes(iSize,:)),"x");
+        cases(end+1) = make3DCase(caseId,families(iFamily),sizes(iSize,:),hydrostatic(iFamily),7,2,seed); %#ok<AGROW>
+    end
+end
+for nxy = [128 256 512 1024]
+    seed = seed + 1;
+    cases(end+1) = make2DCase("barotropic-qg-" + nxy + "x" + nxy,"barotropic-qg",[nxy nxy],7,2,seed); %#ok<AGROW>
+end
+suite.cases = cases;
+end
+
+function suite = largeScalingSuite()
+suite = baseSuite("scaling-large-v1","Large-memory scaling across transform families",true);
+families = ["constant-nonhydrostatic" "constant-hydrostatic" "hydrostatic" "boussinesq" "stratified-qg"];
+hydrostatic = [false true true false true];
+commonSizes = [256 256 129; 512 512 129; 512 512 257];
+cases = emptyCases();
+seed = 4000;
+for iFamily = 1:numel(families)
+    sizes = commonSizes;
+    if startsWith(families(iFamily),"constant-")
+        sizes(end+1,:) = [1024 1024 129]; %#ok<AGROW>
+    end
+    for iSize = 1:size(sizes,1)
+        seed = seed + 1;
+        caseId = families(iFamily) + "-" + join(string(sizes(iSize,:)),"x");
+        cases(end+1) = make3DCase(caseId,families(iFamily),sizes(iSize,:),hydrostatic(iFamily),3,2,seed); %#ok<AGROW>
+    end
+end
+for nxy = [2048 4096]
+    seed = seed + 1;
+    cases(end+1) = make2DCase("barotropic-qg-" + nxy + "x" + nxy,"barotropic-qg",[nxy nxy],3,2,seed); %#ok<AGROW>
+end
+suite.cases = cases;
+end
+
+function suite = baseSuite(id,description,isScored)
+suite = struct("id",id,"version",1,"description",description,"operation","nonlinearAdvection","isScored",isScored,"selectionIsComplete",true,"cases",emptyCases());
+end
+
+function benchmarkCase = make3DCase(id,transformId,Nxyz,isHydrostatic,sampleCount,warmupCount,seed)
+benchmarkCase = baseCase(id,transformId,Nxyz,isHydrostatic,sampleCount,warmupCount,seed);
+benchmarkCase.Lxyz = [15e3 15e3 1300];
+end
+
+function benchmarkCase = make2DCase(id,transformId,Nxy,sampleCount,warmupCount,seed)
+benchmarkCase = baseCase(id,transformId,Nxy,true,sampleCount,warmupCount,seed);
+benchmarkCase.Lxyz = [15e3 15e3];
+end
+
+function benchmarkCase = baseCase(id,transformId,Nxyz,isHydrostatic,sampleCount,warmupCount,seed)
+benchmarkCase = struct("id",string(id),"transformId",string(transformId),"scoreFamily",string(transformId),"operation","nonlinearAdvection","Lxyz",[],"Nxyz",double(Nxyz),"isHydrostatic",logical(isHydrostatic),"shouldAntialias",true,"seed",double(seed),"warmupCount",double(warmupCount),"sampleCount",double(sampleCount));
+end
+
+function cases = emptyCases()
+cases = struct("id",{},"transformId",{},"scoreFamily",{},"operation",{},"Lxyz",{},"Nxyz",{},"isHydrostatic",{},"shouldAntialias",{},"seed",{},"warmupCount",{},"sampleCount",{});
+end
+
+function validateSuite(suite)
+if strlength(suite.id) == 0 || isempty(suite.cases)
+    error("WaveVortexBenchmark:InvalidSuite","Suite definitions require an ID and at least one case.");
+end
+caseIds = string({suite.cases.id});
+if numel(unique(caseIds)) ~= numel(caseIds)
+    error("WaveVortexBenchmark:DuplicateCase","Suite %s contains duplicate case IDs.",suite.id);
+end
+knownTransforms = ["constant-nonhydrostatic" "constant-hydrostatic" "hydrostatic" "boussinesq" "stratified-qg" "barotropic-qg"];
+if ~all(ismember(string({suite.cases.transformId}),knownTransforms))
+    error("WaveVortexBenchmark:InvalidTransform","Suite %s contains an unknown transform ID.",suite.id);
+end
+end

--- a/Benchmarks/waveVortexBenchmarkSummary.m
+++ b/Benchmarks/waveVortexBenchmarkSummary.m
@@ -1,0 +1,54 @@
+function summary = waveVortexBenchmarkSummary(results)
+% Render a WaveVortex benchmark result as a Markdown summary.
+arguments
+    results (1,1) struct
+end
+lines = ["# WaveVortex benchmark";"";"- Status: `" + results.status + "`";"- Run: `" + results.runId + "`";"- MATLAB: `" + results.environment.matlabRelease + "`";"- Architecture: `" + results.environment.architecture + "`";"";"## Suite scores";"";"| Suite | Backend | Score |";"|---|---|---:|"];
+for iSuite = 1:numel(results.suites)
+    for iScore = 1:numel(results.suites(iSuite).suiteScores)
+        score = results.suites(iSuite).suiteScores(iScore);
+        lines(end+1) = sprintf("| %s | %s | %.3f |",results.suites(iSuite).id,score.backendId,score.score); %#ok<AGROW>
+    end
+end
+lines = [lines;"";"## Family scores";"";"| Suite | Family | Backend | Score |";"|---|---|---|---:|"];
+for iSuite = 1:numel(results.suites)
+    for iScore = 1:numel(results.suites(iSuite).familyScores)
+        score = results.suites(iSuite).familyScores(iScore);
+        lines(end+1) = sprintf("| %s | %s | %s | %.3f |",results.suites(iSuite).id,score.id,score.backendId,score.score); %#ok<AGROW>
+    end
+end
+lines = [lines;"";"## Timing and scores";"";"| Suite | Case | Transform | Backend | Median (ms) | Reference score | Same-host speedup | Error |";"|---|---|---|---|---:|---:|---:|---:|"];
+for iSuite = 1:numel(results.suites)
+    suite = results.suites(iSuite);
+    for iCase = 1:numel(suite.cases)
+        benchmarkCase = suite.cases(iCase);
+        for iBackend = 1:numel(benchmarkCase.backends)
+            backend = benchmarkCase.backends(iBackend);
+            lines(end+1) = sprintf("| %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3g |",suite.id,benchmarkCase.id,benchmarkCase.transformId,backend.id,1e3*backend.medianSeconds,backend.caseScore,backend.sameHostSpeedup,backend.relativeError); %#ok<AGROW>
+        end
+    end
+end
+lines = [lines;"";"## Construction and cache diagnostics";"";"| Suite | Case | Backend | Construction (s) | First call (ms) | Same-state cache hit (ms) |";"|---|---|---|---:|---:|---:|"];
+for iSuite = 1:numel(results.suites)
+    suite = results.suites(iSuite);
+    for iCase = 1:numel(suite.cases)
+        benchmarkCase = suite.cases(iCase);
+        for iBackend = 1:numel(benchmarkCase.backends)
+            backend = benchmarkCase.backends(iBackend);
+            lines(end+1) = sprintf("| %s | %s | %s | %.3f | %.3f | %.3f |",suite.id,benchmarkCase.id,backend.id,backend.constructionSeconds,1e3*backend.firstCallSeconds,1e3*backend.sameStateCacheHitSeconds); %#ok<AGROW>
+        end
+    end
+end
+lines = [lines;"";"## Memory";"";"| Suite | Case | Backend | Persistent increment (MiB) | Peak increment (MiB) | Provider |";"|---|---|---|---:|---:|---|"];
+for iSuite = 1:numel(results.suites)
+    suite = results.suites(iSuite);
+    for iCase = 1:numel(suite.cases)
+        benchmarkCase = suite.cases(iCase);
+        for iBackend = 1:numel(benchmarkCase.backends)
+            backend = benchmarkCase.backends(iBackend);
+            lines(end+1) = sprintf("| %s | %s | %s | %.3f | %.3f | %s |",suite.id,benchmarkCase.id,backend.id,backend.memory.persistentIncrementBytes/2^20,backend.memory.peakIncrementBytes/2^20,backend.memory.provider); %#ok<AGROW>
+        end
+    end
+end
+summary = strjoin(lines,newline) + newline;
+end

--- a/UnitTests/TestWaveVortexBenchmark.m
+++ b/UnitTests/TestWaveVortexBenchmark.m
@@ -1,0 +1,100 @@
+classdef TestWaveVortexBenchmark < matlab.unittest.TestCase
+    properties
+        repositoryRoot
+        benchmarkFolder
+        temporaryFolder
+    end
+
+    methods (TestClassSetup)
+        function addBenchmarkPath(testCase)
+            testCase.repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            testCase.benchmarkFolder = fullfile(testCase.repositoryRoot,"Benchmarks");
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(testCase.benchmarkFolder));
+        end
+    end
+
+    methods (TestMethodSetup)
+        function createTemporaryFolder(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            testCase.temporaryFolder = string(fixture.Folder);
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function suiteRegistryIsVersionedAndTransformSpecific(testCase)
+            suites = waveVortexBenchmarkSuites(["smoke-v1" "core-v1" "scaling-standard-v1" "scaling-large-v1"]);
+            testCase.verifyEqual(string({suites.id}),["smoke-v1" "core-v1" "scaling-standard-v1" "scaling-large-v1"]);
+            testCase.verifyEqual([suites.version],[1 1 1 1]);
+            testCase.verifyEqual(numel(suites(1).cases),6);
+            testCase.verifyEqual(numel(suites(2).cases),4);
+            testCase.verifyEqual(numel(suites(3).cases),34);
+            testCase.verifyEqual(numel(suites(4).cases),19);
+            testCase.verifyTrue(all(ismember(["constant-nonhydrostatic" "constant-hydrostatic" "hydrostatic" "boussinesq" "stratified-qg" "barotropic-qg"],unique(string({suites(3).cases.transformId})))));
+            testCase.verifyError(@()waveVortexBenchmarkSuites("missing-v1"),"WaveVortexBenchmark:UnknownSuite");
+            testCase.verifyError(@()waveVortexBenchmarkBackends("missing"),"WaveVortexBenchmark:UnknownBackend");
+        end
+
+        function scoringUsesEqualFamilyWeights(testCase)
+            scores = waveVortexBenchmarkScores([2;4;10],[1;2;10],["a";"a";"b"]);
+            testCase.verifyEqual(scores.caseScores,[200;200;100],AbsTol=1e-12);
+            testCase.verifyEqual(scores.familyScores,[200;100],AbsTol=1e-12);
+            testCase.verifyEqual(scores.suiteScore,sqrt(20000),AbsTol=1e-12);
+            testCase.verifyError(@()waveVortexBenchmarkScores([1;2],1,["a";"b"]),"WaveVortexBenchmark:ScoreSizeMismatch");
+        end
+
+        function smokeSuiteRunsWithProductionCacheSemantics(testCase)
+            originalDirectory = pwd;
+            originalPath = path;
+            originalRng = rng;
+            results = runWaveVortexBenchmark(suites="smoke-v1",shouldMeasureMemory=false,shouldWriteArtifacts=false);
+            testCase.verifyEqual(results.status,"complete");
+            testCase.verifyEqual(string({results.suites.cases.status}),repmat("complete",1,6));
+            for benchmarkCase = results.suites.cases
+                backend = benchmarkCase.backends;
+                testCase.verifyNumElements(backend.rawSeconds,benchmarkCase.sampleCount);
+                testCase.verifyTrue(all(isfinite(backend.rawSeconds)));
+                testCase.verifyGreaterThan(backend.medianSeconds,0);
+                testCase.verifyGreaterThan(backend.firstCallSeconds,0);
+                testCase.verifyGreaterThan(backend.sameStateCacheHitSeconds,0);
+                testCase.verifyLessThanOrEqual(backend.relativeError,1e-12);
+                testCase.verifyTrue(backend.correctnessPassed);
+                testCase.verifyEqual(backend.memory.status,"not-requested");
+            end
+            testCase.verifyEqual(pwd,originalDirectory);
+            testCase.verifyEqual(path,originalPath);
+            testCase.verifyEqual(rng,originalRng);
+        end
+
+        function artifactsAndReferenceRoundTrip(testCase)
+            runFolder = fullfile(testCase.temporaryFolder,"run");
+            referenceFolder = fullfile(testCase.temporaryFolder,"reference");
+            results = runWaveVortexBenchmark(suites="smoke-v1",caseIds="smoke-constant-hydrostatic",outputDirectory=runFolder,referenceDirectory=referenceFolder,shouldMeasureMemory=false,shouldCreateReference=true,runId="test-run");
+            testCase.verifyTrue(isfile(fullfile(runFolder,"benchmark.json")));
+            testCase.verifyTrue(isfile(fullfile(runFolder,"summary.md")));
+            referencePath = fullfile(referenceFolder,"smoke-v1-m5-max-r2026a-builtin");
+            testCase.verifyTrue(isfile(fullfile(referencePath,"benchmark.json")));
+            decoded = jsondecode(fileread(fullfile(runFolder,"benchmark.json")));
+            testCase.verifyEqual(string(decoded.schemaVersion),"1.0.0");
+            testCase.verifyEqual(decoded.suites.cases.backends.caseScore,100);
+            summary = fileread(fullfile(runFolder,"summary.md"));
+            testCase.verifySubstring(summary,"## Suite scores");
+            testCase.verifySubstring(summary,"## Family scores");
+            testCase.verifySubstring(summary,"## Timing and scores");
+            testCase.verifySubstring(summary,"## Construction and cache diagnostics");
+            testCase.verifySubstring(summary,"## Memory");
+            testCase.verifyEqual(results.runId,"test-run");
+            testCase.verifyEqual(results.status,"partial");
+            testCase.verifyFalse(results.suites.selectionIsComplete);
+        end
+
+        function freshProcessMemoryIsRecorded(testCase)
+            results = runWaveVortexBenchmark(suites="smoke-v1",caseIds="smoke-barotropic-qg",shouldMeasureMemory=true,shouldWriteArtifacts=false);
+            memory = results.suites.cases.backends.memory;
+            testCase.verifyEqual(string(memory.status),"complete");
+            testCase.verifyGreaterThan(memory.baselineBytes,0);
+            testCase.verifyGreaterThanOrEqual(memory.persistentIncrementBytes,0);
+            testCase.verifyGreaterThanOrEqual(memory.peakIncrementBytes,memory.persistentIncrementBytes);
+            testCase.verifyNotEmpty(memory.provider);
+        end
+    end
+end


### PR DESCRIPTION
Implements #59.

Adds the extensible WaveVortex performance and memory benchmark framework, named suites and backend registry, production-cache timing semantics, peak-RSS measurement, resumable artifacts, normalized comparison scores, documentation, tests, and canonical reference runs.

Verification:
- Full test suite: 573 passed, 0 failed, 0 incomplete
- Focused benchmark tests passed
- MATLAB code checks passed
- core-v1: complete
- scaling-standard-v1: complete
- scaling-large-v1: explicitly partial; aggregate scores suppressed