### PR TITLE
Correct the Stable WVTransform and WVModel API reference

### DIFF
--- a/@WVModel/WVModel.m
+++ b/@WVModel/WVModel.m
@@ -1,33 +1,21 @@
 classdef WVModel < handle & WVModelAdaptiveTimeStepMethods & WVModelFixedTimeStepMethods & WVModelAdaptiveTimeStepCellMethods
-    % The WVModel is responsible for time-stepping (integrating) the ocean state forward in time, as represented by a WVTransform.
+    % Integrate a fluid state represented by a WVTransform.
     %
-    % Assuming you have already initialized a WVTransform, e.g.,
+    % Construct a transform and use it to initialize the model:
     % ```matlab
-    % wvt = WVTransformConstantStratification([Lx, Ly, Lz], [Nx, Ny, Nz], N0,latitude=latitude);
-    % ```
-    % and maybe set some initial conditions, you can then initialize the
-    % model,
-    % ```matlab
-    % model = WVModel(wvt)
-    % ```
-    % 
-    % By default the model only takes a linear time-step. To specify a
-    % nonlinear flux on initialization, for example,
-    %```matlab
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,9],N0=5.2e-3,latitude=45);
     % model = WVModel(wvt);
-    %```
+    % ```
+    % By default `WVModel` integrates the transform's nonlinear forcing and
+    % registers its coefficient observing system. Pass
+    % `shouldUseLinearDynamics=true` for analytical linear evolution. Use
+    % `setupIntegrator` to select the Stable fixed or adaptive integrator;
+    % `adaptive-cell` remains Experimental.
     %
-    % You can also initialize a model from existing output,
+    % Restore a model and its output graph from one restart-capable file:
     % ```matlab
-    % model = WVModel.modelFromFile('SomeFile.nc');
-    %```
-    % 
-    % Advanced usage
-    % --------------
-    %
-    % 1. Create 1 or more NetCDFFiles
-    % 2. Add 1 or more WVModelOutputGroups to each file
-    % 3. Add 1 or more WVObservingSystems to each output group.
+    % model = WVModel.modelFromFile("SomeFile.nc");
+    % ```
     %
     % - Topic: Initialization
     % - Topic: Model Properties
@@ -35,9 +23,12 @@ classdef WVModel < handle & WVModelAdaptiveTimeStepMethods & WVModelFixedTimeSte
     % - Topic: Particles
     % - Topic: Tracer
     % - Topic: Writing to NetCDF files
+    % - Topic: Integrated observing systems
+    % - Topic: Developer
+    % - Declaration: classdef WVModel < handle
 
     properties (GetAccess=public,SetAccess=protected)
-        % The WVTransform instance the represents the ocean state.
+        % WVTransform instance representing the ocean state.
         % - Topic: Model Properties
         % Set on initialization only, the WVTransform in the model
         % performs all computations necessary to return information about
@@ -49,10 +40,11 @@ classdef WVModel < handle & WVModelAdaptiveTimeStepMethods & WVModelFixedTimeSte
         nFluxComputations uint64 = 0
         indicesForFluxedSystem
 
-        % Indicates whether or not the model is using linear or nonlinear dynamics.
+        % Whether the model uses analytical linear dynamics.
         % - Topic: Model Properties
-        % In practice, this is simply checking whether the nonlinearFlux
-        % property is nil.
+        % When `false`, the model integrates registered coefficient and
+        % observing-system tendencies. When `true`, `integrateToTime`
+        % advances the transform and output schedule analytically.
         isDynamicsLinear
 
         eulerianObservingSystem
@@ -93,11 +85,13 @@ classdef WVModel < handle & WVModelAdaptiveTimeStepMethods & WVModelFixedTimeSte
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         function self = WVModel(wvt,options)
-            % Initialize a model from a WVTransform instance
+            % Initialize a model from a WVTransform instance.
             %
             % - Topic: Initialization
-            % - Declaration: WVModel(wvt,options)
-            % - Parameter wvt: a WaveVortexTranform instance
+            % - Declaration: model = WVModel(wvt,options)
+            % - Parameter wvt: `WVTransform` instance representing the initial fluid state
+            % - Parameter options.shouldUseLinearDynamics: use analytical linear evolution; default `false`
+            % - Returns model: new `WVModel` instance
             %
             % 
             arguments
@@ -817,6 +811,9 @@ classdef WVModel < handle & WVModelAdaptiveTimeStepMethods & WVModelFixedTimeSte
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         function summarize(self)
+            % Print a summary of integrated systems and output files.
+            %
+            % - Topic: Model Properties
             if isempty(self.fluxedObservingSystems)
                 fprintf('The model has no systems to integrate.\n');
             else

--- a/@WVModel/modelFromFile.m
+++ b/@WVModel/modelFromFile.m
@@ -14,6 +14,7 @@ function model = modelFromFile(path)
 % - Topic: Initialization
 % - Declaration: model = modelFromFile(path)
 % - Parameter path: path to a NetCDF file
+% - Returns model: restored `WVModel` instance
     arguments
         path char {mustBeFile}
     end

--- a/@WVTransform/WVTransform.m
+++ b/@WVTransform/WVTransform.m
@@ -1,49 +1,91 @@
 classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
-    % Represents the state of the ocean in terms of energetically orthogonal wave and geostrophic (vortex) solutions
+    % Represent a fluid state with orthogonal wave and geostrophic solutions.
     %
+    % `WVTransform` is the abstract base class for the supported wave-vortex
+    % transforms. Each concrete transform represents the fluid state at time
+    % `t` with spectral coefficients and exposes physical variables such as
+    % velocity, isopycnal displacement, pressure, and potential vorticity.
+    % Density is denoted by $$\rho$$. Energetic quantities are normalized per
+    % unit reference density $$\rho_0$$ unless a method states otherwise.
     %
-    % The WVTransform subclasses encapsulate data representing the
-    % state of the ocean at a given instant in time. What makes the
-    % WVTransform subclasses special is that the state of the ocean
-    % is represented as energetically independent waves and geostrophic
-    % motions (vortices). These classes can be queried for any ocean state
-    % variable including $$u$$, $$v$$, $$w$$, $$\rho$$, $$p$$, but also
-    % Ertel PV, relative vorticity, or custom defined state variables.
+    % Use one of the five Stable concrete transform families:
     %
-    % The WVTransform is an abstract class and as such you must
-    % instatiate one of the concrete subclasses,
-    %
-    % + `WVTransformConstantStratification`
+    % + `WVTransformConstantStratification`, in hydrostatic or nonhydrostatic mode
     % + `WVTransformHydrostatic`
-    % + `WVTransformSingleMode`
+    % + `WVTransformBoussinesq`
+    % + `WVTransformStratifiedQG`
+    % + `WVTransformBarotropicQG`
+    %
+    % Wave-bearing transforms store positive- and negative-frequency wave and
+    % inertial coefficients in `Ap` and `Am`, and zero-frequency geostrophic
+    % and mean-density-anomaly coefficients in `A0`. Quasigeostrophic
+    % transforms use `A0` only. The `Apt`, `Amt`, and `A0t` variables are the
+    % corresponding coefficients evaluated at the current transform time.
     %
     % - Topic: Initialization
+    % - Topic: Wave-vortex coefficients
+    % - Topic: Wave-vortex coefficients — At current time
+    % - Topic: State variables
+    % - Topic: Flow components
+    % - Topic: Forcing
     % - Topic: Domain attributes
     % - Topic: Domain attributes — Grid
-    % - Topic: Domain attributes — Grid – Spatial
-    % - Topic: Domain attributes — Grid – Spectral
-    % - Topic: Wave-vortex coefficients
-    % - Topic: Initial Conditions
-    % - Topic: Initial Conditions — Waves
-    % - Topic: Initial Conditions — Inertial Oscillations
-    % - Topic: Initial Conditions — Geostrophic Motions
+    % - Topic: Domain attributes — Grid — Spatial
+    % - Topic: Domain attributes — Grid — Spectral
+    % - Topic: Initial conditions
+    % - Topic: Initial conditions — Waves
+    % - Topic: Initial conditions — Inertial oscillations
+    % - Topic: Initial conditions — Geostrophic motions
+    % - Topic: Operations
     % - Topic: Energetics
+    % - Topic: Potential vorticity and enstrophy
+    % - Topic: Persistence
+    % - Topic: Developer — Projection coefficients
+    % - Topic: Developer — Reconstruction coefficients
     %
-    % - Declaration: classdef WVTransform < handle
+    % - Declaration: classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
     
     % Public read and write properties
     properties (GetAccess=public, SetAccess=public)
+        % Current transform time in seconds.
+        %
+        % - Topic: Domain attributes
         t = 0
+
+        % Reference time for the stored wave phases, in seconds.
+        %
+        % - Topic: Domain attributes
         t0 = 0
-        
-        % positive wave coefficients at reference time t0 (m/s)
-        % Topic: Wave-vortex coefficients
+
+        % Positive-frequency wave and inertial coefficients at reference time `t0`.
+        %
+        % `Ap` is a complex array with the transform's spectral layout. Only
+        % locations selected by the primary wave and inertial component masks
+        % are active. Together with `Am`, it reconstructs a real physical
+        % state and has units of velocity.
+        %
+        % - Topic: Wave-vortex coefficients
         Ap = 0
-        % negative wave coefficients at reference time t0 (m/s)
-        % Topic: Wave-vortex coefficients
+
+        % Negative-frequency wave and inertial coefficients at reference time `t0`.
+        %
+        % `Am` is a complex array with the transform's spectral layout. Only
+        % locations selected by the primary wave and inertial component masks
+        % are active. Its conjugacy relations with `Ap` enforce a real
+        % physical state, including `Am = conj(Ap)` on inertial modes.
+        %
+        % - Topic: Wave-vortex coefficients
         Am = 0
-        % geostrophic coefficients at reference time t0 (m)
-        % Topic: Wave-vortex coefficients
+
+        % Zero-frequency geostrophic and mean-density-anomaly coefficients.
+        %
+        % `A0` is a complex spectral array with units of streamfunction,
+        % $$\mathrm{m^2\,s^{-1}}$$. Geostrophic modes occupy nonzero
+        % horizontal wavenumbers; mean-density-anomaly modes occupy the
+        % horizontally averaged internal-mode locations. Quasigeostrophic
+        % transforms use `A0` without `Ap` or `Am` wave content.
+        %
+        % - Topic: Wave-vortex coefficients
         A0 = 0
     end
 
@@ -100,6 +142,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
     end
     
     methods (Abstract)
+        % Construct the same transform family at a requested resolution.
+        %
+        % - Topic: Initialization
         wvtX2 = waveVortexTransformWithResolution(self,m)
         
         % Required for transformUVEtaToWaveVortex 
@@ -156,10 +201,13 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
 
     methods
         function self = WVTransform(forcingType)
-            % initialize a WVTransform instance
+            % Initialize the internal WVTransform state for a concrete subclass.
             %
-            % This must be called from a subclass.
-            % - Topic: Internal
+            % Concrete transform constructors call this method; users create
+            % one of the supported subclasses instead.
+            %
+            % - Topic: Developer
+            % - Developer: true
             arguments
                 forcingType WVForcingType {mustBeNonempty}
             end
@@ -219,9 +267,21 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         %
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+        % Register a primary flow-component extension.
+        %
+        % - Topic: Flow components
         addPrimaryFlowComponent(self,primaryFlowComponent)
+        % Return the registered primary flow-component names.
+        %
+        % - Topic: Flow components
         names = primaryFlowComponentNames(self)
+        % Return a primary flow component by its Stable short name.
+        %
+        % - Topic: Flow components
         val = primaryFlowComponentWithName(self,name)
+        % Registered primary flow components.
+        %
+        % - Topic: Flow components
         function components = get.primaryFlowComponents(self)
             arguments (Input)
                 self WVTransform
@@ -232,8 +292,17 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
             components = [self.primaryFlowComponentNameMap{self.primaryFlowComponentNameMap.keys}];
         end
 
+        % Register a diagnostic flow-component extension.
+        %
+        % - Topic: Flow components
         addFlowComponent(self,flowComponent)
+        % Return all registered flow-component names.
+        %
+        % - Topic: Flow components
         names = flowComponentNames(self)
+        % Return a registered flow component by short name.
+        %
+        % - Topic: Flow components
         val = flowComponentWithName(self,name)
 
         function n = get.nFluxedComponents(self)
@@ -246,21 +315,32 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         %
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+        % Register an operation and its annotated output variables.
+        %
+        % - Topic: Operations
         addOperation(self,operation,options)
+        % Remove a registered operation.
+        %
+        % - Topic: Operations
         removeOperation(self,transformOperation)
+        % Return a registered operation by name.
+        %
+        % - Topic: Operations
         val = operationWithName(self,name)
 
         varargout = performOperation(self,modelOp)
         varargout = performOperationWithName(self,opName)
 
-        % Primary method for accessing the dynamical variables
+        % Evaluate one or more registered state variables.
+        %
+        % - Topic: State variables
         [varargout] = variableWithName(self, variableNames);
         
         % Access dynamical variables at arbitrary positions.
         %
         % The interpolation method may be `linear` or `spline`. Horizontal
         % coordinates are wrapped periodically before interpolation.
-        % - Topic: Lagrangian
+        % - Topic: State variables
         [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,options)
 
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -296,6 +376,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function removeAllForcing(self)
+            % Remove every forcing and closure from this transform.
+            %
+            % - Topic: Forcing
             arguments
                 self WVTransform {mustBeNonempty}
             end
@@ -308,6 +391,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function setForcing(self,force)
+            % Replace the complete forcing registry.
+            %
+            % - Topic: Forcing
             arguments
                 self WVTransform {mustBeNonempty}
                 force WVForcing
@@ -317,6 +403,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function addForcing(self,force)
+            % Add forcing or closure objects to this transform.
+            %
+            % - Topic: Forcing
             arguments
                 self WVTransform {mustBeNonempty}
                 force WVForcing
@@ -328,6 +417,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function removeForcing(self,force)
+            % Remove the exact registered forcing objects.
+            %
+            % - Topic: Forcing
             arguments
                 self WVTransform {mustBeNonempty}
                 force WVForcing
@@ -348,10 +440,16 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function forcing = get.forcing(self)
+            % Registered forcing and closure objects in execution order.
+            %
+            % - Topic: Forcing
             forcing = cat(2,self.spatialFluxForcing,self.spectralFluxForcing,self.spectralAmplitudeForcing);
         end
 
         function bool = hasForcingWithName(self,name)
+            % Test whether forcing objects are registered by name.
+            %
+            % - Topic: Forcing
             arguments (Input)
                 self WVTransform
             end
@@ -368,7 +466,7 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
             % retrieve the names of all available variables. This preserves
             % the order in which the forcing is applied.
             %
-            % - Topic: Utility function — Metadata
+            % - Topic: Forcing
             arguments (Input)
                 self WVTransform {mustBeNonempty}
             end
@@ -379,6 +477,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function forcing = forcingWithName(self,name)
+            % Return registered forcing objects by name.
+            %
+            % - Topic: Forcing
             arguments (Input)
                 self WVTransform
             end
@@ -592,6 +693,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         function names = variableNames(self)
+            % Return the names of all registered state variables.
+            %
+            % - Topic: State variables
             annotations = self.propertyAnnotations;
             names = {};
             for i=1:length(annotations)
@@ -602,6 +706,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function bool = hasVariableWithName(self,name)
+            % Test whether state variables are registered by name.
+            %
+            % - Topic: State variables
             arguments (Input)
                 self WVTransform
             end
@@ -619,6 +726,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         summarizeModeEnergy(self,options)
 
         function summarizeVariables(self)
+            % Print a table of registered state variables and cache status.
+            %
+            % - Topic: State variables
             annotations = self.propertyAnnotations;
             variableAnnotationNameMap = configureDictionary("string","cell");
             for i=1:length(annotations)
@@ -651,6 +761,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function summarizeFlowComponents(self)
+            % Print a table of registered primary and diagnostic components.
+            %
+            % - Topic: Flow components
             Name = cell(self.flowComponentNameMap.numEntries,1);
             isPrimary = cell(self.flowComponentNameMap.numEntries,1);
             FullName = cell(self.flowComponentNameMap.numEntries,1);
@@ -672,6 +785,9 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
         end
 
         function summarizeForcing(self)
+            % Print a table of registered forcing and closure objects.
+            %
+            % - Topic: Forcing
             Name = cell(length(self.forcing),1);
             IsClosure = cell(length(self.forcing),1);
             for iForce=1:length(self.forcing)

--- a/@WVTransform/classDefinedOperationForKnownVariable.m
+++ b/@WVTransform/classDefinedOperationForKnownVariable.m
@@ -43,17 +43,17 @@ for iOp = 1:length(variableName)
                     f = @(wvt) conj(wvt.phase);
 
                 case 'A0t'
-                    varAnnotation = WVVariableAnnotation(name,options.spectralDimensionNames,'m', 'geostrophic coefficients time t');
+                    varAnnotation = WVVariableAnnotation(name,options.spectralDimensionNames,'m^2 s^{-1}', 'zero-frequency coefficients at current time t');
                     varAnnotation.isComplex = true;
                     f = @(wvt) wvt.A0;
 
                 case 'Apt'
-                    varAnnotation = WVVariableAnnotation(name,options.spectralDimensionNames,'m/s', 'positive wave coefficients at reference time t');
+                    varAnnotation = WVVariableAnnotation(name,options.spectralDimensionNames,'m/s', 'positive-frequency coefficients at current time t');
                     varAnnotation.isComplex = true;
                     f = @(wvt) wvt.Ap .* wvt.phase;
 
                 case 'Amt'
-                    varAnnotation = WVVariableAnnotation(name,options.spectralDimensionNames,'m/s', 'negative wave coefficients at reference time t');
+                    varAnnotation = WVVariableAnnotation(name,options.spectralDimensionNames,'m/s', 'negative-frequency coefficients at current time t');
                     varAnnotation.isComplex = true;
                     f = @(wvt) wvt.Am .* wvt.conjPhase;
 

--- a/@WVTransform/defaultOperations.m
+++ b/@WVTransform/defaultOperations.m
@@ -18,7 +18,7 @@ outputVar(2).isComplex = 1;
 f = @(wvt) wvt.waveCoefficientsAtTimeT();
 operations(end+1) = WVOperation('ApAm',outputVar,f);
 
-outputVar = WVVariableAnnotation('A0t',{'j','kl'},'m', 'geostrophic coefficients at time t');
+outputVar = WVVariableAnnotation('A0t',{'j','kl'},'m^2 s^{-1}', 'zero-frequency coefficients at current time t');
 outputVar.isComplex = 1;
 operations(end+1) = WVOperation('A0t',outputVar,@(wvt) wvt.A0);
 

--- a/@WVTransform/detailedDescriptions/A0.md
+++ b/@WVTransform/detailedDescriptions/A0.md
@@ -1,14 +1,7 @@
+`A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+
+For nonzero horizontal wavenumber, the geostrophic component mask identifies the active `A0` locations. At zero horizontal wavenumber and internal vertical modes, the mean-density-anomaly mask identifies the horizontally averaged density anomaly relative to the no-motion state. These components are orthogonal in quadratic energy and potential enstrophy under the supported transform discretization.
+
+`A0` has no linear phase winding on the $$f$$-plane, so `A0t` equals `A0`. Quasigeostrophic transforms represent their supported state with `A0` and have no active `Ap` or `Am` wave content.
+
 - Topic: Wave-vortex coefficients
-
-These are the coefficients of the geostrophic portion of the flow, denoted  $$A_0$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The geostrophic solution is shown in equation (3.5). A summary of the hydrostatic transformations is in equations (C1)-(C5).
-
-The three different solutions for the geostrophic mode are: barotropic geostrophic ($$G^0$$), geostrophic ($$G$$), and mean density anomaly ($$\bar{\rho}^\prime$$). They exist in the $$A_0$$ array as follows (where k and l are considered equivalent),
-
-|  j\k  | **0** | **1** | **2** | **3** |
-|:-----:|:-----:|:-----:|:-----:|:-----:|
-| **0** |                     |$$G^0$$|$$G^0$$|$$G^0$$|
-| **1** |$$\bar{\rho}^\prime$$| $$G$$ | $$G$$ | $$G$$ |
-| **2** |$$\bar{\rho}^\prime$$| $$G$$ | $$G$$ | $$G$$ |
-| **3** |$$\bar{\rho}^\prime$$| $$G$$ | $$G$$ | $$G$$ |
-
-Note that the $$k=l=0$$ geostrophic solution is not taken to be zero, unlike section 3.1 in the manuscript. If your mean density $$\bar{\rho}(z)$$ really is the spatial mean in the domain, then the $$k=l=0$$ solutions must be zero, as stated in the manuscript. However, in a practical sense it is useful to allow the domain density mean to differ from the defined mean, so we therefore allow a 'mean density anomaly' to exist. 

--- a/@WVTransform/detailedDescriptions/A0N.md
+++ b/@WVTransform/detailedDescriptions/A0N.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 3, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 
@@ -32,3 +30,6 @@ The $$k=l=0, j>=0$$ solution is a mean density anomaly,
 ```matlab
 A0N(1,1,:) = 1;
 ```
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/A0U.md
+++ b/@WVTransform/detailedDescriptions/A0U.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 3, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 
@@ -32,3 +30,6 @@ The $$k=l=0, j>=0$$ solution is a mean density anomaly,
 ```matlab
 A0U(1,1,:) = 0;
 ```
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/A0V.md
+++ b/@WVTransform/detailedDescriptions/A0V.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 3, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 
@@ -32,3 +30,6 @@ The $$k=l=0, j>=0$$ solution is a mean density anomaly,
 ```matlab
 A0V(1,1,:) = 0;
 ```
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/A0t.md
+++ b/@WVTransform/detailedDescriptions/A0t.md
@@ -1,5 +1,9 @@
-- Topic: Wave-vortex coefficients — at time $$t$$
+`A0t` is the zero-frequency coefficient array evaluated at the current transform time. On the supported $$f$$-plane transforms, `A0` has no linear phase winding and therefore
 
-These are the *time dependent* coefficients of the geostrophic flow, denoted  $$A_0$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_0^{k\ell j}(t) = A_0^{k\ell j}(t_0).
+$$
 
-These geostrophic coefficients do not have any linear time dependence on the $$f$$-plane and thus are identical to `A0`.
+Consequently, `A0t` returns the current stored `A0` coefficients.
+
+- Topic: Wave-vortex coefficients — At current time

--- a/@WVTransform/detailedDescriptions/Am.md
+++ b/@WVTransform/detailedDescriptions/Am.md
@@ -1,14 +1,7 @@
+`Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
+
+The stored phase is referenced to `t0`. Linear evolution does not overwrite `Am`; use `Amt` for the coefficients evaluated at the current `t`. The wave and inertial primary-flow-component masks identify the active locations. Coefficients outside those masks must remain zero.
+
+Together `Am` and `Ap` obey the transform's Hermitian and inertial conjugacy relationships so the reconstructed physical fields are real. In particular, the inertial coefficients satisfy `Am = conj(Ap)` on their masks. Quasigeostrophic transforms have no active `Am` content.
+
 - Topic: Wave-vortex coefficients
-
-These are the coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_-$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The internal gravity solutions are showin in equation (3.18) and the inertial oscillations solutions are equation (3.15).
-
-These solutions have their phases wound to time $$t_0$$ (`t0`), and thus do not change for linear dynamics. The two different solutions are internal gravity waves (IGW) and inertial oscillations (IO). They exist in the $$A_-$$ array as follows (where k and l are considered equivalent),
-
-|  j\k  | **0** | **1** | **2** | **3** |
-|:-----:|:-----:|:-----:|:-----:|:-----:|
-| **0** |IO|     |     |     |
-| **1** |IO| IGW | IGW | IGW |
-| **2** |IO| IGW | IGW | IGW |
-| **3** |IO| IGW | IGW | IGW |
-
-These are the negative ($$-$$) frequency solutions of equation (3.18), the positive solutions are in the `Ap` matrix.

--- a/@WVTransform/detailedDescriptions/AmN.md
+++ b/@WVTransform/detailedDescriptions/AmN.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 1, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_-$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -22,3 +20,6 @@ ApN(:,:,1) = 0;
 ```
 
 The inertial solutions at $$k^2+l^2=0$$ do not contribute to $$\eta$$, so that component remains zero.
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/AmU.md
+++ b/@WVTransform/detailedDescriptions/AmU.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 2, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_-$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 AmU(1,1,:) = 1/2;
 ```
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/AmV.md
+++ b/@WVTransform/detailedDescriptions/AmV.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 2, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_-$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 AmV(1,1,:) = sqrt(-1)/2;
 ```
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/Amt.md
+++ b/@WVTransform/detailedDescriptions/Amt.md
@@ -1,5 +1,9 @@
-- Topic: Wave-vortex coefficients — at time $$t$$
+`Amt` is the negative-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_- e^{-i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_-^{k\ell j}(t) = A_-^{k\ell j}(t_0) e^{-i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Am`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Am`, `t`, `t0`, and modal frequency without changing `Am`.
+
+- Topic: Wave-vortex coefficients — At current time

--- a/@WVTransform/detailedDescriptions/Ap.md
+++ b/@WVTransform/detailedDescriptions/Ap.md
@@ -1,14 +1,7 @@
+`Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
+
+The stored phase is referenced to `t0`. Linear evolution does not overwrite `Ap`; use `Apt` for the coefficients evaluated at the current `t`. The wave and inertial primary-flow-component masks identify the active locations. Coefficients outside those masks must remain zero.
+
+Together `Ap` and `Am` obey the transform's Hermitian and inertial conjugacy relationships so the reconstructed physical fields are real. Quasigeostrophic transforms have no active `Ap` content.
+
 - Topic: Wave-vortex coefficients
-
-These are the coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_+$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The internal gravity solutions are showin in equation (3.18) and the inertial oscillations solutions are equation (3.15).
-
-These solutions have their phases wound to time $$t_0$$ (`t0`), and thus do not change for linear dynamics. The two different solutions are internal gravity waves (IGW) and inertial oscillations (IO). They exist in the $$A_+$$ array as follows (where k and l are considered equivalent),
-
-|  j\k  | **0** | **1** | **2** | **3** |
-|:-----:|:-----:|:-----:|:-----:|:-----:|
-| **0** |IO|     |     |     |
-| **1** |IO| IGW | IGW | IGW |
-| **2** |IO| IGW | IGW | IGW |
-| **3** |IO| IGW | IGW | IGW |
-
-These are the positive ($$+$$) frequency solutions of equation (3.18), the negative solutions are in the `Am` matrix.

--- a/@WVTransform/detailedDescriptions/ApN.md
+++ b/@WVTransform/detailedDescriptions/ApN.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 1, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_+$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -22,3 +20,6 @@ ApN(:,:,1) = 0;
 ```
 
 The inertial solutions at $$k^2+l^2=0$$ do not contribute to $$\eta$$, so that component remains zero.
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/ApU.md
+++ b/@WVTransform/detailedDescriptions/ApU.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 1, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_+$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 ApU(1,1,:) = 1/2;
 ```
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/ApV.md
+++ b/@WVTransform/detailedDescriptions/ApV.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — inverse components ($$S^{-1}$$)
-
-These are the row 1, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_+$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 ApV(1,1,:) = -sqrt(-1)/2;
 ```
+
+- Topic: Developer — Projection coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/Apt.md
+++ b/@WVTransform/detailedDescriptions/Apt.md
@@ -1,5 +1,9 @@
-- Topic: Wave-vortex coefficients — at time $$t$$
+`Apt` is the positive-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_+ e^{i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_+^{k\ell j}(t) = A_+^{k\ell j}(t_0) e^{i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Ap`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Ap`, `t`, `t0`, and modal frequency without changing `Ap`.
+
+- Topic: Wave-vortex coefficients — At current time

--- a/@WVTransform/detailedDescriptions/NA0.md
+++ b/@WVTransform/detailedDescriptions/NA0.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -25,3 +23,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 NA0(1,1,:) = 0;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/NAm.md
+++ b/@WVTransform/detailedDescriptions/NAm.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -25,3 +23,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 NAm(1,1,:) = 0;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/NAp.md
+++ b/@WVTransform/detailedDescriptions/NAp.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 3, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -25,3 +23,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 NAp(1,1,:) = 0;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/UA0.md
+++ b/@WVTransform/detailedDescriptions/UA0.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 1, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -25,3 +23,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 UA0(1,1,:) = 0;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/UAm.md
+++ b/@WVTransform/detailedDescriptions/UAm.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 1, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 UAm(1,1,:) = 1;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/UAp.md
+++ b/@WVTransform/detailedDescriptions/UAp.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 1, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 UAp(1,1,:) = 1;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/VA0.md
+++ b/@WVTransform/detailedDescriptions/VA0.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 2, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -25,3 +23,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 VA0(1,1,:) = 0;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/VAm.md
+++ b/@WVTransform/detailedDescriptions/VAm.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 2, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 VAm(1,1,:) = -sqrt(-1);
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/VAp.md
+++ b/@WVTransform/detailedDescriptions/VAp.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 2, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -27,3 +25,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 VAp(1,1,:) = sqrt(-1);
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/WAm.md
+++ b/@WVTransform/detailedDescriptions/WAm.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 4, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -25,3 +23,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 WAm(1,1,:) = 0;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/detailedDescriptions/WAp.md
+++ b/@WVTransform/detailedDescriptions/WAp.md
@@ -1,6 +1,4 @@
-- Topic: Wave-vortex sorting matrix — components of $$S$$
-
-These are the row 4, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 
@@ -25,3 +23,6 @@ The inertial solutions occupy the $$k^2+l^2=0$$ portion of the matrix,
 ```matlab
 WAp(1,1,:) = 0;
 ```
+
+- Topic: Developer — Reconstruction coefficients
+- Developer: true

--- a/@WVTransform/summarizeModeEnergy.m
+++ b/@WVTransform/summarizeModeEnergy.m
@@ -6,7 +6,7 @@ function summarizeModeEnergy(self,options)
     %
     % - Topic: Energetics
     % - Declaration: summarizeModeEnergy(options)
-    % - Parameter n: (optional) number of modes to list
+    % - Parameter options.n: number of modes to list; default `10`
     arguments
         self WVTransform {mustBeNonempty}
     end

--- a/@WVTransform/variableAtPositionWithName.m
+++ b/@WVTransform/variableAtPositionWithName.m
@@ -8,13 +8,14 @@ function [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,optio
 % The interpolation method may be `linear` or `spline`. Horizontal
 % coordinates are wrapped periodically before interpolation.
 %
-% - Topic: State Variables
-% - Declaration: [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,options)
+% - Topic: State variables
+% - Declaration: [varargout] = variableAtPositionWithName(x,y,z,variableNames,options)
 % - Parameter x: array of x-positions
 % - Parameter y: array of y-positions
 % - Parameter z: array of z-positions, or empty for two-dimensional variables
 % - Parameter variableNames: strings of variable names.
-% - Parameter interpolationMethod: (optional) `linear` or `spline`. Default `linear`.
+% - Parameter options.interpolationMethod: periodic `linear` or cubic `spline` interpolation; default `linear`
+% - Returns varargout: interpolated arrays in the requested order and query shape
 arguments
     self WVTransform {mustBeNonempty}
     x (1,:) double

--- a/@WVTransform/variableWithName.m
+++ b/@WVTransform/variableWithName.m
@@ -1,9 +1,10 @@
 function varargout = variableWithName(self,variableNames)
 % Compute or retrieve one or more registered transform variables.
 %
-% - Topic: State Variables
+% - Topic: State variables
 % - Declaration: varargout = variableWithName(variableNames)
-% - Parameter variableNames: registered variable names
+% - Parameter variableNames: names of registered state variables
+% - Returns varargout: state-variable arrays in the requested order
 arguments
     self WVTransform {mustBeNonempty}
 end

--- a/@WVTransformBarotropicQG/WVTransformBarotropicQG.m
+++ b/@WVTransformBarotropicQG/WVTransformBarotropicQG.m
@@ -1,18 +1,31 @@
 classdef WVTransformBarotropicQG < WVGeometryDoublyPeriodicBarotropic & WVTransform & WVGeostrophicMethods
-    % A transform for modeling single-layer quasigeostrophic flow
+    % Represent two-dimensional equivalent-barotropic quasigeostrophic flow.
     %
-    % This is a two-dimensional, single-layer which may be interpreted as
-    % the sea-surface height. The 'h' parameter is the equivalent depth,
-    % and 0.80 m is a typical value for the first baroclinic mode.
+    % This is a two-dimensional, single-layer transform. The `h` parameter
+    % is the equivalent depth; `0.80` m is a representative first-baroclinic
+    % value. The transform stores its state in `A0` and has no wave `Ap` or
+    % `Am` content.
     %
     % ```matlab
     % Lxy = 50e3;
     % Nxy = 256;
     % latitude = 25;
-    % wvt = WVTransformSingleMode([Lxy, Lxy], [Nxy, Nxy], h=0.8, latitude=latitude);
+    % wvt = WVTransformBarotropicQG([Lxy,Lxy],[Nxy,Nxy],h=0.8,latitude=latitude);
     % ```
     %
+    % The Stable quasigeostrophic state is stored in
+    % [`A0`](/classes/transforms/wvtransform/a0.html), with current-time view
+    % `A0t`. This transform has no active `Ap`, `Am`, `Apt`, or `Amt` content.
+    %
     % - Topic: Initialization
+    % - Topic: Wave-vortex coefficients
+    % - Topic: Wave-vortex coefficients — At current time
+    % - Topic: Primary flow components
+    % - Topic: Initial conditions
+    % - Topic: Energetics of flow components
+    % - Topic: Operations
+    % - Topic: Developer — Projection coefficients
+    % - Topic: Developer — Reconstruction coefficients
     %
     % - Declaration: classdef WVTransformBarotropicQG < [WVTransform](/classes/transforms/wvtransform/)
     properties (Dependent)
@@ -28,20 +41,22 @@ classdef WVTransformBarotropicQG < WVGeometryDoublyPeriodicBarotropic & WVTransf
 
     methods
         function self = WVTransformBarotropicQG(Lxy, Nxy, options)
-            % create geometry for 2D barotropic flow
+            % Create an equivalent-barotropic quasigeostrophic transform.
             %
             % ```matlab
             % Lxy = 50e3;
             % Nxy = 256;
-            % wvt = Cartesian2DBarotropic([Lxy, Lxy], [Nxy, Nxy]);
+            % wvt = WVTransformBarotropicQG([Lxy,Lxy],[Nxy,Nxy],h=0.8,latitude=30);
             % ```
             %
             % - Topic: Initialization
-            % - Declaration: wvt = Cartesian2DBarotropic(Lxyz, Nxyz, options)
+            % - Declaration: wvt = WVTransformBarotropicQG(Lxy,Nxy,options)
             % - Parameter Lxy: length of the domain (in meters) in the two coordinate directions, e.g. [Lx Ly]
             % - Parameter Nxy: number of grid points in the two coordinate directions, e.g. [Nx Ny]
             % - Parameter shouldAntialias: (optional) whether or not to de-alias for quadratic multiplications
-            % - Returns wvt: a new Cartesian2DBarotropic instance
+            % - Parameter options.h: equivalent depth in meters; default `0.8`
+            % - Parameter options.latitude: latitude in the supported domain; default `33`
+            % - Returns wvt: new `WVTransformBarotropicQG` instance
             arguments
                 Lxy (1,2) double {mustBePositive}
                 Nxy (1,2) double {mustBePositive}

--- a/@WVTransformBoussinesq/WVTransformBoussinesq.m
+++ b/@WVTransformBoussinesq/WVTransformBoussinesq.m
@@ -1,18 +1,25 @@
 classdef WVTransformBoussinesq < WVGeometryDoublyPeriodicStratifiedBoussinesq & WVTransform & WVGeostrophicMethods & WVInternalGravityWaveMethods & WVInertialOscillationMethods & WVMeanDensityAnomalyMethods
-    % A class for disentangling nonhydrostatic waves and vortices in variable stratification
+    % Decompose nonhydrostatic variable-stratification flow into wave and geostrophic components.
     %
     % To initialize an instance of the WVTransformBoussinesq class you
-    % must specific the domain size, the number of grid points and *either*
+    % must specify the domain size, the number of grid points, and either
     % the density profile or the stratification profile.
     %
     % ```matlab
     % N0 = 3*2*pi/3600;
     % L_gm = 1300;
     % N2 = @(z) N0*N0*exp(2*z/L_gm);
-    % wvt = WVTransformBoussinesq([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30);
+    % wvt = WVTransformBoussinesq([100e3,100e3,4000],[64,64,65],N2Function=N2,latitude=30);
     % ```
     %
+    % The Stable transform state is stored in [`Ap`](/classes/transforms/wvtransform/ap.html),
+    % [`Am`](/classes/transforms/wvtransform/am.html), and
+    % [`A0`](/classes/transforms/wvtransform/a0.html). Their current-time
+    % views are `Apt`, `Amt`, and `A0t`.
+    %
     % - Topic: Initialization
+    % - Topic: Wave-vortex coefficients
+    % - Topic: Wave-vortex coefficients — At current time
     % - Topic: Primary flow components
     % - Topic: Stratification
     % - Topic: Stratification — Vertical modes
@@ -20,6 +27,8 @@ classdef WVTransformBoussinesq < WVGeometryDoublyPeriodicStratifiedBoussinesq & 
     % - Topic: Initial conditions
     % - Topic: Energetics of flow components
     % - Topic: Operations
+    % - Topic: Developer — Projection coefficients
+    % - Topic: Developer — Reconstruction coefficients
     %
     % - Declaration: classdef WVTransformBoussinesq < [WVTransform](/classes/transforms/wvtransform/)
     properties (Dependent)
@@ -43,24 +52,27 @@ classdef WVTransformBoussinesq < WVGeometryDoublyPeriodicStratifiedBoussinesq & 
 
     methods
         function self = WVTransformBoussinesq(Lxyz, Nxyz, options)
-            % create a wave-vortex transform for variable stratification
+            % Create a nonhydrostatic wave-vortex transform for variable stratification.
             %
             % Creates a new instance of the WVTransformBoussinesq class
             % appropriate for disentangling nonhydrostatic waves and vortices
             % in variable stratification
             %
-            % You must initialization by passing *either* the density
-            % profile or the stratification profile.
+            % Supply either `N2Function` or `rhoFunction`. The additional
+            % modal arrays accepted by the constructor are reconstruction
+            % state used by the persistence factories rather than ordinary
+            % user construction options.
             %
             % - Topic: Initialization
-            % - Declaration: wvt = WVTransformHydrostatic(Lxyz, Nxyz, options)
+            % - Declaration: wvt = WVTransformBoussinesq(Lxyz,Nxyz,options)
             % - Parameter Lxyz: length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
             % - Parameter Nxyz: number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-            % - Parameter rho:  (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-            % - Parameter stratification:  (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-            % - Parameter latitude: (optional) latitude of the domain (default is 33 degrees north)
-            % - Parameter rho0: (optional) density at the surface z=0 (default is 1025 kg/m^3)
-            % - Returns wvt: a new WVTransformHydrostatic instance
+            % - Parameter options.N2Function: function returning squared buoyancy frequency on `[-Lz,0]`
+            % - Parameter options.rhoFunction: function returning density on `[-Lz,0]`
+            % - Parameter options.latitude: latitude in the supported domain; default `33`
+            % - Parameter options.shouldAntialias: exclude quadratically aliased modes; default `true`
+            % - Parameter options.rho0: reference density in kilograms per cubic meter; default `1025`
+            % - Returns wvt: new `WVTransformBoussinesq` instance
             arguments
                 Lxyz (1,3) double {mustBePositive}
                 Nxyz (1,3) double {mustBePositive}

--- a/@WVTransformBoussinesq/transformUVWEtaToWaveVortex.m
+++ b/@WVTransformBoussinesq/transformUVWEtaToWaveVortex.m
@@ -1,7 +1,8 @@
 function [Ap,Am,A0] = transformUVWEtaToWaveVortex(self,U,V,W,N)
 % transform momentum variables $$(u,v,w,\eta)$$ to wave-vortex coefficients $$(A_+,A_-,A_0)$$.
 %
-% This function tuned for constant stratification.
+% This implementation uses the nonhydrostatic variable-stratification
+% projection operators.
 %
 % - Topic: Operations — Transformations
 % - Declaration: [Ap,Am,A0] = transformUVWEtaToWaveVortex(U,V,N)

--- a/@WVTransformConstantStratification/WVTransformConstantStratification.m
+++ b/@WVTransformConstantStratification/WVTransformConstantStratification.m
@@ -1,5 +1,5 @@
 classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedConstant & WVTransform & WVGeostrophicMethods & WVInternalGravityWaveMethods & WVInertialOscillationMethods & WVMeanDensityAnomalyMethods
-    % A class for disentangling waves and vortices in constant stratification
+    % Decompose constant-stratification flow into wave and geostrophic components.
     %
     % To initialize an instance of the WVTransformConstantStratification
     % class you must specify the domain size, the number of grid points,
@@ -7,10 +7,18 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
     %
     % ```matlab
     % N0 = 3*2*pi/3600;
-    % wvt = WVTransformConstantStratification([100e3, 100e3, 4000],[64, 64, 65],N0=N0,latitude=30);
+    % wvt = WVTransformConstantStratification([100e3,100e3,4000],[64,64,65],N0=N0,latitude=30);
+    % wvtHydrostatic = WVTransformConstantStratification([100e3,100e3,4000],[64,64,65],N0=N0,latitude=30,isHydrostatic=true);
     % ```
     %
+    % The Stable transform state is stored in [`Ap`](/classes/transforms/wvtransform/ap.html),
+    % [`Am`](/classes/transforms/wvtransform/am.html), and
+    % [`A0`](/classes/transforms/wvtransform/a0.html). Their current-time
+    % views are `Apt`, `Amt`, and `A0t`.
+    %
     % - Topic: Initialization
+    % - Topic: Wave-vortex coefficients
+    % - Topic: Wave-vortex coefficients — At current time
     % - Topic: Primary flow components
     % - Topic: Stratification
     % - Topic: Stratification — Vertical modes
@@ -18,6 +26,8 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
     % - Topic: Initial conditions
     % - Topic: Energetics of flow components
     % - Topic: Operations
+    % - Topic: Developer — Projection coefficients
+    % - Topic: Developer — Reconstruction coefficients
     %
     % - Declaration: classdef WVTransformConstantStratification < [WVTransform](/classes/transforms/wvtransform/)
     properties (Dependent)
@@ -39,24 +49,27 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
 
     methods
         function self = WVTransformConstantStratification(Lxyz, Nxyz, options)
-            % create a wave-vortex transform for constant stratification
+            % Create a wave-vortex transform for constant stratification.
             %
             % Creates a new instance of the WVTransformConstantStratification
             % class appropriate for disentangling waves and vortices in
             % constant stratification.
             %
-            % You must initialization by passing *either* the density
-            % profile or the stratification profile.
+            % Set `isHydrostatic=true` for hydrostatic dynamics; the default
+            % is the nonhydrostatic transform. `N0` is the constant buoyancy
+            % frequency. The remaining geometry options configure the
+            % rotating, doubly periodic domain.
             %
             % - Topic: Initialization
-            % - Declaration: wvt = WVTransformHydrostatic(Lxyz, Nxyz, options)
+            % - Declaration: wvt = WVTransformConstantStratification(Lxyz,Nxyz,options)
             % - Parameter Lxyz: length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
             % - Parameter Nxyz: number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-            % - Parameter rho:  (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-            % - Parameter stratification:  (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-            % - Parameter latitude: (optional) latitude of the domain (default is 33 degrees north)
-            % - Parameter rho0: (optional) density at the surface z=0 (default is 1025 kg/m^3)
-            % - Returns wvt: a new WVTransformHydrostatic instance
+            % - Parameter options.N0: constant buoyancy frequency in radians per second; default `5.2e-3`
+            % - Parameter options.isHydrostatic: use hydrostatic dynamics; default `false`
+            % - Parameter options.latitude: latitude in the supported domain; default `33`
+            % - Parameter options.shouldAntialias: exclude quadratically aliased modes; default `true`
+            % - Parameter options.rho0: reference density in kilograms per cubic meter; default `1025`
+            % - Returns wvt: new `WVTransformConstantStratification` instance
             arguments
                 Lxyz (1,3) double {mustBePositive}
                 Nxyz (1,3) double {mustBePositive}

--- a/@WVTransformConstantStratification/transformUVWEtaToWaveVortex.m
+++ b/@WVTransformConstantStratification/transformUVWEtaToWaveVortex.m
@@ -1,7 +1,7 @@
 function [Ap,Am,A0] = transformUVWEtaToWaveVortex(self,U,V,W,N)
 % transform momentum variables $$(u,v,w,\eta)$$ to wave-vortex coefficients $$(A_+,A_-,A_0)$$.
 %
-% This function tuned for constant stratification.
+% This implementation uses the constant-stratification projection operators.
 %
 % - Topic: Operations — Transformations
 % - Declaration: [Ap,Am,A0] = transformUVWEtaToWaveVortex(U,V,N)

--- a/@WVTransformHydrostatic/WVTransformHydrostatic.m
+++ b/@WVTransformHydrostatic/WVTransformHydrostatic.m
@@ -1,18 +1,25 @@
 classdef WVTransformHydrostatic < WVGeometryDoublyPeriodicStratified & WVTransform & WVGeostrophicMethods & WVInternalGravityWaveMethods & WVInertialOscillationMethods & WVMeanDensityAnomalyMethods
-    % A class for disentangling hydrostatic waves and vortices in variable stratification
+    % Decompose hydrostatic variable-stratification flow into wave and geostrophic components.
     %
-    % To initialization an instance of the WVTransformHydrostatic class you
-    % must specific the domain size, the number of grid points and *either*
+    % To initialize `WVTransformHydrostatic`, specify the domain size, the
+    % number of grid points, and either
     % the density profile or the stratification profile.
     %
     % ```matlab
     % N0 = 3*2*pi/3600;
     % L_gm = 1300;
     % N2 = @(z) N0*N0*exp(2*z/L_gm);
-    % wvt = WVTransformHydrostatic([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30);
+    % wvt = WVTransformHydrostatic([100e3,100e3,4000],[64,64,65],N2Function=N2,latitude=30);
     % ```
     %
+    % The Stable transform state is stored in [`Ap`](/classes/transforms/wvtransform/ap.html),
+    % [`Am`](/classes/transforms/wvtransform/am.html), and
+    % [`A0`](/classes/transforms/wvtransform/a0.html). Their current-time
+    % views are `Apt`, `Amt`, and `A0t`.
+    %
     % - Topic: Initialization
+    % - Topic: Wave-vortex coefficients
+    % - Topic: Wave-vortex coefficients — At current time
     % - Topic: Primary flow components
     % - Topic: Stratification
     % - Topic: Stratification — Vertical modes
@@ -20,6 +27,8 @@ classdef WVTransformHydrostatic < WVGeometryDoublyPeriodicStratified & WVTransfo
     % - Topic: Initial conditions
     % - Topic: Energetics of flow components
     % - Topic: Operations
+    % - Topic: Developer — Projection coefficients
+    % - Topic: Developer — Reconstruction coefficients
     %
     % - Declaration: classdef WVTransformHydrostatic < [WVTransform](/classes/transforms/wvtransform/)
     properties (Dependent)
@@ -39,24 +48,27 @@ classdef WVTransformHydrostatic < WVGeometryDoublyPeriodicStratified & WVTransfo
 
     methods
         function self = WVTransformHydrostatic(Lxyz, Nxyz, options)
-            % create a wave-vortex transform for variable stratification
+            % Create a hydrostatic wave-vortex transform for variable stratification.
             %
             % Creates a new instance of the WVTransformHydrostatic class
             % appropriate for disentangling hydrostatic waves and vortices
             % in variable stratification
             %
-            % You must initialization by passing *either* the density
-            % profile or the stratification profile.
+            % Supply either `N2Function` or `rhoFunction`. The additional
+            % modal arrays accepted by the constructor are reconstruction
+            % state used by the persistence factories rather than ordinary
+            % user construction options.
             %
             % - Topic: Initialization
             % - Declaration: wvt = WVTransformHydrostatic(Lxyz, Nxyz, options)
             % - Parameter Lxyz: length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
             % - Parameter Nxyz: number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-            % - Parameter rho:  (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-            % - Parameter stratification:  (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-            % - Parameter latitude: (optional) latitude of the domain (default is 33 degrees north)
-            % - Parameter rho0: (optional) density at the surface z=0 (default is 1025 kg/m^3)
-            % - Returns wvt: a new WVTransformHydrostatic instance
+            % - Parameter options.N2Function: function returning squared buoyancy frequency on `[-Lz,0]`
+            % - Parameter options.rhoFunction: function returning density on `[-Lz,0]`
+            % - Parameter options.latitude: latitude in the supported domain; default `33`
+            % - Parameter options.shouldAntialias: exclude quadratically aliased modes; default `true`
+            % - Parameter options.rho0: reference density in kilograms per cubic meter; default `1025`
+            % - Returns wvt: new `WVTransformHydrostatic` instance
             arguments
                 Lxyz (1,3) double {mustBePositive}
                 Nxyz (1,3) double {mustBePositive}

--- a/@WVTransformStratifiedQG/WVTransformStratifiedQG.m
+++ b/@WVTransformStratifiedQG/WVTransformStratifiedQG.m
@@ -1,18 +1,24 @@
 classdef WVTransformStratifiedQG < WVGeometryDoublyPeriodicStratified & WVTransform & WVGeostrophicMethods
-    % A quasigeostrophic transform for variable stratification
+    % Represent stratified quasigeostrophic flow with variable stratification.
     %
     % To initialize an instance of the WVTransformStratifiedQG class you
-    % must specific the domain size, the number of grid points and *either*
+    % must specify the domain size, the number of grid points, and either
     % the density profile or the stratification profile.
     %
     % ```matlab
     % N0 = 3*2*pi/3600;
     % L_gm = 1300;
     % N2 = @(z) N0*N0*exp(2*z/L_gm);
-    % wvt = WVTransformStratifiedQG([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30);
+    % wvt = WVTransformStratifiedQG([100e3,100e3,4000],[64,64,65],N2Function=N2,latitude=30);
     % ```
     %
+    % The Stable quasigeostrophic state is stored in
+    % [`A0`](/classes/transforms/wvtransform/a0.html), with current-time view
+    % `A0t`. This transform has no active `Ap`, `Am`, `Apt`, or `Amt` content.
+    %
     % - Topic: Initialization
+    % - Topic: Wave-vortex coefficients
+    % - Topic: Wave-vortex coefficients — At current time
     % - Topic: Primary flow components
     % - Topic: Stratification
     % - Topic: Stratification — Vertical modes
@@ -20,6 +26,8 @@ classdef WVTransformStratifiedQG < WVGeometryDoublyPeriodicStratified & WVTransf
     % - Topic: Initial conditions
     % - Topic: Energetics of flow components
     % - Topic: Operations
+    % - Topic: Developer — Projection coefficients
+    % - Topic: Developer — Reconstruction coefficients
     %
     % - Declaration: classdef WVTransformStratifiedQG < [WVTransform](/classes/transforms/wvtransform/)
     properties (Dependent)
@@ -34,23 +42,26 @@ classdef WVTransformStratifiedQG < WVGeometryDoublyPeriodicStratified & WVTransf
 
     methods
         function self = WVTransformStratifiedQG(Lxyz, Nxyz, options)
-            % create a wave-vortex transform for variable stratification
+            % Create a stratified quasigeostrophic transform.
             %
             % Creates a new instance of the WVTransformStratifiedQG class
             % for quasigeostrophic flow in variable stratification.
             %
-            % You must initialization by passing *either* the density
-            % profile or the stratification profile.
+            % Supply either `N2Function` or `rhoFunction`. This transform
+            % represents the geostrophic `A0` coefficients and has no wave
+            % `Ap` or `Am` content. Additional modal arrays accepted by the
+            % constructor are reconstruction state used by persistence.
             %
             % - Topic: Initialization
-            % - Declaration: wvt = WVTransformHydrostatic(Lxyz, Nxyz, options)
+            % - Declaration: wvt = WVTransformStratifiedQG(Lxyz,Nxyz,options)
             % - Parameter Lxyz: length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
             % - Parameter Nxyz: number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-            % - Parameter rho:  (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-            % - Parameter stratification:  (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-            % - Parameter latitude: (optional) latitude of the domain (default is 33 degrees north)
-            % - Parameter rho0: (optional) density at the surface z=0 (default is 1025 kg/m^3)
-            % - Returns wvt: a new WVTransformHydrostatic instance
+            % - Parameter options.N2Function: function returning squared buoyancy frequency on `[-Lz,0]`
+            % - Parameter options.rhoFunction: function returning density on `[-Lz,0]`
+            % - Parameter options.latitude: latitude in the supported domain; default `33`
+            % - Parameter options.shouldAntialias: exclude quadratically aliased modes; default `true`
+            % - Parameter options.rho0: reference density in kilograms per cubic meter; default `1025`
+            % - Returns wvt: new `WVTransformStratifiedQG` instance
             arguments
                 Lxyz (1,3) double {mustBePositive}
                 Nxyz (1,3) double {mustBePositive}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Corrected the Stable `WVTransform` and `WVModel` API reference, promoted the stored and time-evaluated wave-vortex coefficients, and classified low-level projection and reconstruction arrays as Developer reference.
 - Made documentation generation clean, deterministic, transactional, and reviewable with an exact ClassDocumentation 1.3.0 authoring dependency, canonical build/check tasks, generated hierarchy validation, and case-sensitive internal-route checks.
 - Quarantined disconnected legacy implementations, corrected Internal adaptive-integrator and geometry spelling, retained a narrow 4.x file fallback for `shouldExludeConjugates`, and repaired the retained Internal barotropic FINUFFT path.
 - Stabilized model-output scheduling and NetCDF restart across multiple files and groups; preserved linear dynamics and shared observing systems; and made initialization, writing, restoration, and handle ownership exception-safe.

--- a/FlowComponents/WVMeanDensityAnomalyMethods.m
+++ b/FlowComponents/WVMeanDensityAnomalyMethods.m
@@ -74,18 +74,15 @@ classdef WVMeanDensityAnomalyMethods < handle
         end
 
         function addMeanDensityAnomaly(self,eta)
-            % add inertial motions to existing inertial motions
+            % Add a mean-density anomaly to the existing fluid state.
             %
-            % The amplitudes of the inertial part of the flow will be added
-            % to the existing inertial part of the flow.
+            % The supplied horizontally uniform isopycnal displacement is
+            % projected onto the internal mean-density-anomaly modes and
+            % added to their `A0` coefficients.
             %
             % ```matlab
-            % U_io = 0.2;
-            % Ld = wvt.Lz/5;
-            % u_NIO = @(z) U_io*exp((z/Ld));
-            % v_NIO = @(z) zeros(size(z));
-            %
-            % wvt.addInertialMotions(u_NIO,v_NIO);
+            % eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+            % wvt.addMeanDensityAnomaly(eta);
             % ```
             %
             % It is important to note that because the WVTransform
@@ -93,7 +90,6 @@ classdef WVMeanDensityAnomalyMethods < handle
             % same function out that you put in. The high-modes are
             % removed.
             %
-            % The new inertial motions are added to the existing inertial motions
             % - Topic: Initial conditions — Mean density anomaly
             % - Declaration: addMeanDensityAnomaly(eta)
             % - Parameter eta: function handle that takes a single argument, eta(Z)
@@ -101,17 +97,15 @@ classdef WVMeanDensityAnomalyMethods < handle
         end
 
         function initWithMeanDensityAnomaly(self,eta)
-            % initialize with inertial motions
+            % Initialize the fluid state with a mean-density anomaly.
             %
-            % Clears variables Ap,Am,A0 and then sets inertial motions.
+            % Clear `Ap`, `Am`, and `A0`, then project the supplied
+            % horizontally uniform isopycnal displacement onto the internal
+            % mean-density-anomaly modes.
             % 
             % ```matlab
-            % U_io = 0.2;
-            % Ld = wvt.Lz/5;
-            % u_NIO = @(z) U_io*exp((z/Ld));
-            % v_NIO = @(z) zeros(size(z));
-            %
-            % wvt.initWithInertialMotions(u_NIO,v_NIO);
+            % eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+            % wvt.initWithMeanDensityAnomaly(eta);
             % ```
             %
             % It is important to note that because the WVTransform
@@ -127,18 +121,15 @@ classdef WVMeanDensityAnomalyMethods < handle
         end
 
         function setMeanDensityAnomaly(self,eta)
-            % set inertial motions
+            % Set the mean-density-anomaly component.
             %
-            % Overwrites existing inertial motions with the new values.
+            % Overwrite existing mean-density-anomaly coefficients with the
+            % projection of `eta` while preserving other flow components.
             % Other components of the flow will remain unaffected.
             %
             % ```matlab
-            % U_io = 0.2;
-            % Ld = wvt.Lz/5;
-            % u_NIO = @(z) U_io*exp((z/Ld));
-            % v_NIO = @(z) zeros(size(z));
-            %
-            % wvt.setInertialMotions(u_NIO,v_NIO);
+            % eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+            % wvt.setMeanDensityAnomaly(eta);
             % ```
             %
             % It is important to note that because the WVTransform

--- a/UnitTests/TestStableAPIDocumentation.m
+++ b/UnitTests/TestStableAPIDocumentation.m
@@ -1,0 +1,194 @@
+classdef TestStableAPIDocumentation < matlab.unittest.TestCase
+    properties
+        repositoryRoot (1,1) string
+    end
+
+    methods (TestMethodSetup)
+        function locateRepository(testCase)
+            testCase.repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function abstractTransformListsStableFamilies(testCase)
+            page = testCase.generatedTransformPage("wvtransform","index.md");
+            stableFamilies = [
+                "WVTransformConstantStratification"
+                "WVTransformHydrostatic"
+                "WVTransformBoussinesq"
+                "WVTransformStratifiedQG"
+                "WVTransformBarotropicQG"
+                ];
+            for family = stableFamilies'
+                testCase.verifySubstring(page,"`" + family + "`");
+            end
+            testCase.verifyFalse(contains(page,"WVTransformSingleMode"));
+            testCase.verifyFalse(contains(page,"Cartesian2DBarotropic"));
+        end
+
+        function constructorPagesUseCurrentDeclarations(testCase)
+            expectations = {
+                "wvtransformconstantstratification", "WVTransformConstantStratification", ["options.N0" "options.isHydrostatic"]
+                "wvtransformhydrostatic", "WVTransformHydrostatic", ["options.N2Function" "options.rhoFunction"]
+                "wvtransformboussinesq", "WVTransformBoussinesq", ["options.N2Function" "options.rhoFunction"]
+                "wvtransformstratifiedqg", "WVTransformStratifiedQG", ["options.N2Function" "options.rhoFunction"]
+                "wvtransformbarotropicqg", "WVTransformBarotropicQG", "options.h"
+                };
+            for iExpectation = 1:size(expectations,1)
+                folder = expectations{iExpectation,1};
+                className = expectations{iExpectation,2};
+                page = testCase.generatedTransformPage(folder,folder + ".md");
+                testCase.verifySubstring(page,"wvt = " + className + "(");
+                testCase.verifySubstring(page,"new `" + className + "` instance");
+                for option = expectations{iExpectation,3}
+                    testCase.verifySubstring(page,"`" + option + "`");
+                end
+                testCase.verifyFalse(contains(page,"WaveVortexTranform"));
+                if className ~= "WVTransformHydrostatic"
+                    testCase.verifyFalse(contains(page,"WVTransformHydrostatic instance"), ...
+                        "A copied Hydrostatic return description remains in " + className + ".");
+                end
+            end
+        end
+
+        function waveVortexCoefficientsAreProminent(testCase)
+            abstractPage = testCase.generatedTransformPage("wvtransform","index.md");
+            coefficientSection = extractBetween(abstractPage,"+ Wave-vortex coefficients","+ State variables");
+            for name = ["Ap" "Am" "A0"]
+                testCase.verifySubstring(coefficientSection,"[`" + name + "`]");
+            end
+
+            waveBearing = [
+                "wvtransformconstantstratification"
+                "wvtransformhydrostatic"
+                "wvtransformboussinesq"
+                ];
+            for folder = waveBearing'
+                page = testCase.generatedTransformPage(folder,"index.md");
+                for name = ["Ap" "Am" "A0"]
+                    testCase.verifySubstring(page,"wvtransform/" + lower(name) + ".html");
+                end
+                for name = ["Apt" "Amt" "A0t"]
+                    testCase.verifySubstring(page,"[`" + name + "`]");
+                end
+            end
+
+            qgTransforms = ["wvtransformstratifiedqg" "wvtransformbarotropicqg"];
+            for folder = qgTransforms
+                page = testCase.generatedTransformPage(folder,"index.md");
+                testCase.verifySubstring(page,"wvtransform/a0.html");
+                testCase.verifySubstring(page,"no active `Ap`, `Am`, `Apt`, or `Amt` content");
+                testCase.verifySubstring(page,"[`A0t`]");
+            end
+        end
+
+        function lowLevelCoefficientArraysAreDeveloperReference(testCase)
+            page = testCase.generatedTransformPage("wvtransformconstantstratification","index.md");
+            developerSection = extractAfter(page,"## Developer Topics");
+            testCase.verifySubstring(developerSection,"Projection coefficients");
+            testCase.verifySubstring(developerSection,"Reconstruction coefficients");
+            for name = ["A0N" "A0U" "A0V" "UAp" "VAm" "NA0"]
+                testCase.verifySubstring(developerSection,"[`" + name + "`]");
+            end
+
+            source = fileread(fullfile(testCase.repositoryRoot,"@WVTransform","detailedDescriptions","ApU.md"));
+            testCase.verifySubstring(source,"projection coefficients");
+            testCase.verifyFalse(contains(source,"sorting matrix"));
+        end
+
+        function reviewedPagesContainNoObsoleteReferenceText(testCase)
+            relativePaths = [
+                "classes/transforms/wvtransform/index.md"
+                "classes/transforms/wvtransformconstantstratification/index.md"
+                "classes/transforms/wvtransformhydrostatic/index.md"
+                "classes/transforms/wvtransformboussinesq/index.md"
+                "classes/transforms/wvtransformstratifiedqg/index.md"
+                "classes/transforms/wvtransformbarotropicqg/index.md"
+                "classes/wvmodel/index.md"
+                ];
+            forbidden = [
+                "WVTransformSingleMode"
+                "Cartesian2DBarotropic"
+                "WaveVortexTranform"
+                "sorting matrix"
+                ];
+            for relativePath = relativePaths'
+                page = fileread(fullfile(testCase.repositoryRoot,"docs",relativePath));
+                for phrase = forbidden'
+                    testCase.verifyFalse(contains(page,phrase),relativePath + " contains " + phrase + ".");
+                end
+            end
+
+            interpolationPage = testCase.generatedTransformPage("wvtransform","variableatpositionwithname.md");
+            testCase.verifySubstring(interpolationPage,"`linear`");
+            testCase.verifySubstring(interpolationPage,"`spline`");
+            testCase.verifyFalse(contains(interpolationPage,"`exact`"));
+            testCase.verifyFalse(contains(interpolationPage,"`finufft`"));
+        end
+
+        function documentedConstructorsExecute(testCase)
+            Lxyz = [40e3 30e3 2e3];
+            Nxyz = [8 6 5];
+            N2 = @(z)(5.2e-3)^2*ones(size(z));
+
+            transforms = {
+                WVTransformConstantStratification(Lxyz,Nxyz,N0=5.2e-3,latitude=45)
+                WVTransformConstantStratification(Lxyz,Nxyz,N0=5.2e-3,latitude=45,isHydrostatic=true)
+                WVTransformHydrostatic(Lxyz,Nxyz,N2Function=N2,latitude=45)
+                WVTransformBoussinesq(Lxyz,Nxyz,N2Function=N2,latitude=45)
+                WVTransformStratifiedQG(Lxyz,Nxyz,N2Function=N2,latitude=45)
+                WVTransformBarotropicQG(Lxyz(1:2),Nxyz(1:2),h=0.8,latitude=45)
+                };
+            expectedClasses = [
+                "WVTransformConstantStratification"
+                "WVTransformConstantStratification"
+                "WVTransformHydrostatic"
+                "WVTransformBoussinesq"
+                "WVTransformStratifiedQG"
+                "WVTransformBarotropicQG"
+                ];
+            testCase.verifyEqual(string(cellfun(@class,transforms,UniformOutput=false)),expectedClasses);
+
+            linearModel = WVModel(transforms{1},shouldUseLinearDynamics=true);
+            transforms{2}.addForcing(WVAdaptiveDamping(transforms{2}));
+            nonlinearModel = WVModel(transforms{2});
+            testCase.verifyTrue(linearModel.isDynamicsLinear);
+            testCase.verifyFalse(nonlinearModel.isDynamicsLinear);
+        end
+
+        function coefficientClaimsMatchTransformState(testCase)
+            wvt = WVTransformConstantStratification([40e3 30e3 2e3],[8 6 5],N0=5.2e-3,latitude=45);
+            testCase.verifyEqual(size(wvt.Ap),size(wvt.Am));
+            testCase.verifyEqual(size(wvt.Ap),size(wvt.A0));
+            testCase.verifyEqual(string(wvt.propertyAnnotationWithName("Ap").units),"m/s");
+            testCase.verifyEqual(string(wvt.propertyAnnotationWithName("Am").units),"m/s");
+            testCase.verifyEqual(string(wvt.propertyAnnotationWithName("A0").units),"m^2 s^{-1}");
+            testCase.verifyEqual(string(wvt.propertyAnnotationWithName("A0t").units),"m^2 s^{-1}");
+
+            waveIndex = find(wvt.waveComponent.maskAp,1);
+            wvt.Ap(waveIndex) = 1.25 - 0.5i;
+            wvt.t0 = 7;
+            wvt.t = 19;
+            expected = wvt.Ap(waveIndex)*exp(1i*wvt.Omega(waveIndex)*(wvt.t-wvt.t0));
+            testCase.verifyEqual(wvt.Apt(waveIndex),expected,AbsTol=10*eps(abs(expected)));
+            testCase.verifyEqual(wvt.Ap(waveIndex),1.25 - 0.5i);
+
+            wvt.initWithInertialMotions(@(z)0.1*ones(size(z)),@(z)zeros(size(z)));
+            maskAp = logical(wvt.inertialComponent.maskAp);
+            maskAm = logical(wvt.inertialComponent.maskAm);
+            testCase.verifyEqual(wvt.Am(maskAm),conj(wvt.Ap(maskAp)));
+
+            qg = WVTransformBarotropicQG([40e3 30e3],[8 6],h=0.8,latitude=45);
+            testCase.verifyFalse(qg.hasVariableWithName("Ap"));
+            testCase.verifyFalse(qg.hasVariableWithName("Am"));
+            testCase.verifyTrue(qg.hasVariableWithName("A0"));
+            testCase.verifyEqual(qg.A0t,qg.A0);
+        end
+    end
+
+    methods (Access=private)
+        function page = generatedTransformPage(testCase,folder,file)
+            page = string(fileread(fullfile(testCase.repositoryRoot,"docs","classes","transforms",folder,file)));
+        end
+    end
+end

--- a/docs/classes/flow-components/wvflowcomponent/abbreviatedname.md
+++ b/docs/classes/flow-components/wvflowcomponent/abbreviatedname.md
@@ -16,4 +16,4 @@ abbreviated name
 
 ## Discussion
 
-  abreviated feature name, e.g., "igw" for internal gravity waves.
+abreviated feature name, e.g., "igw" for internal gravity waves.

--- a/docs/classes/flow-components/wvflowcomponent/index.md
+++ b/docs/classes/flow-components/wvflowcomponent/index.md
@@ -18,17 +18,17 @@ Orthogonal solution group
 
 ## Overview
 
-Each degree-of-freedom in the model is associated with an analytical
-solution to the equations of motion. This class groups together
-solutions of a particular type and provides a mapping between their
-analytical solutions and their numerical representation.
+ch degree-of-freedom in the model is associated with an analytical
+lution to the equations of motion. This class groups together
+lutions of a particular type and provides a mapping between their
+alytical solutions and their numerical representation.
 
-Perhaps the most complicate part of the numerical implementation is
-the indexing---finding where each solution is represented
-numerically. In general, a solution will have some properties, e.g.,
-  (kMode,lMode,jMode,phi,A,omegasign)
-which will have a primary and conjugate part, each of which might be
-in two different matrices.
+rhaps the most complicate part of the numerical implementation is
+e indexing---finding where each solution is represented
+merically. In general, a solution will have some properties, e.g.,
+(kMode,lMode,jMode,phi,A,omegasign)
+ich will have a primary and conjugate part, each of which might be
+ two different matrices.
 
 
 

--- a/docs/classes/flow-components/wvflowcomponent/maska0.md
+++ b/docs/classes/flow-components/wvflowcomponent/maska0.md
@@ -16,5 +16,5 @@ returns a mask indicating where solutions live in the A0 matrix.
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the A0 matrix.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the A0 matrix.

--- a/docs/classes/flow-components/wvflowcomponent/maskam.md
+++ b/docs/classes/flow-components/wvflowcomponent/maskam.md
@@ -16,5 +16,5 @@ returns a mask indicating where solutions live in the Am matrix.
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Am matrix.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Am matrix.

--- a/docs/classes/flow-components/wvflowcomponent/maskap.md
+++ b/docs/classes/flow-components/wvflowcomponent/maskap.md
@@ -16,5 +16,5 @@ returns a mask indicating where solutions live in the Ap matrix.
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap matrix.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap matrix.

--- a/docs/classes/flow-components/wvflowcomponent/name.md
+++ b/docs/classes/flow-components/wvflowcomponent/name.md
@@ -16,4 +16,4 @@ of the flow feature
 
 ## Discussion
 
-  long-form version of the feature name, e.g., "internal gravity wave"
+long-form version of the feature name, e.g., "internal gravity wave"

--- a/docs/classes/flow-components/wvflowcomponent/randomamplitudes.md
+++ b/docs/classes/flow-components/wvflowcomponent/randomamplitudes.md
@@ -25,6 +25,6 @@ returns random amplitude for a valid flow state
 
 ## Discussion
 
-  Returns Ap, Am, A0 matrices initialized with random amplitude
-  for this flow component. These resulting matrices will have
-  the correct symmetries for a valid flow state.
+Returns Ap, Am, A0 matrices initialized with random amplitude
+for this flow component. These resulting matrices will have
+the correct symmetries for a valid flow state.

--- a/docs/classes/flow-components/wvflowcomponent/randomamplitudeswithspectrum.md
+++ b/docs/classes/flow-components/wvflowcomponent/randomamplitudeswithspectrum.md
@@ -30,5 +30,5 @@ initialize with coefficients following a specified spectrum
 
 ## Discussion
 
-  This allows you to initialize amplitudes following a spectrum
-  defined in terms of wavenumber and vertical mode.
+This allows you to initialize amplitudes following a spectrum
+defined in terms of wavenumber and vertical mode.

--- a/docs/classes/flow-components/wvflowcomponent/shortname.md
+++ b/docs/classes/flow-components/wvflowcomponent/shortname.md
@@ -16,4 +16,4 @@ name of the flow feature
 
 ## Discussion
 
-  camel-case version of the feature name, e.g., "internalGravityWave"
+camel-case version of the feature name, e.g., "internalGravityWave"

--- a/docs/classes/flow-components/wvflowcomponent/wvt.md
+++ b/docs/classes/flow-components/wvflowcomponent/wvt.md
@@ -16,4 +16,4 @@ reference to the wave vortex transform
 
 ## Discussion
 
-  reference to the WVTransform instance
+reference to the WVTransform instance

--- a/docs/classes/flow-components/wvgeostrophiccomponent/geostrophicsolution.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/geostrophicsolution.md
@@ -36,4 +36,4 @@ return a real-valued analytical solution of the geostrophic mode
 
 ## Discussion
 
-  Returns function handles of the form u=@(x,y,z,t)
+Returns function handles of the form u=@(x,y,z,t)

--- a/docs/classes/flow-components/wvgeostrophiccomponent/index.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/index.md
@@ -46,7 +46,7 @@ OrthogonalSolutionGroup
 + Quadratic quantities
   + [`totalEnergyFactorForCoefficientMatrix`](/classes/flow-components/wvgeostrophiccomponent/totalenergyfactorforcoefficientmatrix.html) returns the total energy multiplier for the coefficient matrix.
 + Other
-  + [`WVGeostrophicComponent`](/classes/flow-components/wvgeostrophiccomponent/wvgeostrophiccomponent.html) Geostrophic solution group
+  + [`WVGeostrophicComponent`](/classes/flow-components/wvgeostrophiccomponent/wvgeostrophiccomponent.html)
   + [`degreesOfFreedomPerMode`](/classes/flow-components/wvgeostrophiccomponent/degreesoffreedompermode.html)
   + [`multiplierForVariable`](/classes/flow-components/wvgeostrophiccomponent/multiplierforvariable.html)
   + [`normalization`](/classes/flow-components/wvgeostrophiccomponent/normalization.html)

--- a/docs/classes/flow-components/wvgeostrophiccomponent/isvalidconjugatemodenumber.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/isvalidconjugatemodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvgeostrophiccomponent/isvalidmodenumber.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvgeostrophiccomponent/isvalidprimarymodenumber.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/isvalidprimarymodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvgeostrophiccomponent/maskofconjugatemodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/maskofconjugatemodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the redundant (conjugate )solutions live in the 
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvgeostrophiccomponent/maskofmodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/maskofmodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where solutions live in the requested coefficient matr
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvgeostrophiccomponent/maskofprimarymodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/maskofprimarymodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the primary (non-conjugate) solutions live in th
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvgeostrophiccomponent/nmodes.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/nmodes.md
@@ -23,5 +23,5 @@ return the number of unique modes of this type
 
 ## Discussion
 
-  Returns the number of unique modes of this type for the
-  transform in its current configuration.
+Returns the number of unique modes of this type for the
+transform in its current configuration.

--- a/docs/classes/flow-components/wvgeostrophiccomponent/normalizegeostrophicmodeproperties.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/normalizegeostrophicmodeproperties.md
@@ -34,6 +34,6 @@ returns properties of a geostrophic solution relative to the primary mode number
 
 ## Discussion
 
-  This function will return the primary mode numbers (k,l,j),
-  given the any valid mode numbers (k,l,j) and adjust the
-  amplitude (A) and phase (phi), if necessary.
+This function will return the primary mode numbers (k,l,j),
+given the any valid mode numbers (k,l,j) and adjust the
+amplitude (A) and phase (phi), if necessary.

--- a/docs/classes/flow-components/wvgeostrophiccomponent/solutionformodeatindex.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/solutionformodeatindex.md
@@ -26,4 +26,4 @@ return the analytical solution at this index
 
 ## Discussion
 
-  Returns WVOrthogonalSolution object for this index
+Returns WVOrthogonalSolution object for this index

--- a/docs/classes/flow-components/wvgeostrophiccomponent/totalenergyfactorforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/totalenergyfactorforcoefficientmatrix.md
@@ -26,6 +26,6 @@ returns the total energy multiplier for the coefficient matrix.
 
 ## Discussion
 
-  Returns a matrix of size wvt.spectralMatrixSize that
-  multiplies the squared absolute value of this matrix to
-  produce the total energy.
+Returns a matrix of size wvt.spectralMatrixSize that
+multiplies the squared absolute value of this matrix to
+produce the total energy.

--- a/docs/classes/flow-components/wvgeostrophiccomponent/wvgeostrophiccomponent.md
+++ b/docs/classes/flow-components/wvgeostrophiccomponent/wvgeostrophiccomponent.md
@@ -9,17 +9,7 @@ mathjax: true
 
 #  WVGeostrophicComponent
 
-Geostrophic solution group
+
 
 
 ---
-
-## Declaration
-```matlab
- classdef WVGeostrophicComponent < WVPrimaryFlowComponent
-```
-## Discussion
-FlowConstituentGroup WVGeostrophicFlowGroup
-  WVInternalGravityWaveFlowGroup
-  WVRigidLidFlowGroup
-  OrthogonalSolutionGroup

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/index.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/index.md
@@ -42,7 +42,7 @@ Inertial oscillation solution group
 + Quadratic quantities
   + [`totalEnergyFactorForCoefficientMatrix`](/classes/flow-components/wvinertialoscillationcomponent/totalenergyfactorforcoefficientmatrix.html) returns the total energy multiplier for the coefficient matrix.
 + Other
-  + [`WVInertialOscillationComponent`](/classes/flow-components/wvinertialoscillationcomponent/wvinertialoscillationcomponent.html) Inertial oscillation solution group
+  + [`WVInertialOscillationComponent`](/classes/flow-components/wvinertialoscillationcomponent/wvinertialoscillationcomponent.html)
   + [`degreesOfFreedomPerMode`](/classes/flow-components/wvinertialoscillationcomponent/degreesoffreedompermode.html)
   + [`inertialOscillationSpatialTransformCoefficients`](/classes/flow-components/wvinertialoscillationcomponent/inertialoscillationspatialtransformcoefficients.html)
 

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/inertialoscillationsolution.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/inertialoscillationsolution.md
@@ -35,4 +35,4 @@ return a real-valued analytical solution of the internal gravity wave mode
 
 ## Discussion
 
-  Returns function handles of the form u=@(x,y,z,t)
+Returns function handles of the form u=@(x,y,z,t)

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/isvalidconjugatemodenumber.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/isvalidconjugatemodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/isvalidmodenumber.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/isvalidprimarymodenumber.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/isvalidprimarymodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/maskofconjugatemodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/maskofconjugatemodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the redundant (conjugate )solutions live in the 
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/maskofmodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/maskofmodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where solutions live in the requested coefficient matr
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/maskofprimarymodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/maskofprimarymodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the primary (non-conjugate) solutions live in th
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/nmodes.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/nmodes.md
@@ -23,5 +23,5 @@ return the number of unique modes of this type
 
 ## Discussion
 
-  Returns the number of unique modes of this type for the
-  transform in its current configuration.
+Returns the number of unique modes of this type for the
+transform in its current configuration.

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/solutionformodeatindex.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/solutionformodeatindex.md
@@ -26,4 +26,4 @@ return the analytical solution at this index
 
 ## Discussion
 
-  Returns WVOrthogonalSolution object for this index
+Returns WVOrthogonalSolution object for this index

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/totalenergyfactorforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/totalenergyfactorforcoefficientmatrix.md
@@ -26,6 +26,6 @@ returns the total energy multiplier for the coefficient matrix.
 
 ## Discussion
 
-  Returns a matrix of size wvt.spectralMatrixSize that
-  multiplies the squared absolute value of this matrix to
-  produce the total energy.
+Returns a matrix of size wvt.spectralMatrixSize that
+multiplies the squared absolute value of this matrix to
+produce the total energy.

--- a/docs/classes/flow-components/wvinertialoscillationcomponent/wvinertialoscillationcomponent.md
+++ b/docs/classes/flow-components/wvinertialoscillationcomponent/wvinertialoscillationcomponent.md
@@ -9,13 +9,7 @@ mathjax: true
 
 #  WVInertialOscillationComponent
 
-Inertial oscillation solution group
+
 
 
 ---
-
-## Declaration
-```matlab
- classdef WVInertialOscillationComponent < WVPrimaryFlowComponent
-```
-## Discussion

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/index.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/index.md
@@ -43,7 +43,7 @@ Geostrophic solution group
 + Quadratic quantities
   + [`totalEnergyFactorForCoefficientMatrix`](/classes/flow-components/wvinternalgravitywavecomponent/totalenergyfactorforcoefficientmatrix.html) returns the total energy multiplier for the coefficient matrix.
 + Other
-  + [`WVInternalGravityWaveComponent`](/classes/flow-components/wvinternalgravitywavecomponent/wvinternalgravitywavecomponent.html) Geostrophic solution group
+  + [`WVInternalGravityWaveComponent`](/classes/flow-components/wvinternalgravitywavecomponent/wvinternalgravitywavecomponent.html)
   + [`degreesOfFreedomPerMode`](/classes/flow-components/wvinternalgravitywavecomponent/degreesoffreedompermode.html)
   + [`internalGravityWaveSpatialTransformCoefficients`](/classes/flow-components/wvinternalgravitywavecomponent/internalgravitywavespatialtransformcoefficients.html)
   + [`internalGravityWaveSpectralTransformCoefficients`](/classes/flow-components/wvinternalgravitywavecomponent/internalgravitywavespectraltransformcoefficients.html)

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/internalgravitywavesolution.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/internalgravitywavesolution.md
@@ -38,4 +38,4 @@ return a real-valued analytical solution of the internal gravity wave mode
 
 ## Discussion
 
-  Returns function handles of the form u=@(x,y,z,t)
+Returns function handles of the form u=@(x,y,z,t)

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/isvalidconjugatemodenumber.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/isvalidconjugatemodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/isvalidmodenumber.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/isvalidprimarymodenumber.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/isvalidprimarymodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/maskofconjugatemodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/maskofconjugatemodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the redundant (conjugate )solutions live in the 
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/maskofmodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/maskofmodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where solutions live in the requested coefficient matr
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/maskofprimarymodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/maskofprimarymodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the primary (non-conjugate) solutions live in th
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/nmodes.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/nmodes.md
@@ -23,5 +23,5 @@ return the number of unique modes of this type
 
 ## Discussion
 
-  Returns the number of unique modes of this type for the
-  transform in its current configuration.
+Returns the number of unique modes of this type for the
+transform in its current configuration.

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/normalizewavemodeproperties.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/normalizewavemodeproperties.md
@@ -36,6 +36,6 @@ returns properties of a internal gravity wave solutions relative to the primary 
 
 ## Discussion
 
-  This function will return the primary mode numbers (k,l,j),
-  given the any valid mode numbers (k,l,j) and adjust the
-  amplitude (A) and phase (phi), if necessary.
+This function will return the primary mode numbers (k,l,j),
+given the any valid mode numbers (k,l,j) and adjust the
+amplitude (A) and phase (phi), if necessary.

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/solutionformodeatindex.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/solutionformodeatindex.md
@@ -26,4 +26,4 @@ return the analytical solution at this index
 
 ## Discussion
 
-  Returns WVOrthogonalSolution object for this index
+Returns WVOrthogonalSolution object for this index

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/totalenergyfactorforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/totalenergyfactorforcoefficientmatrix.md
@@ -26,6 +26,6 @@ returns the total energy multiplier for the coefficient matrix.
 
 ## Discussion
 
-  Returns a matrix of size wvt.spectralMatrixSize that
-  multiplies the squared absolute value of this matrix to
-  produce the total energy.
+Returns a matrix of size wvt.spectralMatrixSize that
+multiplies the squared absolute value of this matrix to
+produce the total energy.

--- a/docs/classes/flow-components/wvinternalgravitywavecomponent/wvinternalgravitywavecomponent.md
+++ b/docs/classes/flow-components/wvinternalgravitywavecomponent/wvinternalgravitywavecomponent.md
@@ -9,13 +9,7 @@ mathjax: true
 
 #  WVInternalGravityWaveComponent
 
-Geostrophic solution group
+
 
 
 ---
-
-## Declaration
-```matlab
- classdef WVInternalGravityWaveComponent < WVPrimaryFlowComponent
-```
-## Discussion

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/index.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/index.md
@@ -42,7 +42,7 @@ Inertial oscillation solution group
 + Quadratic quantities
   + [`totalEnergyFactorForCoefficientMatrix`](/classes/flow-components/wvmeandensityanomalycomponent/totalenergyfactorforcoefficientmatrix.html) returns the total energy multiplier for the coefficient matrix.
 + Other
-  + [`WVMeanDensityAnomalyComponent`](/classes/flow-components/wvmeandensityanomalycomponent/wvmeandensityanomalycomponent.html) Inertial oscillation solution group
+  + [`WVMeanDensityAnomalyComponent`](/classes/flow-components/wvmeandensityanomalycomponent/wvmeandensityanomalycomponent.html)
   + [`degreesOfFreedomPerMode`](/classes/flow-components/wvmeandensityanomalycomponent/degreesoffreedompermode.html)
   + [`meanDensityAnomalySpatialTransformCoefficients`](/classes/flow-components/wvmeandensityanomalycomponent/meandensityanomalyspatialtransformcoefficients.html)
   + [`meanDensityAnomalySpectralTransformCoefficients`](/classes/flow-components/wvmeandensityanomalycomponent/meandensityanomalyspectraltransformcoefficients.html)

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/isvalidconjugatemodenumber.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/isvalidconjugatemodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/isvalidmodenumber.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/isvalidprimarymodenumber.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/isvalidprimarymodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/maskofconjugatemodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/maskofconjugatemodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the redundant (conjugate )solutions live in the 
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/maskofmodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/maskofmodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where solutions live in the requested coefficient matr
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/meandensityanomalysolution.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/meandensityanomalysolution.md
@@ -32,4 +32,4 @@ return a real-valued analytical solution of the mean density anomaly mode
 
 ## Discussion
 
-  Returns function handles of the form u=@(x,y,z,t)
+Returns function handles of the form u=@(x,y,z,t)

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/nmodes.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/nmodes.md
@@ -23,5 +23,5 @@ return the number of unique modes of this type
 
 ## Discussion
 
-  Returns the number of unique modes of this type for the
-  transform in its current configuration.
+Returns the number of unique modes of this type for the
+transform in its current configuration.

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/solutionformodeatindex.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/solutionformodeatindex.md
@@ -26,4 +26,4 @@ return the analytical solution at this index
 
 ## Discussion
 
-  Returns WVOrthogonalSolution object for this index
+Returns WVOrthogonalSolution object for this index

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/totalenergyfactorforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/totalenergyfactorforcoefficientmatrix.md
@@ -26,6 +26,6 @@ returns the total energy multiplier for the coefficient matrix.
 
 ## Discussion
 
-  Returns a matrix of size wvt.spectralMatrixSize that
-  multiplies the squared absolute value of this matrix to
-  produce the total energy.
+Returns a matrix of size wvt.spectralMatrixSize that
+multiplies the squared absolute value of this matrix to
+produce the total energy.

--- a/docs/classes/flow-components/wvmeandensityanomalycomponent/wvmeandensityanomalycomponent.md
+++ b/docs/classes/flow-components/wvmeandensityanomalycomponent/wvmeandensityanomalycomponent.md
@@ -9,13 +9,7 @@ mathjax: true
 
 #  WVMeanDensityAnomalyComponent
 
-Inertial oscillation solution group
+
 
 
 ---
-
-## Declaration
-```matlab
- classdef WVMeanDensityAnomalyComponent < WVPrimaryFlowComponent
-```
-## Discussion

--- a/docs/classes/flow-components/wvprimaryflowcomponent/index.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/index.md
@@ -18,17 +18,17 @@ Orthogonal solution group
 
 ## Overview
 
-Each degree-of-freedom in the model is associated with an analytical
-solution to the equations of motion. This class groups together
-solutions of a particular type and provides a mapping between their
-analytical solutions and their numerical representation.
+ch degree-of-freedom in the model is associated with an analytical
+lution to the equations of motion. This class groups together
+lutions of a particular type and provides a mapping between their
+alytical solutions and their numerical representation.
 
-Perhaps the most complicate part of the numerical implementation is
-the indexing---finding where each solution is represented
-numerically. In general, a solution will have some properties, e.g.,
-  (kMode,lMode,jMode,phi,A,omegasign)
-which will have a primary and conjugate part, each of which might be
-in two different matrices.
+rhaps the most complicate part of the numerical implementation is
+e indexing---finding where each solution is represented
+merically. In general, a solution will have some properties, e.g.,
+(kMode,lMode,jMode,phi,A,omegasign)
+ich will have a primary and conjugate part, each of which might be
+ two different matrices.
 
 
 

--- a/docs/classes/flow-components/wvprimaryflowcomponent/isvalidconjugatemodenumber.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/isvalidconjugatemodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvprimaryflowcomponent/isvalidmodenumber.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvprimaryflowcomponent/isvalidprimarymodenumber.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/isvalidprimarymodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvprimaryflowcomponent/maskofconjugatemodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/maskofconjugatemodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the redundant (conjugate )solutions live in the 
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvprimaryflowcomponent/maskofmodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/maskofmodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where solutions live in the requested coefficient matr
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvprimaryflowcomponent/maskofprimarymodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/maskofprimarymodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the primary (non-conjugate) solutions live in th
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvprimaryflowcomponent/nmodes.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/nmodes.md
@@ -23,5 +23,5 @@ return the number of unique modes of this type
 
 ## Discussion
 
-  Returns the number of unique modes of this type for the
-  transform in its current configuration.
+Returns the number of unique modes of this type for the
+transform in its current configuration.

--- a/docs/classes/flow-components/wvprimaryflowcomponent/solutionformodeatindex.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/solutionformodeatindex.md
@@ -27,10 +27,10 @@ return the analytical solution for the mode at this index
 
 ## Discussion
 
-  Returns WVOrthogonalSolution object for this index.
-  The solution indices run from 1:nModes.
+Returns WVOrthogonalSolution object for this index.
+The solution indices run from 1:nModes.
 
-  The solution amplitude can be set to either 'wvt' or
-  'random'. Setting the amplitude='wvt' will use the amplitude
-  currently set in the wvt to initialize this solution.
-  Otherwise an appropriate random amplitude will be created.
+The solution amplitude can be set to either 'wvt' or
+'random'. Setting the amplitude='wvt' will use the amplitude
+currently set in the wvt to initialize this solution.
+Otherwise an appropriate random amplitude will be created.

--- a/docs/classes/flow-components/wvprimaryflowcomponent/totalenergyfactorforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/totalenergyfactorforcoefficientmatrix.md
@@ -26,6 +26,6 @@ returns the total energy multiplier for the coefficient matrix.
 
 ## Discussion
 
-  Returns a matrix of size wvt.spectralMatrixSize that
-  multiplies the squared absolute value of this matrix to
-  produce the total energy.
+Returns a matrix of size wvt.spectralMatrixSize that
+multiplies the squared absolute value of this matrix to
+produce the total energy.

--- a/docs/classes/flow-components/wvtotalflowcomponent/index.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/index.md
@@ -18,17 +18,17 @@ Orthogonal solution group
 
 ## Overview
 
-Each degree-of-freedom in the model is associated with an analytical
-solution to the equations of motion. This class groups together
-solutions of a particular type and provides a mapping between their
-analytical solutions and their numerical representation.
+ch degree-of-freedom in the model is associated with an analytical
+lution to the equations of motion. This class groups together
+lutions of a particular type and provides a mapping between their
+alytical solutions and their numerical representation.
 
-Perhaps the most complicate part of the numerical implementation is
-the indexing---finding where each solution is represented
-numerically. In general, a solution will have some properties, e.g.,
-  (kMode,lMode,jMode,phi,A,omegasign)
-which will have a primary and conjugate part, each of which might be
-in two different matrices.
+rhaps the most complicate part of the numerical implementation is
+e indexing---finding where each solution is represented
+merically. In general, a solution will have some properties, e.g.,
+(kMode,lMode,jMode,phi,A,omegasign)
+ich will have a primary and conjugate part, each of which might be
+ two different matrices.
 
 
 

--- a/docs/classes/flow-components/wvtotalflowcomponent/isvalidconjugatemodenumber.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/isvalidconjugatemodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvtotalflowcomponent/isvalidmodenumber.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvtotalflowcomponent/isvalidprimarymodenumber.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/isvalidprimarymodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/flow-components/wvtotalflowcomponent/maskofconjugatemodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/maskofconjugatemodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the redundant (conjugate )solutions live in the 
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvtotalflowcomponent/maskofmodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/maskofmodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where solutions live in the requested coefficient matr
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvtotalflowcomponent/maskofprimarymodesforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/maskofprimarymodesforcoefficientmatrix.md
@@ -26,5 +26,5 @@ returns a mask indicating where the primary (non-conjugate) solutions live in th
 
 ## Discussion
 
-  Returns a 'mask' (matrix with 1s or 0s) indicating where
-  different solution types live in the Ap, Am, A0 matrices.
+Returns a 'mask' (matrix with 1s or 0s) indicating where
+different solution types live in the Ap, Am, A0 matrices.

--- a/docs/classes/flow-components/wvtotalflowcomponent/nmodes.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/nmodes.md
@@ -23,5 +23,5 @@ return the number of unique modes of this type
 
 ## Discussion
 
-  Returns the number of unique modes of this type for the
-  transform in its current configuration.
+Returns the number of unique modes of this type for the
+transform in its current configuration.

--- a/docs/classes/flow-components/wvtotalflowcomponent/solutionformodeatindex.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/solutionformodeatindex.md
@@ -27,13 +27,13 @@ Return analytical solutions from the complete primary-flow basis.
 
 ## Discussion
 
-  Total-flow indices run from 1 through `nModes`. Primary flow
-  components are ordered lexically by `shortName`, and each
-  component contributes one contiguous range while retaining its
-  own local mode ordering. Scalar inputs return a scalar solution;
-  column-vector inputs return solutions in the requested order.
+Total-flow indices run from 1 through `nModes`. Primary flow
+components are ordered lexically by `shortName`, and each
+component contributes one contiguous range while retaining its
+own local mode ordering. Scalar inputs return a scalar solution;
+column-vector inputs return solutions in the requested order.
 
-  Set `amplitude='wvt'` to reconstruct each solution from the
-  corresponding coefficient currently stored by the transform.
-  Set `amplitude='random'` to generate an appropriate random
-  amplitude for each requested solution.
+Set `amplitude='wvt'` to reconstruct each solution from the
+corresponding coefficient currently stored by the transform.
+Set `amplitude='random'` to generate an appropriate random
+amplitude for each requested solution.

--- a/docs/classes/flow-components/wvtotalflowcomponent/totalenergyfactorforcoefficientmatrix.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/totalenergyfactorforcoefficientmatrix.md
@@ -26,6 +26,6 @@ returns the total energy multiplier for the coefficient matrix.
 
 ## Discussion
 
-  Returns a matrix of size wvt.spectralMatrixSize that
-  multiplies the squared absolute value of this matrix to
-  produce the total energy.
+Returns a matrix of size wvt.spectralMatrixSize that
+multiplies the squared absolute value of this matrix to
+produce the total energy.

--- a/docs/classes/forcing/closures/wvadaptivedamping/builddampingoperator.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/builddampingoperator.md
@@ -23,4 +23,4 @@ Builds the damping operator
 
 ## Discussion
 
-        - Returns: None
+- Returns: None

--- a/docs/classes/forcing/closures/wvadaptivedamping/classrequiredpropertynames.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/closures/wvadaptivedamping/dampingtimescale.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/dampingtimescale.md
@@ -23,4 +23,4 @@ Computes the minimum damping time scale
 
 ## Discussion
 
-        - Returns: dampingTimeScale
+- Returns: dampingTimeScale

--- a/docs/classes/forcing/closures/wvadaptivedamping/index.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/index.md
@@ -22,62 +22,62 @@ Adaptive small-scale damping
 
 ## Overview
 
-This damping operator is a linear closure that dynamically changes
-its amplitude to keep the Reynolds number at the grid scale equal to
-one. This closure is ideal for a spin-up problem where the amplitude
-of the flow is changing.
+ damping operator is a linear closure that dynamically changes
+amplitude to keep the Reynolds number at the grid scale equal to
+ This closure is ideal for a spin-up problem where the amplitude
+he flow is changing.
 
-This closure has a number of noteworthy features:
+ closure has a number of noteworthy features:
 
-- It does not mix geostrophic and wave modes, which requires setting
-the diffusivity equal to the viscosity.
-- The properties `k_no_damp` and `j_no_damp` indicate the wavenumber and
-mode below which there is zero damping, due to the spectral vanishing
-viscosity filter.
-- The properties `k_damp` and `j_damp` are *estimates* of the
-wavenumber and mode above which significant damping will occur.
+ does not mix geostrophic and wave modes, which requires setting
+diffusivity equal to the viscosity.
+e properties `k_no_damp` and `j_no_damp` indicate the wavenumber and
+ below which there is zero damping, due to the spectral vanishing
+osity filter.
+e properties `k_damp` and `j_damp` are *estimates* of the
+number and mode above which significant damping will occur.
 
-The damping operator acts in the spectral domain, directly damping
-the wave-vortex coefficients.
-
-$$
-\begin{align}
-    \partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
-    \partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}
-\end{align}
-$$
-
-where
+damping operator acts in the spectral domain, directly damping
+wave-vortex coefficients.
 
 $$
-\nu_z = \nu \lambda^2_\textrm{min} k^2_\textrm{max} = \nu \lambda^2_\textrm{min} \left( \frac{\pi}{\Delta} \right)^2
+in{align}
+\partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
+\partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}
+{align}
 $$
 
-is chosen to make the damping isotropic. The notation here is that
-$$\Delta$$ is the horizontal grid resolution and
-$$\lambda^2_\textrm{min}$$ is the smallest resolved radius of
-deformation. The value of $$\nu$$ is set as
+e
 
 $$
-\nu = \frac{U \Delta}{\pi^2}
+z = \nu \lambda^2_\textrm{min} k^2_\textrm{max} = \nu \lambda^2_\textrm{min} \left( \frac{\pi}{\Delta} \right)^2
 $$
 
-where $$U$$ is the maximum fluid velocity.
+hosen to make the damping isotropic. The notation here is that
+elta$$ is the horizontal grid resolution and
+ambda^2_\textrm{min}$$ is the smallest resolved radius of
+rmation. The value of $$\nu$$ is set as
 
-### Usage
+$$
+= \frac{U \Delta}{\pi^2}
+$$
 
-Assuming there is a WVTransform instance wvt, to add this forcing,
+e $$U$$ is the maximum fluid velocity.
 
-```matlab
-wvt.addForcing(WVAdaptiveDamping(wvt));
+Usage
+
+ming there is a WVTransform instance wvt, to add this forcing,
+
+atlab
+addForcing(WVAdaptiveDamping(wvt));
 ```
 
-### Notes
+Notes
 
-This currently damps the non-hydrostatic wavemodes the same as the
-hydrostatic geostrophic modes. The non-hydrostatic modes would have a
-smaller deformation radius, and thus would be damped more strongly.
-So arguably they're under-damped in a non-hydrostatic simulation.
+ currently damps the non-hydrostatic wavemodes the same as the
+ostatic geostrophic modes. The non-hydrostatic modes would have a
+ler deformation radius, and thus would be damped more strongly.
+rguably they're under-damped in a non-hydrostatic simulation.
 
 
 

--- a/docs/classes/forcing/closures/wvadaptivedamping/spectralvanishingviscosityfilter.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/spectralvanishingviscosityfilter.md
@@ -24,4 +24,4 @@ Builds the spectral vanishing viscosity operator
 
 ## Discussion
 
-          - Returns: Qkl, Qj, kl_cutoff, kl_damp
+- Returns: Qkl, Qj, kl_cutoff, kl_damp

--- a/docs/classes/forcing/closures/wvantialiasing/classrequiredpropertynames.md
+++ b/docs/classes/forcing/closures/wvantialiasing/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/closures/wvantialiasing/effectivehorizontalgridresolution.md
+++ b/docs/classes/forcing/closures/wvantialiasing/effectivehorizontalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/forcing/closures/wvantialiasing/effectivejmax.md
+++ b/docs/classes/forcing/closures/wvantialiasing/effectivejmax.md
@@ -23,7 +23,7 @@ returns the effective highest vertical mode
 
 ## Discussion
 
-  The effective highest vertical modeis the highest fully resolved
-  mode in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective highest vertical modeis the highest fully resolved
+mode in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/forcing/closures/wvantialiasing/nj.md
+++ b/docs/classes/forcing/closures/wvantialiasing/nj.md
@@ -19,5 +19,5 @@ Real valued property with no dimensions and units of $$1$$.
 
 ## Discussion
 
-  This value is preserved when the forcing is converted to another
-  resolution or restored from an annotated NetCDF file.
+This value is preserved when the forcing is converted to another
+resolution or restored from an annotated NetCDF file.

--- a/docs/classes/forcing/closures/wvhorizontaldamping/classrequiredpropertynames.md
+++ b/docs/classes/forcing/closures/wvhorizontaldamping/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/closures/wvhorizontaldamping/index.md
+++ b/docs/classes/forcing/closures/wvhorizontaldamping/index.md
@@ -54,7 +54,6 @@ Assuming there is a WVTransform instance wvt, to add this forcing,
 wvt.addForcing(WVHorizontalDamping(wvt,nu=1e-4, kappa=1e-6));
 ```
 
-
 ### Notes
 
 This is currently implemented in the spatial domain and is

--- a/docs/classes/forcing/closures/wvthermaldamping/classrequiredpropertynames.md
+++ b/docs/classes/forcing/closures/wvthermaldamping/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/closures/wvverticaldamping/classrequiredpropertynames.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/closures/wvverticaldamping/index.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/index.md
@@ -52,7 +52,6 @@ Assuming there is a WVTransform instance wvt, to add this forcing,
 wvt.addForcing(WVVerticalDamping(wvt,nu=5e-4, kappa=1e-6));
 ```
 
-
 ### Notes
 
 This is currently implemented in the spatial domain and is

--- a/docs/classes/forcing/closures/wvverticaldiffusivity/classrequiredpropertynames.md
+++ b/docs/classes/forcing/closures/wvverticaldiffusivity/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/wvbetaplanepvadvection/index.md
+++ b/docs/classes/forcing/wvbetaplanepvadvection/index.md
@@ -24,7 +24,6 @@ Advection of QGPV from beta
 
 This applies $$\beta v_g$$ to the PV (A0) flux of a simulation.
 
-
 ### Usage
 
 Assuming there is a WVTransform instance wvt, to add this forcing,
@@ -50,9 +49,8 @@ actually justifiable with the correct asymptotics. -- Jeffrey
 
 
 ## Topics
-+ Initializing
-  + [`WVBetaPlanePVAdvection`](/classes/forcing/wvbetaplanepvadvection/wvbetaplanepvadvection.html) Advection of QGPV from beta
 + Other
+  + [`WVBetaPlanePVAdvection`](/classes/forcing/wvbetaplanepvadvection/wvbetaplanepvadvection.html)
   + [`betaA0`](/classes/forcing/wvbetaplanepvadvection/betaa0.html)
   + [`classRequiredPropertyNames`](/classes/forcing/wvbetaplanepvadvection/classrequiredpropertynames.html)
 

--- a/docs/classes/forcing/wvbetaplanepvadvection/wvbetaplanepvadvection.md
+++ b/docs/classes/forcing/wvbetaplanepvadvection/wvbetaplanepvadvection.md
@@ -9,37 +9,7 @@ mathjax: true
 
 #  WVBetaPlanePVAdvection
 
-Advection of QGPV from beta
+
 
 
 ---
-
-## Declaration
-```matlab
- WVBetaPlanePVAdvection < [WVForcing](/classes/forcing/wvforcing/)
-```
-## Discussion
-
-  This applies $$\beta v_g$$ to the PV (A0) flux of a simulation.
-
-
-  ### Usage
-
-  Assuming there is a WVTransform instance wvt, to add this forcing,
-
-  ```matlab
-  wvt.addForcing(WVBetaPlanePVAdvection(wvt));
-  ```
-
-  ### Notes
-
-  This may not be justified for a hydrostatic or Boussinesq flow, but
-  it works.
-
-  A doubly-periodic domain with $$\beta$$ has a different $$f$$ at the
-  northern and southern boundary. This is fine for quasigeostrophic
-  dynamics, which only cares about the gradient of $$f$$, but is not
-  okay for internal waves. However, because the wave-vortex model
-  evolves coupled QG-wave equations in the spectral domain, we can add
-  this effect to only the PV part of the flow. I suspect this is
-  actually justifiable with the correct asymptotics. -- Jeffrey

--- a/docs/classes/forcing/wvbottomfrictionlinear/classrequiredpropertynames.md
+++ b/docs/classes/forcing/wvbottomfrictionlinear/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/wvbottomfrictionquadratic/classrequiredpropertynames.md
+++ b/docs/classes/forcing/wvbottomfrictionquadratic/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/wvbottomfrictionquadratic/index.md
+++ b/docs/classes/forcing/wvbottomfrictionquadratic/index.md
@@ -65,7 +65,6 @@ wvt.addForcing(WVBottomFrictionQuadratic(Cd=0.001));
 
 
 
-
 ## Topics
 + Initialization
   + [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/wvbottomfrictionquadratic.html) initialize the WVBottomFrictionQuadratic

--- a/docs/classes/forcing/wvfixedamplitudeforcing/classrequiredpropertynames.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/wvfixedamplitudeforcing/index.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/index.md
@@ -26,7 +26,6 @@ The fixed-amplitude forcing maintains the amplitude of the wave or geostrophic f
 
 As a simple example, one can set an internal wave mode with amplitude 1 cm/s, and that mode will continue to oscillate and maintain its amplitude. The wave will participate in all the nonlinear dynamics, but its amplitude will be maintained/restored at each time step.
 
-
 There are several different ways to write this style of forcing mathematically. The equations of motion, written in the spectral domain, take the following form
 
 $$

--- a/docs/classes/forcing/wvfixedamplitudeforcing/setgeostrophicforcingcoefficients.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/setgeostrophicforcingcoefficients.md
@@ -24,5 +24,5 @@ set amplitude to fix for the geostrophic part of the flow
 
 ## Discussion
 
-  This function will automatically remove modes set in the
-  damping region of the WVAdaptiveDamping forcing, if present.
+This function will automatically remove modes set in the
+damping region of the WVAdaptiveDamping forcing, if present.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/setnarrowbandgeostrophicforcing.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/setnarrowbandgeostrophicforcing.md
@@ -23,4 +23,4 @@ sets a narrow waveband of geostrophic forcing for forced-dissipative modeling
 
 ## Discussion
 
-  to be moved to a subclass
+to be moved to a subclass

--- a/docs/classes/forcing/wvfixedamplitudeforcing/setwaveforcingcoefficients.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/setwaveforcingcoefficients.md
@@ -26,5 +26,5 @@ set the amplitude to fix for the wave part of the flow
 
 ## Discussion
 
-  This function will automatically remove modes set in the
-  damping region of the WVAdaptiveDamping forcing, if present.
+This function will automatically remove modes set in the
+damping region of the WVAdaptiveDamping forcing, if present.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/wvfixedamplitudeforcing.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/wvfixedamplitudeforcing.md
@@ -33,5 +33,5 @@ initialize the WVFixedAmplitudeForcing
 
 ## Discussion
 
-  You must pass the instance of the WVTransform to be used and
-  you must also specify a unique name for the forcing.
+You must pass the instance of the WVTransform to be used and
+you must also specify a unique name for the forcing.

--- a/docs/classes/forcing/wvforcing/forcingfromgroup.md
+++ b/docs/classes/forcing/wvforcing/forcingfromgroup.md
@@ -26,6 +26,6 @@ initialize a WVForcing instance from NetCDF file
 
 ## Discussion
 
-  Subclasses to should override this method to enable model
-  restarts. This method works in conjunction with -writeToFile
-  to provide restart capability.
+Subclasses to should override this method to enable model
+restarts. This method works in conjunction with -writeToFile
+to provide restart capability.

--- a/docs/classes/forcing/wvforcing/forcingtype.md
+++ b/docs/classes/forcing/wvforcing/forcingtype.md
@@ -19,15 +19,15 @@ Array of supported forcing types
 
 ## Discussion
 
-  If the class supports a given forcing type, that indicates that
-  the class implements a particular methods. The correspondence is
-  as follows:
-  WVForcingType                 Method
-  -------------                 ------
-  HydrostaticSpatial            addHydrostaticSpatialForcing
-  NonhydrostaticSpatial         addNonhydrostaticSpatialForcing
-  PVSpatial                     addPotentialVorticitySpatialForcing
-  Spectral                      addSpectralForcing
-  PVSpectral                    addPotentialVorticitySpectralForcing
-  SpectralAmplitude             setSpectralForcing / setSpectralAmplitude
-  PVSpectralAmplitude           setPotentialVorticitySpectralForcing / setPotentialVorticitySpectralAmplitude
+If the class supports a given forcing type, that indicates that
+the class implements a particular methods. The correspondence is
+as follows:
+WVForcingType                 Method
+-------------                 ------
+HydrostaticSpatial            addHydrostaticSpatialForcing
+NonhydrostaticSpatial         addNonhydrostaticSpatialForcing
+PVSpatial                     addPotentialVorticitySpatialForcing
+Spectral                      addSpectralForcing
+PVSpectral                    addPotentialVorticitySpectralForcing
+SpectralAmplitude             setSpectralForcing / setSpectralAmplitude
+PVSpectralAmplitude           setPotentialVorticitySpectralForcing / setPotentialVorticitySpectralAmplitude

--- a/docs/classes/forcing/wvforcing/forcingwithresolutionoftransform.md
+++ b/docs/classes/forcing/wvforcing/forcingwithresolutionoftransform.md
@@ -26,5 +26,5 @@ create a new WVForcing with a new resolution
 
 ## Discussion
 
-  Subclasses to should override this method an implement the
-  correct logic.
+Subclasses to should override this method an implement the
+correct logic.

--- a/docs/classes/forcing/wvforcing/index.md
+++ b/docs/classes/forcing/wvforcing/index.md
@@ -21,23 +21,23 @@ Computes a forcing
 
 ## Overview
 
-WVForcing is an abstract class that defines how forcing gets added to
-a WVTransform. You can use one the built-in forcing operations, or
-make your own.
+orcing is an abstract class that defines how forcing gets added to
+VTransform. You can use one the built-in forcing operations, or
+e your own.
 
-Forcing is applied at two stages:
-1. in the spatial domain to
-   1. non-hydrostatic flow d/dt(u,v,w,eta) = (Fu,Fv,Fw,Feta) or
-   1. hydrostatic flow d/dt(u,v,eta) = (Fu,Fv,Feta)  and
-2. in the spectral domain to d/dt(Ap,Am,A0) = (Fp,Fm,F0)
+cing is applied at two stages:
+in the spatial domain to
+1. non-hydrostatic flow d/dt(u,v,w,eta) = (Fu,Fv,Fw,Feta) or
+1. hydrostatic flow d/dt(u,v,eta) = (Fu,Fv,Feta)  and
+in the spectral domain to d/dt(Ap,Am,A0) = (Fp,Fm,F0)
 
-Each WVForcingFluxOperation must choose one of the two options and
-override either,
-1. [Fu, Fv, Fw, Feta] = addSpatialForcing(wvt, Fu, Fv, Fw, Feta) or,
-2. [Fp, Fm, F0] = addSpectralForcing( wvt, Fp, Fm, F0)
+h WVForcingFluxOperation must choose one of the two options and
+rride either,
+[Fu, Fv, Fw, Feta] = addSpatialForcing(wvt, Fu, Fv, Fw, Feta) or,
+[Fp, Fm, F0] = addSpectralForcing( wvt, Fp, Fm, F0)
 
-Regardless of which method is chosen, the energy flux from the forcing
-can always be deduced at each moment in time.
+ardless of which method is chosen, the energy flux from the forcing
+ always be deduced at each moment in time.
 
 
 

--- a/docs/classes/forcing/wvforcing/priority.md
+++ b/docs/classes/forcing/wvforcing/priority.md
@@ -19,9 +19,9 @@ determines the order in which the WVForcing will be
 
 ## Discussion
 applied. Highest priority (0) will get called first, lowest (255)
-  will get called last. The default is 255. The priority level is
-  relativity to the ForcingType: i.e., spatial forcing is always
-  called before spectral forcing, regardless of priority. Nonlinear
-  advection and Antialiasing have priorities set to 127, and thus
-  by default they will be called before other forcings in their
-  type.
+will get called last. The default is 255. The priority level is
+relativity to the ForcingType: i.e., spatial forcing is always
+called before spectral forcing, regardless of priority. Nonlinear
+advection and Antialiasing have priorities set to 127, and thus
+by default they will be called before other forcings in their
+type.

--- a/docs/classes/forcing/wvforcing/wvforcing.md
+++ b/docs/classes/forcing/wvforcing/wvforcing.md
@@ -28,5 +28,5 @@ create a new nonlinear flux operation
 
 ## Discussion
 
-  This class is intended to be subclassed, so it generally
-  assumed that this initialization will not be called directly.
+This class is intended to be subclassed, so it generally
+assumed that this initialization will not be called directly.

--- a/docs/classes/forcing/wvnonlinearadvection/classrequiredpropertynames.md
+++ b/docs/classes/forcing/wvnonlinearadvection/classrequiredpropertynames.md
@@ -20,4 +20,4 @@ Returns the required property names for the class
 ```
 ## Discussion
 
-      - Returns: vars
+- Returns: vars

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/barotropicvelocityamplitude.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/barotropicvelocityamplitude.md
@@ -23,6 +23,6 @@ Complex valued property with dimension $$barotropicVelocityComponent$$ and units
 
 ## Discussion
 
-  The two entries are the zonal and meridional amplitudes in
-  $$\boldsymbol U_{\mathrm{bt}}=R(t)\operatorname{Re}
-  \{\widehat{\boldsymbol U}_{\mathrm{bt}}e^{-i\omega(t-t_0)}\}$$.
+The two entries are the zonal and meridional amplitudes in
+$$\boldsymbol U_{\mathrm{bt}}=R(t)\operatorname{Re}
+\{\widehat{\boldsymbol U}_{\mathrm{bt}}e^{-i\omega(t-t_0)}\}$$.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/barotropicvelocitycomponent.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/barotropicvelocitycomponent.md
@@ -20,5 +20,5 @@ Coordinate for the barotropic-velocity components.
 
 ## Discussion
 
-  Values 1 and 2 identify the zonal and meridional components,
-  respectively. This coordinate is used for NetCDF persistence.
+Values 1 and 2 identify the zonal and meridional components,
+respectively. This coordinate is used for NetCDF persistence.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/classrequiredpropertynames.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/classrequiredpropertynames.md
@@ -23,6 +23,6 @@ Return the forcing properties required for restart.
 
 ## Discussion
 
-  Derived gradients and modal responses are intentionally not
-  persisted; construction against the restored transform
-  rebuilds them.
+Derived gradients and modal responses are intentionally not
+persisted; construction against the restored transform
+rebuilds them.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/darwinsymbol.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/darwinsymbol.md
@@ -20,6 +20,6 @@ Darwin symbol used to select the tidal frequency.
 
 ## Discussion
 
-  This is empty when `frequency` was supplied directly. On restart,
-  the persisted symbol is descriptive metadata and the persisted
-  frequency remains authoritative.
+This is empty when `frequency` was supplied directly. On restart,
+the persisted symbol is descriptive metadata and the persisted
+frequency remains authoritative.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/goffabyssalhilltopography.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/goffabyssalhilltopography.md
@@ -32,16 +32,16 @@ Generate periodic Goff abyssal-hill topography.
 
 ## Discussion
 
-  The isotropic two-dimensional power spectrum is
+The isotropic two-dimensional power spectrum is
 
-  $$P_h(K)=\frac{4\pi h_{\mathrm{rms}}^2}{K_c^2}
-  \left(1+\frac{K^2}{K_c^2}\right)^{-2}.$$
+$$P_h(K)=\frac{4\pi h_{\mathrm{rms}}^2}{K_c^2}
+\left(1+\frac{K^2}{K_c^2}\right)^{-2}.$$
 
-  The returned height is positive upward, zero mean, and
-  normalized to the requested post-filter RMS. Random phases
-  use a local stream and do not alter MATLAB's global random
-  state.
+The returned height is positive upward, zero mean, and
+normalized to the requested post-filter RMS. Random phases
+use a local stream and do not alter MATLAB's global random
+state.
 
-  ```matlab
-  [H,h,diagnostics] = WVPseudoTopographicWaveGeneration.goffAbyssalHillTopography(wvt,minimumWavelength=30e3);
-  ```
+```matlab
+[H,h,diagnostics] = WVPseudoTopographicWaveGeneration.goffAbyssalHillTopography(wvt,minimumWavelength=30e3);
+```

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/maximumforcedhorizontalwavenumber.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/maximumforcedhorizontalwavenumber.md
@@ -23,4 +23,4 @@ Real valued property with no dimensions and units of $$rad m^{-1}$$.
 
 ## Discussion
 
-  The default `Inf` applies no manual horizontal restriction.
+The default `Inf` applies no manual horizontal restriction.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/maximumforcedverticalmode.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/maximumforcedverticalmode.md
@@ -23,4 +23,4 @@ Real valued property with no dimensions and units of $$1$$.
 
 ## Discussion
 
-  The default `Inf` applies no manual vertical-mode restriction.
+The default `Inf` applies no manual vertical-mode restriction.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/shouldavoidadaptivedamping.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/shouldavoidadaptivedamping.md
@@ -23,6 +23,6 @@ Real valued property with no dimensions and units of $$bool$$.
 
 ## Discussion
 
-  When true, modes for which an active `WVAdaptiveDamping` has a
-  nonzero spectral operator are excluded from the generated wave
-  tendency.
+When true, modes for which an active `WVAdaptiveDamping` has a
+nonzero spectral operator are excluded from the generated wave
+tendency.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/spectralgenerationmask.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/spectralgenerationmask.md
@@ -24,8 +24,8 @@ Return the spectral region eligible for bottom-wave generation.
 
 ## Discussion
 
-  The common `mask` combines wave validity, the manual radial
-  horizontal-wavenumber and vertical-mode bounds, and the exact
-  zero-damping support of active `WVAdaptiveDamping` objects.
-  `components` reports those masks separately, including the
-  distinct positive- and negative-wave validity masks.
+The common `mask` combines wave validity, the manual radial
+horizontal-wavenumber and vertical-mode bounds, and the exact
+zero-damping support of active `WVAdaptiveDamping` objects.
+`components` reports those masks separately, including the
+distinct positive- and negative-wave validity masks.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/topographicheight.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/topographicheight.md
@@ -23,5 +23,5 @@ Real valued property with dimensions $$(x,y)$$ and units of $$m$$.
 
 ## Discussion
 
-  The field is stationary and periodic on the transform's
-  horizontal grid.
+The field is stationary and periodic on the transform's
+horizontal grid.

--- a/docs/classes/forcing/wvpseudotopographicwavegeneration/wvpseudotopographicwavegeneration.md
+++ b/docs/classes/forcing/wvpseudotopographicwavegeneration/wvpseudotopographicwavegeneration.md
@@ -36,11 +36,11 @@ Create a prescribed bottom wave-generation forcing.
 
 ## Discussion
 
-  Supply either `frequency` or `darwinSymbol`, but not both.
-  Omitting both selects M2. Supported Darwin symbols are `M2`,
-  `S2`, `N2`, `K1`, and `O1`. A zero ramp duration activates
-  the harmonic current immediately at `startTime`. The
-  transform must contain a wave component and implement
-  `waveModeVerticalStructureAtIndex`. Generation avoids active
-  adaptive damping by default. Manual bounds use radial
-  horizontal wavenumber and vertical wave-mode index.
+Supply either `frequency` or `darwinSymbol`, but not both.
+Omitting both selects M2. Supported Darwin symbols are `M2`,
+`S2`, `N2`, `K1`, and `O1`. A zero ramp duration activates
+the harmonic current immediately at `startTime`. The
+transform must contain a wave component and implement
+`waveModeVerticalStructureAtIndex`. Generation avoids active
+adaptive damping by default. Manual bounds use radial
+horizontal wavenumber and vertical wave-mode index.

--- a/docs/classes/model-output/wvmodeloutputfile/addobservingsystem.md
+++ b/docs/classes/model-output/wvmodeloutputfile/addobservingsystem.md
@@ -16,6 +16,6 @@ add an observing system to the ouput group (if there is only one group)
 
 ## Discussion
 
-  If there are multiple output groups this will throw an error,
-  as you must decide which group you want to add the observing
-  system to.
+If there are multiple output groups this will throw an error,
+as you must decide which group you want to add the observing
+system to.

--- a/docs/classes/model-output/wvmodeloutputfile/closenetcdffile.md
+++ b/docs/classes/model-output/wvmodeloutputfile/closenetcdffile.md
@@ -16,5 +16,5 @@ closes the netcdf file after informing the output groups
 
 ## Discussion
 
-  The file handle is released even if an output-group cleanup
-  notification fails.
+The file handle is released even if an output-group cleanup
+notification fails.

--- a/docs/classes/model-output/wvmodeloutputfile/index.md
+++ b/docs/classes/model-output/wvmodeloutputfile/index.md
@@ -56,7 +56,6 @@ the wave-vortex coefficients.
 
 
 
-
 ## Topics
 + Properties
   + [`didInitializeStorage`](/classes/model-output/wvmodeloutputfile/didinitializestorage.html) boolean indicating whether or not the internal structure of the NetCDF file has been created

--- a/docs/classes/model-output/wvmodeloutputfile/initializeoutputfile.md
+++ b/docs/classes/model-output/wvmodeloutputfile/initializeoutputfile.md
@@ -16,14 +16,14 @@ tells the output groups to initialize themselves in the NetCDF file
 
 ## Discussion
 
-  One noteworthy piece of logic handle by this function: we
-  want all files to able to re-initialize the model, so we make
-  sure that the NetCDFFile has all the required properties of
-  the transform. However, we are writing time series data, so
-  we need to exclude `t`. Additionally, if we happen to also be
-  writing the wave-vortex coefficients, we can neglect writing
-  those to file.
+One noteworthy piece of logic handle by this function: we
+want all files to able to re-initialize the model, so we make
+sure that the NetCDFFile has all the required properties of
+the transform. However, we are writing time series data, so
+we need to exclude `t`. Additionally, if we happen to also be
+writing the wave-vortex coefficients, we can neglect writing
+those to file.
 
-  Initialization is transactional. If any group or observing
-  system fails, the new file is closed and deleted and every
-  storage object returns to its uninitialized state.
+Initialization is transactional. If any group or observing
+system fails, the new file is closed and deleted and every
+storage object returns to its uninitialized state.

--- a/docs/classes/model-output/wvmodeloutputfile/ncfile.md
+++ b/docs/classes/model-output/wvmodeloutputfile/ncfile.md
@@ -19,4 +19,4 @@ reference to the NetCDFFile being used for model output
 
 ## Discussion
 
-  This property may be empty if the file is not yet created
+This property may be empty if the file is not yet created

--- a/docs/classes/model-output/wvmodeloutputfile/outputtimesforintegrationperiod.md
+++ b/docs/classes/model-output/wvmodeloutputfile/outputtimesforintegrationperiod.md
@@ -16,5 +16,5 @@ returns a unique, ordered array of the aggregate output times during the request
 
 ## Discussion
 
-  This will be called exactly once by the model before an
-  integration begins.
+This will be called exactly once by the model before an
+integration begins.

--- a/docs/classes/model-output/wvmodeloutputfile/writetimesteptooutputfile.md
+++ b/docs/classes/model-output/wvmodeloutputfile/writetimesteptooutputfile.md
@@ -16,8 +16,8 @@ tells the output groups to write data at time t
 
 ## Discussion
 
-  This will only be called if the
-  `outputTimesForIntegrationPeriod` previously returned this
-  time `t`. Thus, the actual NetCDF file will be created if
-  it does not yet exist, and then the output groups can write
-  to file.
+This will only be called if the
+`outputTimesForIntegrationPeriod` previously returned this
+time `t`. Thus, the actual NetCDF file will be created if
+it does not yet exist, and then the output groups can write
+to file.

--- a/docs/classes/model-output/wvmodeloutputgroup/closenetcdffile.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/closenetcdffile.md
@@ -16,5 +16,5 @@ notification that the NetCDF file will close
 
 ## Discussion
 
-  This gives the output group an opportunity to display some
-  relevant data or do other necessary clean up.
+This gives the output group an opportunity to display some
+relevant data or do other necessary clean up.

--- a/docs/classes/model-output/wvmodeloutputgroup/group.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/group.md
@@ -19,4 +19,4 @@ Reference to the NetCDFGroup being used for model output
 
 ## Discussion
 Empty indicates no file output. The output group creates the
-  NetCDFGroup, but the NetCDFFile owns it, hence a WeakHandle.
+NetCDFGroup, but the NetCDFFile owns it, hence a WeakHandle.

--- a/docs/classes/model-output/wvmodeloutputgroup/index.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/index.md
@@ -50,7 +50,6 @@ outputFile.addOutputGroup(outputGroup);
 
 
 
-
 ## Topics
 + Properties
   + [`didInitializeStorage`](/classes/model-output/wvmodeloutputgroup/didinitializestorage.html) boolean indicating whether or not the internal structure of the NetCDF file has been created

--- a/docs/classes/model-output/wvmodeloutputgroup/initializeoutputgroup.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/initializeoutputgroup.md
@@ -16,6 +16,6 @@ initializes a new output group in the NetCDF file
 
 ## Discussion
 
-  This will only be called only once. This creates a new group,
-  adds the required properties, creates a time dimension, then
-  tells the observing systems to also initialize their storage.
+This will only be called only once. This creates a new group,
+adds the required properties, creates a time dimension, then
+tells the observing systems to also initialize their storage.

--- a/docs/classes/model-output/wvmodeloutputgroup/initobservingsystemsfromgroup.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/initobservingsystemsfromgroup.md
@@ -16,4 +16,4 @@ asks the output group to load the observing systems in the NetCDF file
 
 ## Discussion
 
-  Called by the static method `modelOutputGroupFromGroup` during the init from file process, this asks the output group to load the observing systems in the NetCDF file
+Called by the static method `modelOutputGroupFromGroup` during the init from file process, this asks the output group to load the observing systems in the NetCDF file

--- a/docs/classes/model-output/wvmodeloutputgroup/modeloutputgroupfromgroup.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/modeloutputgroupfromgroup.md
@@ -27,6 +27,6 @@ initialize a WVModelOutputGroup instance from NetCDF file
 
 ## Discussion
 
-  Subclasses to should override this method to enable model
-  restarts. This method works in conjunction with -writeToFile
-  to provide restart capability.
+Subclasses to should override this method to enable model
+restarts. This method works in conjunction with -writeToFile
+to provide restart capability.

--- a/docs/classes/model-output/wvmodeloutputgroup/outputtimesforintegrationperiod.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/outputtimesforintegrationperiod.md
@@ -16,5 +16,5 @@ returns a unique, ordered array of the aggregate output times during the request
 
 ## Discussion
 
-  Any new subclass of `WVModelOutputGroup` must override this
-  methods and return the appropriate output times.
+Any new subclass of `WVModelOutputGroup` must override this
+methods and return the appropriate output times.

--- a/docs/classes/model-output/wvmodeloutputgroup/writetimesteptonetcdffile.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/writetimesteptonetcdffile.md
@@ -16,6 +16,6 @@ writes data at time t
 
 ## Discussion
 
-  This is called by the `WVModelOutputFile` when the model
-  reaches time `t`. The new time is written to file, adn the
-  observing systems are also told to write to file.
+This is called by the `WVModelOutputFile` when the model
+reaches time `t`. The new time is written to file, adn the
+observing systems are also told to write to file.

--- a/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/finaltime.md
+++ b/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/finaltime.md
@@ -19,6 +19,6 @@ Real valued property with no dimensions and units of $$s$$.
 
 ## Discussion
 
-  This optional properties determines when the output group will
-  de-actives. By default it is set to `Inf`, indicating that it
-  will always write to file.
+This optional properties determines when the output group will
+de-actives. By default it is set to `Inf`, indicating that it
+will always write to file.

--- a/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/index.md
+++ b/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/index.md
@@ -31,7 +31,6 @@ allow you to customize when this group is active in model time.
 
 
 
-
 ## Topics
 + Properties
   + [`finalTime`](/classes/model-output/wvmodeloutputgroupevenlyspaced/finaltime.html) final model time that the output group is active (seconds)

--- a/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/initialtime.md
+++ b/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/initialtime.md
@@ -19,5 +19,5 @@ Real valued property with no dimensions and units of $$s$$.
 
 ## Discussion
 
-  This optional properties determines when the output group will
-  become active. By default it is set to `-Inf`.
+This optional properties determines when the output group will
+become active. By default it is set to `-Inf`.

--- a/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/outputinterval.md
+++ b/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/outputinterval.md
@@ -19,4 +19,4 @@ Real valued property with no dimensions and units of $$s$$.
 
 ## Discussion
 
-  The model output interval written to the group
+The model output interval written to the group

--- a/docs/classes/observing-systems/wvcoefficients/observingsystemwithresolutionoftransform.md
+++ b/docs/classes/observing-systems/wvcoefficients/observingsystemwithresolutionoftransform.md
@@ -26,5 +26,5 @@ create a new WVObservingSystem with a new resolution
 
 ## Discussion
 
-  Subclasses to should override this method an implement the
-  correct logic.
+Subclasses to should override this method an implement the
+correct logic.

--- a/docs/classes/observing-systems/wvcoefficients/wvcoefficients.md
+++ b/docs/classes/observing-systems/wvcoefficients/wvcoefficients.md
@@ -27,5 +27,5 @@ create a new observing system
 
 ## Discussion
 
-  This class is intended to be subclassed, so it generally
-  assumed that this initialization will not be called directly.
+This class is intended to be subclassed, so it generally
+assumed that this initialization will not be called directly.

--- a/docs/classes/observing-systems/wveulerianfields/addnetcdfoutputvariables.md
+++ b/docs/classes/observing-systems/wveulerianfields/addnetcdfoutputvariables.md
@@ -24,10 +24,10 @@ Add variables to list of variables to be written to the NetCDF variable during t
 ## Discussion
 
 
-  Pass strings of WVTransform state variables of the
-  same name. This must be called before using any of the
-  integrate methods.
+Pass strings of WVTransform state variables of the
+same name. This must be called before using any of the
+integrate methods.
 
-  ```matlab
-  model.addNetCDFOutputVariables('A0','u','v');
-  ```
+```matlab
+model.addNetCDFOutputVariables('A0','u','v');
+```

--- a/docs/classes/observing-systems/wveulerianfields/observingsystemwithresolutionoftransform.md
+++ b/docs/classes/observing-systems/wveulerianfields/observingsystemwithresolutionoftransform.md
@@ -26,5 +26,5 @@ create a new WVObservingSystem with a new resolution
 
 ## Discussion
 
-  Subclasses to should override this method an implement the
-  correct logic.
+Subclasses to should override this method an implement the
+correct logic.

--- a/docs/classes/observing-systems/wveulerianfields/removenetcdfoutputvariables.md
+++ b/docs/classes/observing-systems/wveulerianfields/removenetcdfoutputvariables.md
@@ -24,10 +24,10 @@ Remove variables from the list of variables to be written to the NetCDF variable
 ## Discussion
 
 
-  Pass strings of WVTransform state variables of the
-  same name. This must be called before using any of the
-  integrate methods.
+Pass strings of WVTransform state variables of the
+same name. This must be called before using any of the
+integrate methods.
 
-  ```matlab
-  model.removeNetCDFOutputVariables('A0','u','v');
-  ```
+```matlab
+model.removeNetCDFOutputVariables('A0','u','v');
+```

--- a/docs/classes/observing-systems/wveulerianfields/setnetcdfoutputvariables.md
+++ b/docs/classes/observing-systems/wveulerianfields/setnetcdfoutputvariables.md
@@ -24,10 +24,10 @@ Set list of variables to be written to the NetCDF variable during the model run.
 ## Discussion
 
 
-  Pass strings of WVTransform state variables of the
-  same name. This must be called before using any of the
-  integrate methods.
+Pass strings of WVTransform state variables of the
+same name. This must be called before using any of the
+integrate methods.
 
-  ```matlab
-  model.setNetCDFOutputVariables('A0','u','v');
-  ```
+```matlab
+model.setNetCDFOutputVariables('A0','u','v');
+```

--- a/docs/classes/observing-systems/wveulerianfields/wveulerianfields.md
+++ b/docs/classes/observing-systems/wveulerianfields/wveulerianfields.md
@@ -27,5 +27,5 @@ create a new observing system
 
 ## Discussion
 
-  This class is intended to be subclassed, so it generally
-  assumed that this initialization will not be called directly.
+This class is intended to be subclassed, so it generally
+assumed that this initialization will not be called directly.

--- a/docs/classes/observing-systems/wvlagrangianparticles/wvlagrangianparticles.md
+++ b/docs/classes/observing-systems/wvlagrangianparticles/wvlagrangianparticles.md
@@ -29,5 +29,5 @@ Create a Lagrangian-particle observing system.
 
 ## Discussion
 
-  This class is intended to be subclassed, so this initializer
-  is generally called by a model particle facade.
+This class is intended to be subclassed, so this initializer
+is generally called by a model particle facade.

--- a/docs/classes/observing-systems/wvmooring/cvttorus.md
+++ b/docs/classes/observing-systems/wvmooring/cvttorus.md
@@ -16,15 +16,15 @@ Centroidal Voronoi tessellation on a 2D torus
 
 ## Discussion
 
-    [x,y] = cvtTorus(N, Lx, Ly)
-    [x,y] = cvtTorus(N, Lx, Ly, nIter)
+  [x,y] = cvtTorus(N, Lx, Ly)
+  [x,y] = cvtTorus(N, Lx, Ly, nIter)
 
-    N      – number of generators
-    Lx,Ly  – domain size (periodic in both x and y)
-    nIter  – number of Lloyd iterations (default: 20)
+  N      – number of generators
+  Lx,Ly  – domain size (periodic in both x and y)
+  nIter  – number of Lloyd iterations (default: 20)
 
-    x,y    – N×1 vectors of final seed positions in [0,Lx)×[0,Ly)
+  x,y    – N×1 vectors of final seed positions in [0,Lx)×[0,Ly)
 
-  Example:
-    [x,y] = cvtTorus(100, 4, 2, 30);
-    scatter(x,y,20,'filled'); axis equal; xlim([0 4]); ylim([0 2]);
+Example:
+  [x,y] = cvtTorus(100, 4, 2, 30);
+  scatter(x,y,20,'filled'); axis equal; xlim([0 4]); ylim([0 2]);

--- a/docs/classes/observing-systems/wvmooring/torusdist.md
+++ b/docs/classes/observing-systems/wvmooring/torusdist.md
@@ -16,8 +16,8 @@ Shortest distance on a 2D torus
 
 ## Discussion
 d = torusDist(x, y, Lx, Ly)
-    x, y  : 1×2 vectors [x_coord, y_coord] of the two points
-    Lx, Ly: domain lengths in x and y directions
+x, y  : 1×2 vectors [x_coord, y_coord] of the two points
+Lx, Ly: domain lengths in x and y directions
 
-    Returns the Euclidean distance between x and y
-    accounting for periodic wrap in each direction.
+Returns the Euclidean distance between x and y
+accounting for periodic wrap in each direction.

--- a/docs/classes/observing-systems/wvmooring/wvmooring.md
+++ b/docs/classes/observing-systems/wvmooring/wvmooring.md
@@ -27,5 +27,5 @@ create a new observing system
 
 ## Discussion
 
-  This class is intended to be subclassed, so it generally
-  assumed that this initialization will not be called directly.
+This class is intended to be subclassed, so it generally
+assumed that this initialization will not be called directly.

--- a/docs/classes/observing-systems/wvobservingsystem/abserrortolerance.md
+++ b/docs/classes/observing-systems/wvobservingsystem/abserrortolerance.md
@@ -16,7 +16,7 @@ return a cell array of the absolute tolerances of the
 
 ## Discussion
 variables being integrated. You can pass either scalar
-  values, or an array of the same size as the variable.
+values, or an array of the same size as the variable.
 
-  this will only be called when the time-stepping is run with
-  an adaptive integrator.
+this will only be called when the time-stepping is run with
+an adaptive integrator.

--- a/docs/classes/observing-systems/wvobservingsystem/index.md
+++ b/docs/classes/observing-systems/wvobservingsystem/index.md
@@ -26,9 +26,6 @@ A WVObservingSystem is an abstract class that defines different ways of observin
 
 
 
-
-
-
 ## Topics
 + Initializing
   + [`WVObservingSystem`](/classes/observing-systems/wvobservingsystem/wvobservingsystem.html) create a new observing system

--- a/docs/classes/observing-systems/wvobservingsystem/initializestorage.md
+++ b/docs/classes/observing-systems/wvobservingsystem/initializestorage.md
@@ -16,6 +16,6 @@ called once to allow the observing system to initialize its storage space in the
 
 ## Discussion
 
-  Any observing system must implement this method to initialize
-  the NetCDFGroup with the appropriate attributes, dimensions
-  and variables.
+Any observing system must implement this method to initialize
+the NetCDFGroup with the appropriate attributes, dimensions
+and variables.

--- a/docs/classes/observing-systems/wvobservingsystem/nfluxcomponents.md
+++ b/docs/classes/observing-systems/wvobservingsystem/nfluxcomponents.md
@@ -19,9 +19,9 @@ number of components that need to be integrated in time.
 
 ## Discussion
 
-  Setting a value greater than zero will require that you
-  implement,
-    -absErrorTolerance
-    -initialConditions
-    -fluxAtTime
-    -updateIntegratorValues
+Setting a value greater than zero will require that you
+implement,
+  -absErrorTolerance
+  -initialConditions
+  -fluxAtTime
+  -updateIntegratorValues

--- a/docs/classes/observing-systems/wvobservingsystem/observingsystemfromgroup.md
+++ b/docs/classes/observing-systems/wvobservingsystem/observingsystemfromgroup.md
@@ -26,6 +26,6 @@ initialize a WVObservingSystem instance from NetCDF file
 
 ## Discussion
 
-  Subclasses to should override this method to enable model
-  restarts. This method works in conjunction with -writeToFile
-  to provide restart capability.
+Subclasses to should override this method to enable model
+restarts. This method works in conjunction with -writeToFile
+to provide restart capability.

--- a/docs/classes/observing-systems/wvobservingsystem/writetimesteptofile.md
+++ b/docs/classes/observing-systems/wvobservingsystem/writetimesteptofile.md
@@ -16,5 +16,5 @@ called at each time for the observing system to write to file
 
 ## Discussion
 
-  Any observing system must implement this method to initialize
-  and write to the NetCDFGroup at the particular outputIndex.
+Any observing system must implement this method to initialize
+and write to the NetCDFGroup at the particular outputIndex.

--- a/docs/classes/observing-systems/wvobservingsystem/wvobservingsystem.md
+++ b/docs/classes/observing-systems/wvobservingsystem/wvobservingsystem.md
@@ -27,5 +27,5 @@ create a new observing system
 
 ## Discussion
 
-  This class is intended to be subclassed, so it generally
-  assumed that this initialization will not be called directly.
+This class is intended to be subclassed, so it generally
+assumed that this initialization will not be called directly.

--- a/docs/classes/observing-systems/wvtracer/wvtracer.md
+++ b/docs/classes/observing-systems/wvtracer/wvtracer.md
@@ -27,5 +27,5 @@ create a new observing system
 
 ## Discussion
 
-  This class is intended to be subclassed, so it generally
-  assumed that this initialization will not be called directly.
+This class is intended to be subclassed, so it generally
+assumed that this initialization will not be called directly.

--- a/docs/classes/operations-and-annotations/wvoperation/compute.md
+++ b/docs/classes/operations-and-annotations/wvoperation/compute.md
@@ -26,8 +26,8 @@ the promised variable
 
 ## Discussion
 
-  The compute operation is given the current state of the ocean
-  (wvt) during each call, and it is expected to compute the
-  variables from that state. You can, of course, use other
-  instance variables from your own custom subclass to
-  implement computations with other dependencies.
+The compute operation is given the current state of the ocean
+(wvt) during each call, and it is expected to compute the
+variables from that state. You can, of course, use other
+instance variables from your own custom subclass to
+implement computations with other dependencies.

--- a/docs/classes/operations-and-annotations/wvoperation/f.md
+++ b/docs/classes/operations-and-annotations/wvoperation/f.md
@@ -16,5 +16,5 @@ function handle to be called when computing the operation
 
 ## Discussion
 
-  If you override the compute method, there no need to set or use
-  this function handle.
+If you override the compute method, there no need to set or use
+this function handle.

--- a/docs/classes/operations-and-annotations/wvoperation/name.md
+++ b/docs/classes/operations-and-annotations/wvoperation/name.md
@@ -16,5 +16,5 @@ of the operation
 
 ## Discussion
 
-  If the operation only returns a single variable, it **must** be
-  given the same name as that variable.
+If the operation only returns a single variable, it **must** be
+given the same name as that variable.

--- a/docs/classes/operations-and-annotations/wvoperation/outputvariables.md
+++ b/docs/classes/operations-and-annotations/wvoperation/outputvariables.md
@@ -16,7 +16,7 @@ array of WVVariableAnnotations describing the outputs of the computation
 
 ## Discussion
 
-  This array is set during initialization.
+This array is set during initialization.
 
-  The order of the WVVariableAnnotation must match the order that
-  the variables will be returned with the -compute method.
+The order of the WVVariableAnnotation must match the order that
+the variables will be returned with the -compute method.

--- a/docs/classes/operations-and-annotations/wvoperation/wvoperation.md
+++ b/docs/classes/operations-and-annotations/wvoperation/wvoperation.md
@@ -25,4 +25,4 @@ create a new WVOperation for computing a new variable
 
 ## Discussion
 
-            - Return operation: a new WV operation instance
+- Return operation: a new WV operation instance

--- a/docs/classes/operations-and-annotations/wvvariableannotation/isdependentonapama0.md
+++ b/docs/classes/operations-and-annotations/wvvariableannotation/isdependentonapama0.md
@@ -19,5 +19,5 @@ boolean indicating whether the variable depends on Ap, Am, or A0
 
 ## Discussion
 
-  This information is used when caching variables and when writing
-  to NetCDF file.
+This information is used when caching variables and when writing
+to NetCDF file.

--- a/docs/classes/operations-and-annotations/wvvariableannotation/isvariablewithlineartimestep.md
+++ b/docs/classes/operations-and-annotations/wvvariableannotation/isvariablewithlineartimestep.md
@@ -19,5 +19,5 @@ boolean indicating whether the variable changes value with a linear time step
 
 ## Discussion
 
-  This information is used when caching variables and when writing
-  to NetCDF file.
+This information is used when caching variables and when writing
+to NetCDF file.

--- a/docs/classes/operations-and-annotations/wvvariableannotation/isvariablewithnonlineartimestep.md
+++ b/docs/classes/operations-and-annotations/wvvariableannotation/isvariablewithnonlineartimestep.md
@@ -19,5 +19,5 @@ boolean indicating whether the variable changes value with a non-linear time ste
 
 ## Discussion
 
-  This information is used when caching variables and when writing
-  to NetCDF file.
+This information is used when caching variables and when writing
+to NetCDF file.

--- a/docs/classes/operations-and-annotations/wvvariableannotation/modelop.md
+++ b/docs/classes/operations-and-annotations/wvvariableannotation/modelop.md
@@ -16,5 +16,5 @@ WVOperation responsible for computing this variable
 
 ## Discussion
 
-  This property will be automatically populated when the variable
-  annotation is passed to the WVOperation.
+This property will be automatically populated when the variable
+annotation is passed to the WVOperation.

--- a/docs/classes/operations-and-annotations/wvvariableannotation/wvvariableannotation.md
+++ b/docs/classes/operations-and-annotations/wvvariableannotation/wvvariableannotation.md
@@ -31,6 +31,6 @@ create a new instance of WVVariableAnnotation
 
 ## Discussion
 
-  If a markdown file of the same name is in the same directory
-  or child directory, it will be loaded as the detailed
-  description upon initialization.
+If a markdown file of the same name is in the same directory
+or child directory, it will be loaded as the detailed
+description upon initialization.

--- a/docs/classes/transforms/wvtransform/a0.md
+++ b/docs/classes/transforms/wvtransform/a0.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  A0
 
-geostrophic coefficients at reference time t0 (m)
+Zero-frequency geostrophic and mean-density-anomaly coefficients.
 
 
 ---
 
 ## Discussion
-Topic: Wave-vortex coefficients
+
+`A0` is a complex spectral array with units of streamfunction,
+$$\mathrm{m^2\,s^{-1}}$$. Geostrophic modes occupy nonzero
+horizontal wavenumbers; mean-density-anomaly modes occupy the
+horizontally averaged internal-mode locations. Quasigeostrophic
+transforms use `A0` without `Ap` or `Am` wave content.

--- a/docs/classes/transforms/wvtransform/addflowcomponent.md
+++ b/docs/classes/transforms/wvtransform/addflowcomponent.md
@@ -24,6 +24,6 @@ add a flow component and its standard variables
 ## Discussion
 
 
-  The standard variables supported by the concrete transform are
-  registered for each component. These include the three-dimensional state
-  variables and the sea-surface variables.
+The standard variables supported by the concrete transform are
+registered for each component. These include the three-dimensional state
+variables and the sea-surface variables.

--- a/docs/classes/transforms/wvtransform/addforcing.md
+++ b/docs/classes/transforms/wvtransform/addforcing.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  addForcing
 
-
+Add forcing or closure objects to this transform.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/addoperation.md
+++ b/docs/classes/transforms/wvtransform/addoperation.md
@@ -16,7 +16,7 @@ Register one or more operations and their output variables.
 
 ## Discussion
 
-  The complete request is validated before annotations, lookup maps, or
-  cached values are changed. Existing operations are replaced only when
-  `shouldOverwriteExisting` is true. For an operation array, replacements
-  are evaluated in caller order and the last conflicting operation wins.
+The complete request is validated before annotations, lookup maps, or
+cached values are changed. Existing operations are replaced only when
+`shouldOverwriteExisting` is true. For an operation array, replacements
+are evaluated in caller order and the last conflicting operation wins.

--- a/docs/classes/transforms/wvtransform/addrandomflow.md
+++ b/docs/classes/transforms/wvtransform/addrandomflow.md
@@ -27,19 +27,19 @@ add randomized flow to the existing state
 
 ## Discussion
 
-  Adds random amplitudes at all available modes. Optionally, you can
-  specify which components of the flow should get initialized. For example,
+Adds random amplitudes at all available modes. Optionally, you can
+specify which components of the flow should get initialized. For example,
 
-  ```matlab
-    wvt.addRandomFlow();
-  ```
+```matlab
+  wvt.addRandomFlow();
+```
 
-  will add noise at all modes, while
+will add noise at all modes, while
 
-  ```matlab
-    wvt.addRandomFlow('geostrophic','mda');
-  ```
+```matlab
+  wvt.addRandomFlow('geostrophic','mda');
+```
 
-  will add random flow at only thegeostrophic and mean density anomaly flow
-  components, while the wave and inertial oscillations components will
-  remain untouched
+will add random flow at only thegeostrophic and mean density anomaly flow
+components, while the wave and inertial oscillations components will
+remain untouched

--- a/docs/classes/transforms/wvtransform/adduveta.md
+++ b/docs/classes/transforms/wvtransform/adduveta.md
@@ -25,4 +25,4 @@ add $$(u,v,\eta)$$ to the existing values
 
 ## Discussion
 
-  Add $$(u,v,\eta)$$ to the existing Ap,Am,A0
+Add $$(u,v,\eta)$$ to the existing Ap,Am,A0

--- a/docs/classes/transforms/wvtransform/am.md
+++ b/docs/classes/transforms/wvtransform/am.md
@@ -9,10 +9,14 @@ mathjax: true
 
 #  Am
 
-negative wave coefficients at reference time t0 (m/s)
+Negative-frequency wave and inertial coefficients at reference time `t0`.
 
 
 ---
 
 ## Discussion
-Topic: Wave-vortex coefficients
+
+`Am` is a complex array with the transform's spectral layout. Only
+locations selected by the primary wave and inertial component masks
+are active. Its conjugacy relations with `Ap` enforce a real
+physical state, including `Am = conj(Ap)` on inertial modes.

--- a/docs/classes/transforms/wvtransform/ap.md
+++ b/docs/classes/transforms/wvtransform/ap.md
@@ -9,10 +9,14 @@ mathjax: true
 
 #  Ap
 
-positive wave coefficients at reference time t0 (m/s)
+Positive-frequency wave and inertial coefficients at reference time `t0`.
 
 
 ---
 
 ## Discussion
-Topic: Wave-vortex coefficients
+
+`Ap` is a complex array with the transform's spectral layout. Only
+locations selected by the primary wave and inertial component masks
+are active. Together with `Am`, it reconstructs a real physical
+state and has units of velocity.

--- a/docs/classes/transforms/wvtransform/concatenatevariablesalongtimedimension.md
+++ b/docs/classes/transforms/wvtransform/concatenatevariablesalongtimedimension.md
@@ -23,5 +23,5 @@ Concatenate variables along the time dimension
 
 ## Discussion
 
-  Writes to an existing file initialized with
-  createNetCDFFileForTimeStepOutput.
+Writes to an existing file initialized with
+createNetCDFFileForTimeStepOutput.

--- a/docs/classes/transforms/wvtransform/convertfromwavenumbertofrequency.md
+++ b/docs/classes/transforms/wvtransform/convertfromwavenumbertofrequency.md
@@ -26,8 +26,8 @@ Summary
 
 ## Discussion
 This method transforms an instantaneous WVT field that is in the
-   horizontal wave number domain to the frequency domain.
+ horizontal wave number domain to the frequency domain.
 
-   At this point the method is only set to return the total wave energy.
-   In the future I plan to include an option for the user
-   to transform any WVT field (Leticia)
+ At this point the method is only set to return the total wave energy.
+ In the future I plan to include an option for the user
+ to transform any WVT field (Leticia)

--- a/docs/classes/transforms/wvtransform/createnetcdffilefortimestepoutput.md
+++ b/docs/classes/transforms/wvtransform/createnetcdffilefortimestepoutput.md
@@ -26,9 +26,9 @@ Output the `WVTransform` to file with variable time dimension
 
 ## Discussion
 
-  Writes the WVTransform instance to file, with enough information to
-  re-initialize. Pass additional variables to the variable list that
-  should also be written to file.
+Writes the WVTransform instance to file, with enough information to
+re-initialize. Pass additional variables to the variable list that
+should also be written to file.
 
-  Subclasses should add any necessary properties or variables to the
-  variable list before calling this superclass method.
+Subclasses should add any necessary properties or variables to the
+variable list before calling this superclass method.

--- a/docs/classes/transforms/wvtransform/defaultoperations.md
+++ b/docs/classes/transforms/wvtransform/defaultoperations.md
@@ -23,5 +23,5 @@ return array of WVOperation instances initialized by default
 
 ## Discussion
 
-  This function creates a number of standard StateVariables with associated
-  TransformOperations.
+This function creates a number of standard StateVariables with associated
+TransformOperations.

--- a/docs/classes/transforms/wvtransform/energyfluxfromnonlinearflux.md
+++ b/docs/classes/transforms/wvtransform/energyfluxfromnonlinearflux.md
@@ -32,11 +32,11 @@ converts nonlinear flux into energy flux
 
 ## Discussion
 
-  Multiplies the nonlinear flux (Fp,Fm,F0) by the appropriate coefficients
-  to convert into an energy flux.
+Multiplies the nonlinear flux (Fp,Fm,F0) by the appropriate coefficients
+to convert into an energy flux.
 
-  Optional parameter deltaT added by Bailey Avila: This equation is C17 in
-  the manuscript, but with addition of 1st term on LHS of C16 converted to
-  energy using Apm_TE_factor or A0_TE_factor This differs from energyFlux
-  due to the importance of the 2*F*F*deltaT in equation C16 at the initial
-  condition.
+Optional parameter deltaT added by Bailey Avila: This equation is C17 in
+the manuscript, but with addition of 1st term on LHS of C16 converted to
+energy using Apm_TE_factor or A0_TE_factor This differs from energyFlux
+due to the importance of the 2*F*F*deltaT in equation C16 at the initial
+condition.

--- a/docs/classes/transforms/wvtransform/enstrophyfluxfromnonlinearflux.md
+++ b/docs/classes/transforms/wvtransform/enstrophyfluxfromnonlinearflux.md
@@ -27,5 +27,5 @@ converts nonlinear flux into enstrophy flux
 
 ## Discussion
 
-  Multiplies the nonlinear flux F0 by the appropriate coefficients
-  to convert into an energy flux.
+Multiplies the nonlinear flux F0 by the appropriate coefficients
+to convert into an energy flux.

--- a/docs/classes/transforms/wvtransform/forcingwithname.md
+++ b/docs/classes/transforms/wvtransform/forcingwithname.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  forcingWithName
 
-
+Return registered forcing objects by name.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/hasforcingwithname.md
+++ b/docs/classes/transforms/wvtransform/hasforcingwithname.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  hasForcingWithName
 
-
+Test whether forcing objects are registered by name.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/hasmeanpressuredifference.md
+++ b/docs/classes/transforms/wvtransform/hasmeanpressuredifference.md
@@ -23,18 +23,18 @@ Diagnose an MDA mean-pressure difference between the boundaries.
 
 ## Discussion
 
-  Only the mean-density-anomaly (MDA) component can contribute
-  to a horizontally averaged pressure difference between the
-  top and bottom boundaries. The diagnostic evaluates
+Only the mean-density-anomaly (MDA) component can contribute
+to a horizontally averaged pressure difference between the
+top and bottom boundaries. The diagnostic evaluates
 
-  $$
-  \Delta \bar p_{\mathrm{mda}} =
-  \left|\langle p_{\mathrm{mda,top}}\rangle_{xy}
-  -\langle p_{\mathrm{mda,bottom}}\rangle_{xy}\right|
-  $$
+$$
+\Delta \bar p_{\mathrm{mda}} =
+\left|\langle p_{\mathrm{mda,top}}\rangle_{xy}
+-\langle p_{\mathrm{mda,bottom}}\rangle_{xy}\right|
+$$
 
-  relative to the maximum absolute MDA pressure. It returns
-  `true` when the relative difference is greater than `1e-5`.
-  Transforms without an MDA component return `false`. Other
-  flow components and common pressure-gauge offsets do not
-  enter the calculation.
+relative to the maximum absolute MDA pressure. It returns
+`true` when the relative difference is greater than `1e-5`.
+Transforms without an MDA component return `false`. Other
+flow components and common pressure-gauge offsets do not
+enter the calculation.

--- a/docs/classes/transforms/wvtransform/hasvariablewithname.md
+++ b/docs/classes/transforms/wvtransform/hasvariablewithname.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  hasVariableWithName
 
-
+Test whether state variables are registered by name.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/index.md
+++ b/docs/classes/transforms/wvtransform/index.md
@@ -11,32 +11,37 @@ nav_order: 1
 
 #  WVTransform
 
-Represents the state of the ocean in terms of energetically orthogonal wave and geostrophic (vortex) solutions
+Represent a fluid state with orthogonal wave and geostrophic solutions.
 
 
 ---
 
 ## Declaration
 
-<div class="language-matlab highlighter-rouge"><div class="highlight"><pre class="highlight"><code>classdef WVTransform < handle</code></pre></div></div>
+<div class="language-matlab highlighter-rouge"><div class="highlight"><pre class="highlight"><code>classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass</code></pre></div></div>
 
 ## Overview
 
+`WVTransform` is the abstract base class for the supported wave-vortex
+transforms. Each concrete transform represents the fluid state at time
+`t` with spectral coefficients and exposes physical variables such as
+velocity, isopycnal displacement, pressure, and potential vorticity.
+Density is denoted by $$\rho$$. Energetic quantities are normalized per
+unit reference density $$\rho_0$$ unless a method states otherwise.
 
-The WVTransform subclasses encapsulate data representing the
-state of the ocean at a given instant in time. What makes the
-WVTransform subclasses special is that the state of the ocean
-is represented as energetically independent waves and geostrophic
-motions (vortices). These classes can be queried for any ocean state
-variable including $$u$$, $$v$$, $$w$$, $$\rho$$, $$p$$, but also
-Ertel PV, relative vorticity, or custom defined state variables.
+Use one of the five Stable concrete transform families:
 
-The WVTransform is an abstract class and as such you must
-instatiate one of the concrete subclasses,
-
-+ `WVTransformConstantStratification`
++ `WVTransformConstantStratification`, in hydrostatic or nonhydrostatic mode
 + `WVTransformHydrostatic`
-+ `WVTransformSingleMode`
++ `WVTransformBoussinesq`
++ `WVTransformStratifiedQG`
++ `WVTransformBarotropicQG`
+
+Wave-bearing transforms store positive- and negative-frequency wave and
+inertial coefficients in `Ap` and `Am`, and zero-frequency geostrophic
+and mean-density-anomaly coefficients in `A0`. Quasigeostrophic
+transforms use `A0` only. The `Apt`, `Amt`, and `A0t` variables are the
+corresponding coefficients evaluated at the current transform time.
 
 
 
@@ -47,16 +52,38 @@ instatiate one of the concrete subclasses,
   + [`version`](/classes/transforms/wvtransform/version.html) WaveVortexModel package version read from `resources/mpackage.json`.
   + [`waveVortexTransformFromFile`](/classes/transforms/wvtransform/wavevortextransformfromfile.html) Initialize a WVTransform instance from an existing file
   + [`waveVortexTransformWithDoubleResolution`](/classes/transforms/wvtransform/wavevortextransformwithdoubleresolution.html) create a new WVTransform with double resolution
+  + [`waveVortexTransformWithResolution`](/classes/transforms/wvtransform/wavevortextransformwithresolution.html) Construct the same transform family at a requested resolution.
++ Wave-vortex coefficients
+  + [`A0`](/classes/transforms/wvtransform/a0.html) Zero-frequency geostrophic and mean-density-anomaly coefficients.
+  + [`Am`](/classes/transforms/wvtransform/am.html) Negative-frequency wave and inertial coefficients at reference time `t0`.
+  + [`Ap`](/classes/transforms/wvtransform/ap.html) Positive-frequency wave and inertial coefficients at reference time `t0`.
++ State variables
+  + [`hasVariableWithName`](/classes/transforms/wvtransform/hasvariablewithname.html) Test whether state variables are registered by name.
+  + [`summarizeVariables`](/classes/transforms/wvtransform/summarizevariables.html) Print a table of registered state variables and cache status.
+  + [`variableAtPositionWithName`](/classes/transforms/wvtransform/variableatpositionwithname.html) Access dynamical variables at arbitrary positions in the domain.
+  + [`variableNames`](/classes/transforms/wvtransform/variablenames.html) Return the names of all registered state variables.
+  + [`variableWithName`](/classes/transforms/wvtransform/variablewithname.html) Compute or retrieve one or more registered transform variables.
++ Flow components
+  + [`addFlowComponent`](/classes/transforms/wvtransform/addflowcomponent.html) add a flow component and its standard variables
+  + [`addPrimaryFlowComponent`](/classes/transforms/wvtransform/addprimaryflowcomponent.html) add a primary flow component, automatically added to the flow
+  + [`flowComponentWithName`](/classes/transforms/wvtransform/flowcomponentwithname.html) retrieve a WVFlowComponent by name
+  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransform/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
+  + [`summarizeFlowComponents`](/classes/transforms/wvtransform/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
++ Forcing
+  + [`addForcing`](/classes/transforms/wvtransform/addforcing.html) Add forcing or closure objects to this transform.
+  + [`forcingNames`](/classes/transforms/wvtransform/forcingnames.html) retrieve the names of all available variables. This preserves
+  + [`forcingWithName`](/classes/transforms/wvtransform/forcingwithname.html) Return registered forcing objects by name.
+  + [`hasForcingWithName`](/classes/transforms/wvtransform/hasforcingwithname.html) Test whether forcing objects are registered by name.
+  + [`removeAllForcing`](/classes/transforms/wvtransform/removeallforcing.html) Remove every forcing and closure from this transform.
+  + [`removeForcing`](/classes/transforms/wvtransform/removeforcing.html) Remove the exact registered forcing objects.
+  + [`setForcing`](/classes/transforms/wvtransform/setforcing.html) Replace the complete forcing registry.
+  + [`summarizeForcing`](/classes/transforms/wvtransform/summarizeforcing.html) Print a table of registered forcing and closure objects.
 + Domain attributes
-  + [`t`](/classes/transforms/wvtransform/t.html)
-  + [`t0`](/classes/transforms/wvtransform/t0.html)
+  + [`t`](/classes/transforms/wvtransform/t.html) Current transform time in seconds.
+  + [`t0`](/classes/transforms/wvtransform/t0.html) Reference time for the stored wave phases, in seconds.
   + Grid
     + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransform/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
-+ Wave-vortex coefficients
-  + [`A0`](/classes/transforms/wvtransform/a0.html) geostrophic coefficients at reference time t0 (m)
-  + [`Am`](/classes/transforms/wvtransform/am.html) negative wave coefficients at reference time t0 (m/s)
-  + [`Ap`](/classes/transforms/wvtransform/ap.html) positive wave coefficients at reference time t0 (m/s)
-+ Initial Conditions
++ Initial conditions
   + [`addRandomFlow`](/classes/transforms/wvtransform/addrandomflow.html) add randomized flow to the existing state
   + [`addUVEta`](/classes/transforms/wvtransform/adduveta.html) add $$(u,v,\eta)$$ to the existing values
   + [`hasMeanPressureDifference`](/classes/transforms/wvtransform/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
@@ -66,46 +93,6 @@ instatiate one of the concrete subclasses,
   + [`initWithUVRho`](/classes/transforms/wvtransform/initwithuvrho.html) initialize with fluid variables $$(u,v,\rho)$$
   + Waves
     + [`removeAll`](/classes/transforms/wvtransform/removeall.html) removes all energy from the model
-+ Energetics
-  + [`summarizeEnergyContent`](/classes/transforms/wvtransform/summarizeenergycontent.html) displays a summary of the energy content of the fluid
-  + [`summarizeModeEnergy`](/classes/transforms/wvtransform/summarizemodeenergy.html) List the most energetic modes
-  + [`totalEnergy`](/classes/transforms/wvtransform/totalenergy.html)
-  + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransform/totalenergyspatiallyintegrated.html)
-  + Multiplicative factors
-    + [`A0_PE_factor`](/classes/transforms/wvtransform/a0_pe_factor.html)
-    + [`A0_TE_factor`](/classes/transforms/wvtransform/a0_te_factor.html)
-    + [`Apm_TE_factor`](/classes/transforms/wvtransform/apm_te_factor.html)
-+ Potential Vorticity & Enstrophy
-  + Multiplicative factors
-    + [`A0_QGPV_factor`](/classes/transforms/wvtransform/a0_qgpv_factor.html)
-    + [`A0_TZ_factor`](/classes/transforms/wvtransform/a0_tz_factor.html)
-+ Internal
-  + [`WVTransform`](/classes/transforms/wvtransform/wvtransform.html) initialize a WVTransform instance
-  + [`addToVariableCache`](/classes/transforms/wvtransform/addtovariablecache.html) add variable to internal cache, in case it is needed again
-  + [`clearVariableCacheOfApAmA0DependentVariables`](/classes/transforms/wvtransform/clearvariablecacheofapama0dependentvariables.html) clear the internal cache
-  + [`clearVariableCacheOfTimeDependentVariables`](/classes/transforms/wvtransform/clearvariablecacheoftimedependentvariables.html) clear the internal cache of variables that claim to be time dependent
-  + [`defaultOperations`](/classes/transforms/wvtransform/defaultoperations.html) return array of WVOperation instances initialized by default
-  + [`fetchFromVariableCache`](/classes/transforms/wvtransform/fetchfromvariablecache.html) retrieve a set of variables from the internal cache
-  + [`performOperation`](/classes/transforms/wvtransform/performoperation.html) computes (runs) the operation
-  + [`performOperationWithName`](/classes/transforms/wvtransform/performoperationwithname.html) computes (runs) the operation
-  + [`removeFromVariableCache`](/classes/transforms/wvtransform/removefromvariablecache.html) remove one variable from the internal cache
-+ Flow components
-  + [`addFlowComponent`](/classes/transforms/wvtransform/addflowcomponent.html) add a flow component and its standard variables
-  + [`addPrimaryFlowComponent`](/classes/transforms/wvtransform/addprimaryflowcomponent.html) add a primary flow component, automatically added to the flow
-  + [`flowComponentWithName`](/classes/transforms/wvtransform/flowcomponentwithname.html) retrieve a WVFlowComponent by name
-  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransform/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
-+ Utility function
-  + [`spectralVariableWithResolution`](/classes/transforms/wvtransform/spectralvariablewithresolution.html) create a new variable with different resolution
-  + Metadata
-    + [`addOperation`](/classes/transforms/wvtransform/addoperation.html) Register one or more operations and their output variables.
-    + [`flowComponentNames`](/classes/transforms/wvtransform/flowcomponentnames.html) retrieve the names of all available variables
-    + [`forcingNames`](/classes/transforms/wvtransform/forcingnames.html) retrieve the names of all available variables. This preserves
-    + [`operationWithName`](/classes/transforms/wvtransform/operationwithname.html) retrieve a WVOperation by name
-    + [`primaryFlowComponentNames`](/classes/transforms/wvtransform/primaryflowcomponentnames.html) retrieve the names of all available variables
-    + [`removeOperation`](/classes/transforms/wvtransform/removeoperation.html) Remove the exact registered operation and its cached outputs.
-+ Write to file
-  + [`concatenateVariablesAlongTimeDimension`](/classes/transforms/wvtransform/concatenatevariablesalongtimedimension.html) Concatenate variables along the time dimension
-  + [`createNetCDFFileForTimeStepOutput`](/classes/transforms/wvtransform/createnetcdffilefortimestepoutput.html) Output the `WVTransform` to file with variable time dimension
 + Operations
   + Transformations
     + [`convertFromWavenumberToFrequency`](/classes/transforms/wvtransform/convertfromwavenumbertofrequency.html) Summary
@@ -117,21 +104,50 @@ instatiate one of the concrete subclasses,
     + [`transformToSpatialDomainWithGAllDerivatives`](/classes/transforms/wvtransform/transformtospatialdomainwithgallderivatives.html)
     + [`transformUVEtaToWaveVortex`](/classes/transforms/wvtransform/transformuvetatowavevortex.html) transform fluid variables $$(u,v,\eta)$$ to wave-vortex coefficients $$(A_+,A_-,A_0)$$.
     + [`transformWaveVortexToUVWEta`](/classes/transforms/wvtransform/transformwavevortextouvweta.html) transform wave-vortex coefficients $$(A_+,A_-,A_0)$$ to fluid variables $$(u,v,\eta)$$.
++ Energetics
+  + [`summarizeEnergyContent`](/classes/transforms/wvtransform/summarizeenergycontent.html) displays a summary of the energy content of the fluid
+  + [`summarizeModeEnergy`](/classes/transforms/wvtransform/summarizemodeenergy.html) List the most energetic modes
+  + [`totalEnergy`](/classes/transforms/wvtransform/totalenergy.html)
+  + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransform/totalenergyspatiallyintegrated.html)
+  + Multiplicative factors
+    + [`A0_PE_factor`](/classes/transforms/wvtransform/a0_pe_factor.html)
+    + [`A0_TE_factor`](/classes/transforms/wvtransform/a0_te_factor.html)
+    + [`Apm_TE_factor`](/classes/transforms/wvtransform/apm_te_factor.html)
++ Developer
+  + [`propertyAnnotationsForTransform`](/classes/transforms/wvtransform/propertyannotationsfortransform.html) return array of CAPropertyAnnotations for the WVTransform
++ Potential Vorticity & Enstrophy
+  + Multiplicative factors
+    + [`A0_QGPV_factor`](/classes/transforms/wvtransform/a0_qgpv_factor.html)
+    + [`A0_TZ_factor`](/classes/transforms/wvtransform/a0_tz_factor.html)
++ Utility function
+  + [`spectralVariableWithResolution`](/classes/transforms/wvtransform/spectralvariablewithresolution.html) create a new variable with different resolution
+  + Metadata
+    + [`addOperation`](/classes/transforms/wvtransform/addoperation.html) Register one or more operations and their output variables.
+    + [`flowComponentNames`](/classes/transforms/wvtransform/flowcomponentnames.html) retrieve the names of all available variables
+    + [`operationWithName`](/classes/transforms/wvtransform/operationwithname.html) retrieve a WVOperation by name
+    + [`primaryFlowComponentNames`](/classes/transforms/wvtransform/primaryflowcomponentnames.html) retrieve the names of all available variables
+    + [`removeOperation`](/classes/transforms/wvtransform/removeoperation.html) Remove the exact registered operation and its cached outputs.
++ Internal
+  + [`addToVariableCache`](/classes/transforms/wvtransform/addtovariablecache.html) add variable to internal cache, in case it is needed again
+  + [`clearVariableCacheOfApAmA0DependentVariables`](/classes/transforms/wvtransform/clearvariablecacheofapama0dependentvariables.html) clear the internal cache
+  + [`clearVariableCacheOfTimeDependentVariables`](/classes/transforms/wvtransform/clearvariablecacheoftimedependentvariables.html) clear the internal cache of variables that claim to be time dependent
+  + [`defaultOperations`](/classes/transforms/wvtransform/defaultoperations.html) return array of WVOperation instances initialized by default
+  + [`fetchFromVariableCache`](/classes/transforms/wvtransform/fetchfromvariablecache.html) retrieve a set of variables from the internal cache
+  + [`performOperation`](/classes/transforms/wvtransform/performoperation.html) computes (runs) the operation
+  + [`performOperationWithName`](/classes/transforms/wvtransform/performoperationwithname.html) computes (runs) the operation
+  + [`removeFromVariableCache`](/classes/transforms/wvtransform/removefromvariablecache.html) remove one variable from the internal cache
++ Write to file
+  + [`concatenateVariablesAlongTimeDimension`](/classes/transforms/wvtransform/concatenatevariablesalongtimedimension.html) Concatenate variables along the time dimension
+  + [`createNetCDFFileForTimeStepOutput`](/classes/transforms/wvtransform/createnetcdffilefortimestepoutput.html) Output the `WVTransform` to file with variable time dimension
 + Nonlinear flux and energy transfers
   + [`energyFluxFromNonlinearFlux`](/classes/transforms/wvtransform/energyfluxfromnonlinearflux.html) converts nonlinear flux into energy flux
   + [`enstrophyFluxFromNonlinearFlux`](/classes/transforms/wvtransform/enstrophyfluxfromnonlinearflux.html) converts nonlinear flux into enstrophy flux
   + [`nonlinearFluxForFlowComponents`](/classes/transforms/wvtransform/nonlinearfluxforflowcomponents.html) returns the flux of each coefficient as determined by the nonlinear flux operation
   + [`nonlinearFluxWithGradientMasks`](/classes/transforms/wvtransform/nonlinearfluxwithgradientmasks.html) returns the flux of each coefficient as determined by the nonlinear flux operation
   + [`nonlinearFluxWithMask`](/classes/transforms/wvtransform/nonlinearfluxwithmask.html) returns the flux of each coefficient as determined by the nonlinear flux
-+ Developer
-  + [`propertyAnnotationsForTransform`](/classes/transforms/wvtransform/propertyannotationsfortransform.html) return array of CAPropertyAnnotations for the WVTransform
-+ State Variables
-  + [`variableAtPositionWithName`](/classes/transforms/wvtransform/variableatpositionwithname.html) Access dynamical variables at arbitrary positions in the domain.
-  + [`variableWithName`](/classes/transforms/wvtransform/variablewithname.html) Compute or retrieve one or more registered transform variables.
 + Other
   + [`A0_KE_factor`](/classes/transforms/wvtransform/a0_ke_factor.html)
   + [`A0_Psi_factor`](/classes/transforms/wvtransform/a0_psi_factor.html)
-  + [`addForcing`](/classes/transforms/wvtransform/addforcing.html)
   + [`addlistener`](/classes/transforms/wvtransform/addlistener.html)
   + [`classDefinedOperationForKnownVariable`](/classes/transforms/wvtransform/classdefinedoperationforknownvariable.html) This is one of two functions that returns operations for computing
   + [`delete`](/classes/transforms/wvtransform/delete.html)
@@ -143,13 +159,10 @@ instatiate one of the concrete subclasses,
   + [`forcing`](/classes/transforms/wvtransform/forcing.html)
   + [`forcingNameMap`](/classes/transforms/wvtransform/forcingnamemap.html)
   + [`forcingType`](/classes/transforms/wvtransform/forcingtype.html)
-  + [`forcingWithName`](/classes/transforms/wvtransform/forcingwithname.html)
   + [`ge`](/classes/transforms/wvtransform/ge.html)
   + [`gt`](/classes/transforms/wvtransform/gt.html)
   + [`hasClosure`](/classes/transforms/wvtransform/hasclosure.html)
-  + [`hasForcingWithName`](/classes/transforms/wvtransform/hasforcingwithname.html)
   + [`hasPVComponent`](/classes/transforms/wvtransform/haspvcomponent.html)
-  + [`hasVariableWithName`](/classes/transforms/wvtransform/hasvariablewithname.html)
   + [`hasWaveComponent`](/classes/transforms/wvtransform/haswavecomponent.html)
   + [`initForcingFromNetCDFFile`](/classes/transforms/wvtransform/initforcingfromnetcdffile.html) forcingGroupName = join( [string(class(self)),"forcing"],"-");
   + [`isHydrostatic`](/classes/transforms/wvtransform/ishydrostatic.html)
@@ -168,28 +181,30 @@ instatiate one of the concrete subclasses,
   + [`primaryFlowComponentNameMap`](/classes/transforms/wvtransform/primaryflowcomponentnamemap.html)
   + [`primaryFlowComponents`](/classes/transforms/wvtransform/primaryflowcomponents.html)
   + [`propertyAnnotationForKnownVariable`](/classes/transforms/wvtransform/propertyannotationforknownvariable.html) This is one of two functions that returns operations for computing
-  + [`removeAllForcing`](/classes/transforms/wvtransform/removeallforcing.html)
-  + [`removeForcing`](/classes/transforms/wvtransform/removeforcing.html)
   + [`restoreForcingAmplitudes`](/classes/transforms/wvtransform/restoreforcingamplitudes.html)
   + [`rk4NonlinearFlux`](/classes/transforms/wvtransform/rk4nonlinearflux.html)
   + [`rk4NonlinearFluxForFlowComponents`](/classes/transforms/wvtransform/rk4nonlinearfluxforflowcomponents.html)
-  + [`setForcing`](/classes/transforms/wvtransform/setforcing.html)
   + [`spatialDimensionNames`](/classes/transforms/wvtransform/spatialdimensionnames.html)
   + [`spatialFluxForcing`](/classes/transforms/wvtransform/spatialfluxforcing.html)
   + [`spectralAmplitudeForcing`](/classes/transforms/wvtransform/spectralamplitudeforcing.html)
   + [`spectralDimensionNames`](/classes/transforms/wvtransform/spectraldimensionnames.html)
   + [`spectralFluxForcing`](/classes/transforms/wvtransform/spectralfluxforcing.html)
-  + [`summarizeFlowComponents`](/classes/transforms/wvtransform/summarizeflowcomponents.html)
-  + [`summarizeForcing`](/classes/transforms/wvtransform/summarizeforcing.html)
-  + [`summarizeVariables`](/classes/transforms/wvtransform/summarizevariables.html)
   + [`timeDependentVariablesNameMap`](/classes/transforms/wvtransform/timedependentvariablesnamemap.html)
   + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransform/totalenergyofflowcomponent.html)
   + [`totalFlowComponent`](/classes/transforms/wvtransform/totalflowcomponent.html)
   + [`updateDependentVariablesNameMap`](/classes/transforms/wvtransform/updatedependentvariablesnamemap.html)
   + [`variableCache`](/classes/transforms/wvtransform/variablecache.html)
-  + [`variableNames`](/classes/transforms/wvtransform/variablenames.html)
-  + [`waveVortexTransformWithResolution`](/classes/transforms/wvtransform/wavevortextransformwithresolution.html)
   + [`wvCoefficientDependentVariablesNameMap`](/classes/transforms/wvtransform/wvcoefficientdependentvariablesnamemap.html)
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Wave-vortex coefficients
++ Domain attributes
+  + Grid
++ Initial conditions
++ Developer
+  + [`WVTransform`](/classes/transforms/wvtransform/wvtransform.html) Initialize the internal WVTransform state for a concrete subclass.
 
 
 ---

--- a/docs/classes/transforms/wvtransform/initfromnetcdffile.md
+++ b/docs/classes/transforms/wvtransform/initfromnetcdffile.md
@@ -24,24 +24,24 @@ initialize the flow from a NetCDF file
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets them the values found in the file
-  at the requested time.
+Clears variables Ap,Am,A0 and then sets them the values found in the file
+at the requested time.
 
-  This is intended to be used in conjunction with
-  [`waveVortexTransformFromFile`](/classes/transforms/wvtransform/wavevortextransformfromfile.html)
-  e.g.,
+This is intended to be used in conjunction with
+[`waveVortexTransformFromFile`](/classes/transforms/wvtransform/wavevortextransformfromfile.html)
+e.g.,
 
-  ```matlab
-  [wvt,ncfile] = WVTransform.waveVortexTransformFromFile('cyprus-eddy.nc');
-  t = ncfile.readVariables('t');
-  for iTime=1:length(t)
-      wvt.initFromNetCDFFile(ncfile,iTime=iTime)
-      // some analysis
-  end
-  ```
+```matlab
+[wvt,ncfile] = WVTransform.waveVortexTransformFromFile('cyprus-eddy.nc');
+t = ncfile.readVariables('t');
+for iTime=1:length(t)
+    wvt.initFromNetCDFFile(ncfile,iTime=iTime)
+    // some analysis
+end
+```
 
-  Note that this method only lightly checks that you are reading from a
-  file that is compatible with this transform! So be careful.
+Note that this method only lightly checks that you are reading from a
+file that is compatible with this transform! So be careful.
 
-  See also the users guide for [reading and writing to
-  file](/users-guide/reading-and-writing-to-file.html).
+See also the users guide for [reading and writing to
+file](/users-guide/reading-and-writing-to-file.html).

--- a/docs/classes/transforms/wvtransform/initwithrandomflow.md
+++ b/docs/classes/transforms/wvtransform/initwithrandomflow.md
@@ -27,20 +27,20 @@ initialize with a random flow state
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then randomizes the flow by adding random
-  amplitudes at all available modes. Optionally, you can specify which
-  components of the flow should get initialized. For example,
+Clears variables Ap,Am,A0 and then randomizes the flow by adding random
+amplitudes at all available modes. Optionally, you can specify which
+components of the flow should get initialized. For example,
 
-  ```matlab
-    wvt.initWithRandomFlow();
-  ```
+```matlab
+  wvt.initWithRandomFlow();
+```
 
-  will initialize all modes, while
+will initialize all modes, while
 
-  ```matlab
-    wvt.initWithRandomFlow('geostrophic','mda');
-  ```
+```matlab
+  wvt.initWithRandomFlow('geostrophic','mda');
+```
 
-  will initialize the flow with geostrophic and mean density anomaly flow
-  components, while the wave and inertial oscillations components will be
-  zero.
+will initialize the flow with geostrophic and mean density anomaly flow
+components, while the wave and inertial oscillations components will be
+zero.

--- a/docs/classes/transforms/wvtransform/initwithuveta.md
+++ b/docs/classes/transforms/wvtransform/initwithuveta.md
@@ -25,4 +25,4 @@ initialize with fluid variables $$(u,v,\eta)$$
 
 ## Discussion
 
-  Replaces the variables Ap,Am,A0 with those computed from $$(u,v,\eta)$$.
+Replaces the variables Ap,Am,A0 with those computed from $$(u,v,\eta)$$.

--- a/docs/classes/transforms/wvtransform/initwithuvrho.md
+++ b/docs/classes/transforms/wvtransform/initwithuvrho.md
@@ -25,4 +25,4 @@ initialize with fluid variables $$(u,v,\rho)$$
 
 ## Discussion
 
-  Replaces the variables Ap,Am,A0 with those computed from $$(u,v,\rho_e)$$.
+Replaces the variables Ap,Am,A0 with those computed from $$(u,v,\rho_e)$$.

--- a/docs/classes/transforms/wvtransform/nonlinearfluxforflowcomponents.md
+++ b/docs/classes/transforms/wvtransform/nonlinearfluxforflowcomponents.md
@@ -29,7 +29,7 @@ returns the flux of each coefficient as determined by the nonlinear flux operati
 
 ## Discussion
 
-  This computes the nonlinear flux that results from a subset of flow
-  constituents. The masks are applied to the coefficients Ap,Am,A0 before
-  computing the nonlinear flux, $$\vec{u} \cdot \nabla \vec{u}$$. This
-  function calls -nonlinearFluxWithGradientMasks.
+This computes the nonlinear flux that results from a subset of flow
+constituents. The masks are applied to the coefficients Ap,Am,A0 before
+computing the nonlinear flux, $$\vec{u} \cdot \nabla \vec{u}$$. This
+function calls -nonlinearFluxWithGradientMasks.

--- a/docs/classes/transforms/wvtransform/nonlinearfluxwithgradientmasks.md
+++ b/docs/classes/transforms/wvtransform/nonlinearfluxwithgradientmasks.md
@@ -31,8 +31,8 @@ returns the flux of each coefficient as determined by the nonlinear flux operati
 
 ## Discussion
 
-  The masks are applied to the coefficients Ap,Am,A0 before computing the
-  nonlinear flux, $$\vec{u} \cdot \nabla \vec{u}$$. This function offers
-  more fine-grained control than -nonlinearFluxWithMask.
+The masks are applied to the coefficients Ap,Am,A0 before computing the
+nonlinear flux, $$\vec{u} \cdot \nabla \vec{u}$$. This function offers
+more fine-grained control than -nonlinearFluxWithMask.
 
-  The nonlinear flux used is the unforced, invicid equations.
+The nonlinear flux used is the unforced, invicid equations.

--- a/docs/classes/transforms/wvtransform/nonlinearfluxwithmask.md
+++ b/docs/classes/transforms/wvtransform/nonlinearfluxwithmask.md
@@ -29,8 +29,8 @@ returns the flux of each coefficient as determined by the nonlinear flux
 ## Discussion
 operation and the given mask.
 
-  The mask is applied to the coefficients Ap,Am,A0 before computing the
-  nonlinear flux. This is useful for zeroing wavenumbers at given total
-  wavenumber or frequency, for example.
+The mask is applied to the coefficients Ap,Am,A0 before computing the
+nonlinear flux. This is useful for zeroing wavenumbers at given total
+wavenumber or frequency, for example.
 
-  The nonlinear flux used is the unforced, invicid equations.
+The nonlinear flux used is the unforced, invicid equations.

--- a/docs/classes/transforms/wvtransform/optimizedtransformsforflowcomponent.md
+++ b/docs/classes/transforms/wvtransform/optimizedtransformsforflowcomponent.md
@@ -16,12 +16,12 @@ returns optimized transforms that avoid unnecessary computation
 
 ## Discussion
 
-  The mask structure has fields {Ap,Am,A0}, which have values of 0, 1, or a
-  full array that is the spectral matrix size. The value will be set to 0
-  if *either* the primary components OR this component have no active
-  components. The value will be set to 1 if the primary component is
-  nonzero, and this component has the same values. Otherwise, an array will
-  be returned.
+The mask structure has fields {Ap,Am,A0}, which have values of 0, 1, or a
+full array that is the spectral matrix size. The value will be set to 0
+if *either* the primary components OR this component have no active
+components. The value will be set to 1 if the primary component is
+nonzero, and this component has the same values. Otherwise, an array will
+be returned.
 
-  The isMasked boolean is true if this flow component deviates from the
-  total primary flow components in some fashion.
+The isMasked boolean is true if this flow component deviates from the
+total primary flow components in some fashion.

--- a/docs/classes/transforms/wvtransform/propertyannotationsfortransform.md
+++ b/docs/classes/transforms/wvtransform/propertyannotationsfortransform.md
@@ -26,7 +26,7 @@ return array of CAPropertyAnnotations for the WVTransform
 
 ## Discussion
 
-  This function returns annotations for all properties defined
-  by the WVTransform. It selectively returns annotations for
-  the wave-vortex coefficients, as not all subclass will handle
-  these coefficients in the same way.
+This function returns annotations for all properties defined
+by the WVTransform. It selectively returns annotations for
+the wave-vortex coefficients, as not all subclass will handle
+these coefficients in the same way.

--- a/docs/classes/transforms/wvtransform/removeall.md
+++ b/docs/classes/transforms/wvtransform/removeall.md
@@ -16,4 +16,4 @@ removes all energy from the model
 
 ## Discussion
 
-  Simply sets Ap, Am, and A0 to zero.
+Simply sets Ap, Am, and A0 to zero.

--- a/docs/classes/transforms/wvtransform/removeallforcing.md
+++ b/docs/classes/transforms/wvtransform/removeallforcing.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  removeAllForcing
 
-
+Remove every forcing and closure from this transform.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/removeforcing.md
+++ b/docs/classes/transforms/wvtransform/removeforcing.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  removeForcing
 
-
+Remove the exact registered forcing objects.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/setforcing.md
+++ b/docs/classes/transforms/wvtransform/setforcing.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  setForcing
 
-
+Replace the complete forcing registry.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/spectralvariablewithresolution.md
+++ b/docs/classes/transforms/wvtransform/spectralvariablewithresolution.md
@@ -27,7 +27,7 @@ create a new variable with different resolution
 
 ## Discussion
 
-  Given a variable with dimensions `[Nj Nkl]`, this returns a new variable
-  with dimensions matching `wvtX2`. Coefficients are matched by their
-  integer `(kMode,lMode,jMode)` identities. Modes absent from the target are
-  discarded and target modes absent from the source are initialized to zero.
+Given a variable with dimensions `[Nj Nkl]`, this returns a new variable
+with dimensions matching `wvtX2`. Coefficients are matched by their
+integer `(kMode,lMode,jMode)` identities. Modes absent from the target are
+discarded and target modes absent from the source are initialized to zero.

--- a/docs/classes/transforms/wvtransform/summarizedegreesoffreedom.md
+++ b/docs/classes/transforms/wvtransform/summarizedegreesoffreedom.md
@@ -20,10 +20,10 @@ Summarize the spatial grid and active spectral degrees of freedom.
 ```
 ## Discussion
 
-  The summary lists each primary flow component in lexical `shortName`
-  order. Mode counts come from the component's active primary spectral
-  masks in the transform's current antialias configuration. Each subtotal
-  is the mode count multiplied by the component's degrees of freedom per
-  mode; the final line sums those subtotals. The method does not assert an
-  equivalence between spatial-grid values and active spectral degrees of
-  freedom.
+The summary lists each primary flow component in lexical `shortName`
+order. Mode counts come from the component's active primary spectral
+masks in the transform's current antialias configuration. Each subtotal
+is the mode count multiplied by the component's degrees of freedom per
+mode; the final line sums those subtotals. The method does not assert an
+equivalence between spatial-grid values and active spectral degrees of
+freedom.

--- a/docs/classes/transforms/wvtransform/summarizeflowcomponents.md
+++ b/docs/classes/transforms/wvtransform/summarizeflowcomponents.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  summarizeFlowComponents
 
-
+Print a table of registered primary and diagnostic components.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/summarizeforcing.md
+++ b/docs/classes/transforms/wvtransform/summarizeforcing.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  summarizeForcing
 
-
+Print a table of registered forcing and closure objects.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/summarizemodeenergy.md
+++ b/docs/classes/transforms/wvtransform/summarizemodeenergy.md
@@ -19,9 +19,9 @@ List the most energetic modes
  summarizeModeEnergy(options)
 ```
 ## Parameters
-+ `n`  (optional) number of modes to list
++ `options.n`  number of modes to list; default `10`
 
 ## Discussion
 
-  At the moment the +/- waves are simply added together for each mode.
-  It would be better if they were separate.
+At the moment the +/- waves are simply added together for each mode.
+It would be better if they were separate.

--- a/docs/classes/transforms/wvtransform/summarizevariables.md
+++ b/docs/classes/transforms/wvtransform/summarizevariables.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  summarizeVariables
 
-
+Print a table of registered state variables and cache status.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/t.md
+++ b/docs/classes/transforms/wvtransform/t.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  t
 
-
+Current transform time in seconds.
 
 
 ---

--- a/docs/classes/transforms/wvtransform/t0.md
+++ b/docs/classes/transforms/wvtransform/t0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  t0
 
-
+Reference time for the stored wave phases, in seconds.
 
 
 ---

--- a/docs/classes/transforms/wvtransform/transformuvetatowavevortex.md
+++ b/docs/classes/transforms/wvtransform/transformuvetatowavevortex.md
@@ -30,12 +30,12 @@ transform fluid variables $$(u,v,\eta)$$ to wave-vortex coefficients $$(A_+,A_-,
 
 ## Discussion
 
-  This function **is** the WVTransform. It is a [linear
-  transformation](/mathematical-introduction/transformations.html)
-  denoted $$\mathcal{L}$$.
+This function **is** the WVTransform. It is a [linear
+transformation](/mathematical-introduction/transformations.html)
+denoted $$\mathcal{L}$$.
 
-  This function is not intended to be used directly (although
-  you can), and is kept here to demonstrate a simple
-  implementation of the transformation. Instead, you should
-  initialize the WVTransform using one of the
-  initialization functions.
+This function is not intended to be used directly (although
+you can), and is kept here to demonstrate a simple
+implementation of the transformation. Instead, you should
+initialize the WVTransform using one of the
+initialization functions.

--- a/docs/classes/transforms/wvtransform/transformwavevortextouvweta.md
+++ b/docs/classes/transforms/wvtransform/transformwavevortextouvweta.md
@@ -32,13 +32,13 @@ transform wave-vortex coefficients $$(A_+,A_-,A_0)$$ to fluid variables $$(u,v,\
 
 ## Discussion
 
-  This function is the inverse WVTransform. It is a
-  [linear
-  transformation](/mathematical-introduction/transformations.html)
-  denoted $$\mathcal{L}$$.
+This function is the inverse WVTransform. It is a
+[linear
+transformation](/mathematical-introduction/transformations.html)
+denoted $$\mathcal{L}$$.
 
-  This function is not intended to be used directly (although
-  you can), and is kept here to demonstrate a simple
-  implementation of the transformation. Instead, you should
-  initialize the WVTransform using one of the
-  initialization functions.
+This function is not intended to be used directly (although
+you can), and is kept here to demonstrate a simple
+implementation of the transformation. Instead, you should
+initialize the WVTransform using one of the
+initialization functions.

--- a/docs/classes/transforms/wvtransform/variableatpositionwithname.md
+++ b/docs/classes/transforms/wvtransform/variableatpositionwithname.md
@@ -16,20 +16,23 @@ Access dynamical variables at arbitrary positions in the domain.
 
 ## Declaration
 ```matlab
- [varargout] = variableAtPositionWithName(self,x,y,z,variableNames,options)
+ [varargout] = variableAtPositionWithName(x,y,z,variableNames,options)
 ```
 ## Parameters
 + `x`  array of x-positions
 + `y`  array of y-positions
 + `z`  array of z-positions, or empty for two-dimensional variables
 + `variableNames`  strings of variable names.
-+ `interpolationMethod`  (optional) `linear` or `spline`. Default `linear`.
++ `options.interpolationMethod`  periodic `linear` or cubic `spline` interpolation; default `linear`
+
+## Returns
++ `varargout`  interpolated arrays in the requested order and query shape
 
 ## Discussion
 
-  Computes (or retrieves from cache) any known state variables and computes
-  their values at the requested positions (x,y,z). For two-dimensional
-  variables, interpolation uses only (x,y), and z may be empty.
+Computes (or retrieves from cache) any known state variables and computes
+their values at the requested positions (x,y,z). For two-dimensional
+variables, interpolation uses only (x,y), and z may be empty.
 
-  The interpolation method may be `linear` or `spline`. Horizontal
-  coordinates are wrapped periodically before interpolation.
+The interpolation method may be `linear` or `spline`. Horizontal
+coordinates are wrapped periodically before interpolation.

--- a/docs/classes/transforms/wvtransform/variablenames.md
+++ b/docs/classes/transforms/wvtransform/variablenames.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  variableNames
 
-
+Return the names of all registered state variables.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/variablewithname.md
+++ b/docs/classes/transforms/wvtransform/variablewithname.md
@@ -19,6 +19,9 @@ Compute or retrieve one or more registered transform variables.
  varargout = variableWithName(variableNames)
 ```
 ## Parameters
-+ `variableNames`  registered variable names
++ `variableNames`  names of registered state variables
+
+## Returns
++ `varargout`  state-variable arrays in the requested order
 
 ## Discussion

--- a/docs/classes/transforms/wvtransform/wavevortextransformfromfile.md
+++ b/docs/classes/transforms/wvtransform/wavevortextransformfromfile.md
@@ -29,27 +29,27 @@ Initialize a WVTransform instance from an existing file
 
 ## Discussion
 
-  A WVTransform instance can be recreated from a NetCDF file and .mat
-  sidecar file if the default variables were save to file. For example,
+A WVTransform instance can be recreated from a NetCDF file and .mat
+sidecar file if the default variables were save to file. For example,
 
-  ```matlab
-  wvt = WVTransform.waveVortexTransformFromFile('cyprus-eddy.nc',iTime=Inf);
-  ```
+```matlab
+wvt = WVTransform.waveVortexTransformFromFile('cyprus-eddy.nc',iTime=Inf);
+```
 
-  will create a WVTransform instance populated with values from the last
-  time point of the file. Note that this is a static function---it is a
-  function defined on the class, not an instance variable---so requires we
-  prepend `WVTransform.` The result of this function call is an instance
-  variable.
+will create a WVTransform instance populated with values from the last
+time point of the file. Note that this is a static function---it is a
+function defined on the class, not an instance variable---so requires we
+prepend `WVTransform.` The result of this function call is an instance
+variable.
 
-  Restoring only the transform closes the NetCDF file before returning. If
-  you intend to read more than one time point from the save file, request
-  the second output and hold onto that read-only NetCDFFile instance, then call
-  [`initFromNetCDFFile`](/classes/transforms/wvtransform/initfromnetcdffile.html). This
-  avoids the relatively expensive operation recreating the WVTransform, and
-  simply reads the appropriate data from file. The caller owns the returned
-  NetCDFFile and must close it. Set `shouldReadOnly=false` only when writable
-  access is required.
+Restoring only the transform closes the NetCDF file before returning. If
+you intend to read more than one time point from the save file, request
+the second output and hold onto that read-only NetCDFFile instance, then call
+[`initFromNetCDFFile`](/classes/transforms/wvtransform/initfromnetcdffile.html). This
+avoids the relatively expensive operation recreating the WVTransform, and
+simply reads the appropriate data from file. The caller owns the returned
+NetCDFFile and must close it. Set `shouldReadOnly=false` only when writable
+access is required.
 
-  See also the users guide for [reading and writing to
-  file](/users-guide/reading-and-writing-to-file.html).
+See also the users guide for [reading and writing to
+file](/users-guide/reading-and-writing-to-file.html).

--- a/docs/classes/transforms/wvtransform/wavevortextransformwithresolution.md
+++ b/docs/classes/transforms/wvtransform/wavevortextransformwithresolution.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  waveVortexTransformWithResolution
 
-
+Construct the same transform family at a requested resolution.
 
 
 ---
+
+## Discussion

--- a/docs/classes/transforms/wvtransform/wvtransform.md
+++ b/docs/classes/transforms/wvtransform/wvtransform.md
@@ -9,11 +9,14 @@ mathjax: true
 
 #  WVTransform
 
-initialize a WVTransform instance
+Initialize the internal WVTransform state for a concrete subclass.
+
+> Developer documentation: this item describes internal implementation details.
 
 
 ---
 
 ## Discussion
 
-  This must be called from a subclass.
+Concrete transform constructors call this method; users create
+one of the supported subclasses instead.

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0n.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0n.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 Real valued property with dimension $$kl$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0t.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0t.md
@@ -9,16 +9,19 @@ mathjax: true
 
 #  A0t
 
-geostrophic coefficients time t
+zero-frequency coefficients at current time t
 
 
 ---
 
 ## Description
-Complex valued property with dimension $$kl$$ and units of $$m$$.
+Complex valued property with dimension $$kl$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+`A0t` is the zero-frequency coefficient array evaluated at the current transform time. On the supported $$f$$-plane transforms, `A0` has no linear phase winding and therefore
 
-These are the *time dependent* coefficients of the geostrophic flow, denoted  $$A_0$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_0^{k\ell j}(t) = A_0^{k\ell j}(t_0).
+$$
 
-These geostrophic coefficients do not have any linear time dependence on the $$f$$-plane and thus are identical to `A0`.
+Consequently, `A0t` returns the current stored `A0` coefficients.

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0u.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0u.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 Complex valued property with dimension $$kl$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0v.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0v.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 Complex valued property with dimension $$kl$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformbarotropicqg/addgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/addgeostrophicmodes.md
@@ -31,4 +31,4 @@ add amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformbarotropicqg/addgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/addgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ add a geostrophic streamfunction to existing geostrophic motions
 
 ## Discussion
 
-  The geostrophic streamfunction is added to the existing values in `A0`
+The geostrophic streamfunction is added to the existing values in `A0`
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.addGeostrophicStreamfunction(psi);
-  ```
+wvt.addGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforcomplexmatrix.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforcomplexmatrix.md
@@ -27,7 +27,7 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A complex valued matrix A defined on a grid of size [Nx Ny]
-  would has 2*Nx*Ny degrees-of-freedom at each grid point. In
-  the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
-  each grid point.
+A complex valued matrix A defined on a grid of size [Nx Ny]
+would has 2*Nx*Ny degrees-of-freedom at each grid point. In
+the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
+each grid point.

--- a/docs/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforrealmatrix.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforrealmatrix.md
@@ -28,10 +28,10 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A real-valued matrix A defined on a grid of size [Nx Ny] has
-  Nx*Ny degrees of freedom, one at each grid point. In the
-  Fourier domain these degrees-of-freedom are more complicated,
-  because some modes are strictly real-valued (k=l=0 and
-  Nyquist), while others are complex, and there are redundant
-  Hermitian conjugates. Nyquist coordinates contribute
-  self-conjugate modes only in even-sized dimensions.
+A real-valued matrix A defined on a grid of size [Nx Ny] has
+Nx*Ny degrees of freedom, one at each grid point. In the
+Fourier domain these degrees-of-freedom are more complicated,
+because some modes are strictly real-valued (k=l=0 and
+Nyquist), while others are complex, and there are redundant
+Hermitian conjugates. Nyquist coordinates contribute
+self-conjugate modes only in even-sized dimensions.

--- a/docs/classes/transforms/wvtransformbarotropicqg/effectivehorizontalgridresolution.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/effectivehorizontalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformbarotropicqg/index.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/index.md
@@ -11,7 +11,7 @@ nav_order: 5
 
 #  WVTransformBarotropicQG
 
-A transform for modeling single-layer quasigeostrophic flow
+Represent two-dimensional equivalent-barotropic quasigeostrophic flow.
 
 
 ---
@@ -22,16 +22,21 @@ A transform for modeling single-layer quasigeostrophic flow
 
 ## Overview
 
-This is a two-dimensional, single-layer which may be interpreted as
-the sea-surface height. The 'h' parameter is the equivalent depth,
-and 0.80 m is a typical value for the first baroclinic mode.
+This is a two-dimensional, single-layer transform. The `h` parameter
+is the equivalent depth; `0.80` m is a representative first-baroclinic
+value. The transform stores its state in `A0` and has no wave `Ap` or
+`Am` content.
 
 ```matlab
 Lxy = 50e3;
 Nxy = 256;
 latitude = 25;
-wvt = WVTransformSingleMode([Lxy, Lxy], [Nxy, Nxy], h=0.8, latitude=latitude);
+wvt = WVTransformBarotropicQG([Lxy,Lxy],[Nxy,Nxy],h=0.8,latitude=latitude);
 ```
+
+The Stable quasigeostrophic state is stored in
+[`A0`](/classes/transforms/wvtransform/a0.html), with current-time view
+`A0t`. This transform has no active `Ap`, `Am`, `Apt`, or `Amt` content.
 
 
 
@@ -39,19 +44,33 @@ wvt = WVTransformSingleMode([Lxy, Lxy], [Nxy, Nxy], h=0.8, latitude=latitude);
 
 ## Topics
 + Initialization
-  + [`WVTransformBarotropicQG`](/classes/transforms/wvtransformbarotropicqg/wvtransformbarotropicqg.html) create geometry for 2D barotropic flow
-+ Wave-vortex sorting matrix
-  + inverse components ($$S^{-1}$$)
-    + [`A0N`](/classes/transforms/wvtransformbarotropicqg/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
-    + [`A0U`](/classes/transforms/wvtransformbarotropicqg/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
-    + [`A0V`](/classes/transforms/wvtransformbarotropicqg/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
-  + components of $$S$$
-    + [`NA0`](/classes/transforms/wvtransformbarotropicqg/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
-    + [`UA0`](/classes/transforms/wvtransformbarotropicqg/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
-    + [`VA0`](/classes/transforms/wvtransformbarotropicqg/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
+  + [`WVTransformBarotropicQG`](/classes/transforms/wvtransformbarotropicqg/wvtransformbarotropicqg.html) Create an equivalent-barotropic quasigeostrophic transform.
 + Wave-vortex coefficients
-  + at time $$t$$
-    + [`A0t`](/classes/transforms/wvtransformbarotropicqg/a0t.html) geostrophic coefficients time t
+  + At current time
+    + [`A0t`](/classes/transforms/wvtransformbarotropicqg/a0t.html) zero-frequency coefficients at current time t
++ Primary flow components
+  + [`geostrophicComponent`](/classes/transforms/wvtransformbarotropicqg/geostrophiccomponent.html) returns the geostrophic flow component
++ Initial conditions
+  + Geostrophic Motions
+    + [`initWithGeostrophicStreamfunction`](/classes/transforms/wvtransformbarotropicqg/initwithgeostrophicstreamfunction.html) initialize with a geostrophic streamfunction
+    + [`setGeostrophicStreamfunction`](/classes/transforms/wvtransformbarotropicqg/setgeostrophicstreamfunction.html) set a geostrophic streamfunction
+    + [`addGeostrophicStreamfunction`](/classes/transforms/wvtransformbarotropicqg/addgeostrophicstreamfunction.html) add a geostrophic streamfunction to existing geostrophic motions
+    + [`setGeostrophicModes`](/classes/transforms/wvtransformbarotropicqg/setgeostrophicmodes.html) set amplitudes of the given geostrophic modes
+    + [`addGeostrophicModes`](/classes/transforms/wvtransformbarotropicqg/addgeostrophicmodes.html) add amplitudes of the given geostrophic modes
+    + [`removeAllGeostrophicMotions`](/classes/transforms/wvtransformbarotropicqg/removeallgeostrophicmotions.html) remove all geostrophic motions
++ Operations
+  + Grid transformation
+    + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
+    + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
+  + Fourier transformation
+    + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
+    + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
+    + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Transformations
+    + [`transformToKLAxes`](/classes/transforms/wvtransformbarotropicqg/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
+    + [`transformToRadialWavenumber`](/classes/transforms/wvtransformbarotropicqg/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
++ Developer
+  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformbarotropicqg/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + Domain Attributes
   + [`f`](/classes/transforms/wvtransformbarotropicqg/f.html) Coriolis parameter
   + [`g`](/classes/transforms/wvtransformbarotropicqg/g.html) gravity of Earth
@@ -106,14 +125,6 @@ wvt = WVTransformSingleMode([Lxy, Lxy], [Nxy, Nxy], h=0.8, latitude=latitude);
     + [`shouldExcludeConjugates`](/classes/transforms/wvtransformbarotropicqg/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
     + [`shouldExcludeNyquist`](/classes/transforms/wvtransformbarotropicqg/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
     + [`wvConjugateIndex`](/classes/transforms/wvtransformbarotropicqg/wvconjugateindex.html) index into the WV mode that matches the dftConjugateIndices
-+ Initial conditions
-  + Geostrophic Motions
-    + [`initWithGeostrophicStreamfunction`](/classes/transforms/wvtransformbarotropicqg/initwithgeostrophicstreamfunction.html) initialize with a geostrophic streamfunction
-    + [`setGeostrophicStreamfunction`](/classes/transforms/wvtransformbarotropicqg/setgeostrophicstreamfunction.html) set a geostrophic streamfunction
-    + [`addGeostrophicStreamfunction`](/classes/transforms/wvtransformbarotropicqg/addgeostrophicstreamfunction.html) add a geostrophic streamfunction to existing geostrophic motions
-    + [`setGeostrophicModes`](/classes/transforms/wvtransformbarotropicqg/setgeostrophicmodes.html) set amplitudes of the given geostrophic modes
-    + [`addGeostrophicModes`](/classes/transforms/wvtransformbarotropicqg/addgeostrophicmodes.html) add amplitudes of the given geostrophic modes
-    + [`removeAllGeostrophicMotions`](/classes/transforms/wvtransformbarotropicqg/removeallgeostrophicmotions.html) remove all geostrophic motions
 + Utility function
   + [`degreesOfFreedomForComplexMatrix`](/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforcomplexmatrix.html) a matrix with the number of degrees-of-freedom at each entry
   + [`degreesOfFreedomForRealMatrix`](/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforrealmatrix.html) a matrix with the number of degrees-of-freedom at each entry
@@ -122,8 +133,6 @@ wvt = WVTransformSingleMode([Lxy, Lxy], [Nxy, Nxy], h=0.8, latitude=latitude);
   + [`setConjugateToUnity`](/classes/transforms/wvtransformbarotropicqg/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
 + Properties
   + [`effectiveHorizontalGridResolution`](/classes/transforms/wvtransformbarotropicqg/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
-+ Primary flow components
-  + [`geostrophicComponent`](/classes/transforms/wvtransformbarotropicqg/geostrophiccomponent.html) returns the geostrophic flow component
 + Energetics
   + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
   + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
@@ -142,23 +151,10 @@ wvt = WVTransformSingleMode([Lxy, Lxy], [Nxy, Nxy], h=0.8, latitude=latitude);
   + [`maskForAliasedModes`](/classes/transforms/wvtransformbarotropicqg/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
   + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformbarotropicqg/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
   + [`maskForNyquistModes`](/classes/transforms/wvtransformbarotropicqg/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
-+ Developer
-  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformbarotropicqg/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + State Variables
   + [`psi`](/classes/transforms/wvtransformbarotropicqg/psi.html) geostrophic streamfunction
 + Potential Vorticity & Enstrophy
   + [`qgpv`](/classes/transforms/wvtransformbarotropicqg/qgpv.html) quasigeostrophic potential vorticity
-+ Operations
-  + Grid transformation
-    + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
-    + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
-  + Fourier transformation
-    + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
-    + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
-    + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
-  + Transformations
-    + [`transformToKLAxes`](/classes/transforms/wvtransformbarotropicqg/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
-    + [`transformToRadialWavenumber`](/classes/transforms/wvtransformbarotropicqg/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
 + Other
   + [`A0Z`](/classes/transforms/wvtransformbarotropicqg/a0z.html)
   + [`F0`](/classes/transforms/wvtransformbarotropicqg/f0.html)
@@ -217,6 +213,20 @@ wvt = WVTransformSingleMode([Lxy, Lxy], [Nxy, Nxy], h=0.8, latitude=latitude);
   + [`v`](/classes/transforms/wvtransformbarotropicqg/v.html) y-component of the fluid velocity
   + [`xyGrid`](/classes/transforms/wvtransformbarotropicqg/xygrid.html)
   + [`zeta_z`](/classes/transforms/wvtransformbarotropicqg/zeta_z.html) vertical component of relative vorticity
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Wave-vortex coefficients
++ Developer
+  + Projection coefficients
+    + [`A0N`](/classes/transforms/wvtransformbarotropicqg/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
+    + [`A0U`](/classes/transforms/wvtransformbarotropicqg/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
+    + [`A0V`](/classes/transforms/wvtransformbarotropicqg/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
+  + Reconstruction coefficients
+    + [`NA0`](/classes/transforms/wvtransformbarotropicqg/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
+    + [`UA0`](/classes/transforms/wvtransformbarotropicqg/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
+    + [`VA0`](/classes/transforms/wvtransformbarotropicqg/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 
 
 ---

--- a/docs/classes/transforms/wvtransformbarotropicqg/indexfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/indexfromklmodenumber.md
@@ -27,8 +27,8 @@ return the linear index into k_wv and l_wv from a mode number
 
 ## Discussion
 
-  This function will return the linear index into the (k_wv,l_wv) arrays,
-  given the mode numbers (kMode,lMode). Note that this will
-  *not* normalize the mode to the primary mode number, but will
-  throw an error. Scalar and column-vector inputs preserve their
-  shape and ordering.
+This function will return the linear index into the (k_wv,l_wv) arrays,
+given the mode numbers (kMode,lMode). Note that this will
+*not* normalize the mode to the primary mode number, but will
+throw an error. Scalar and column-vector inputs preserve their
+shape and ordering.

--- a/docs/classes/transforms/wvtransformbarotropicqg/indicesfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/indicesfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ indices to convert from DFT to WV grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a DFT grid to one on a WV grid.
-  The resulting WV grid will respect the conditions set when
-  this class was initialized (shouldAntialias,
-  shouldExcludeNyquist, shouldExcludeConjugates).
+This function returns indices to quickly reformat the memory
+layout of a data structure on a DFT grid to one on a WV grid.
+The resulting WV grid will respect the conditions set when
+this class was initialized (shouldAntialias,
+shouldExcludeNyquist, shouldExcludeConjugates).
 
-  This function is should generally be faster than the function
-  transformFromDFTGridToWVGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromDFTGridToWVGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformbarotropicqg/indicesfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/indicesfromwvgridtodftgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformbarotropicqg/indicesfromwvgridtofftwgrid.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/indicesfromwvgridtofftwgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformbarotropicqg/initwithgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/initwithgeostrophicstreamfunction.md
@@ -23,42 +23,42 @@ initialize with a geostrophic streamfunction
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets the geostrophic
-  streamfunction.
+Clears variables Ap,Am,A0 and then sets the geostrophic
+streamfunction.
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.initWithGeostrophicStreamfunction(psi);
-  ```
+wvt.initWithGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformbarotropicqg/ishermitian.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/ishermitian.md
@@ -27,12 +27,12 @@ Check if the matrix is Hermitian. Report errors.
 
 ## Discussion
 
-  This algorithm checks whether any 2 or 3 dimensional matrix
-  is Hermitian in the first two dimensions, following the data
-  structure of a 2D DFT algorithm. The third dimension can be
-  any length, including length 1.
+This algorithm checks whether any 2 or 3 dimensional matrix
+is Hermitian in the first two dimensions, following the data
+structure of a 2D DFT algorithm. The third dimension can be
+any length, including length 1.
 
-  Errors can be reported indicating which entries are not
-  conjugate.
+Errors can be reported indicating which entries are not
+conjugate.
 
-  This algorithm is not fast.
+This algorithm is not fast.

--- a/docs/classes/transforms/wvtransformbarotropicqg/isvalidconjugateklmodenumber.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/isvalidconjugateklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid conjugate WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *conjugate* WV mode number. Even if a mode number is
-  available in the DFT matrix, it does not mean it is a valid
-  WV mode number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*conjugate* WV mode number. Even if a mode number is
+available in the DFT matrix, it does not mean it is a valid
+WV mode number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformbarotropicqg/isvalidklmodenumber.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/isvalidklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid WV mode
-  number. Even if a mode number is available in the DFT matrix,
-  it does not mean it is a valid WV mode number, e.g., it may
-  be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid WV mode
+number. Even if a mode number is available in the DFT matrix,
+it does not mean it is a valid WV mode number, e.g., it may
+be removed due to aliasing.
 
-  A valid mode number can be either primary or conjugate, and
-  thus the result is not affected by the chosen
-  conjugateDimension.
+A valid mode number can be either primary or conjugate, and
+thus the result is not affected by the chosen
+conjugateDimension.

--- a/docs/classes/transforms/wvtransformbarotropicqg/isvalidprimaryklmodenumber.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/isvalidprimaryklmodenumber.md
@@ -27,9 +27,9 @@ return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *primary* WV mode number. Even if a mode number is available
-  in the DFT matrix, it does not mean it is a valid WV mode
-  number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*primary* WV mode number. Even if a mode number is available
+in the DFT matrix, it does not mean it is a valid WV mode
+number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformbarotropicqg/klmodenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/klmodenumberfromindex.md
@@ -27,6 +27,6 @@ return mode number from a linear index into a WV matrix
 
 ## Discussion
 
-  This function will return the mode numbers (kMode,lMode)
-  given some linear index into a WV structured matrix. Scalar
-  and column-vector inputs preserve their shape and ordering.
+This function will return the mode numbers (kMode,lMode)
+given some linear index into a WV structured matrix. Scalar
+and column-vector inputs preserve their shape and ordering.

--- a/docs/classes/transforms/wvtransformbarotropicqg/maskforaliasedmodes.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/maskforaliasedmodes.md
@@ -28,18 +28,18 @@ returns a mask with locations of modes that will alias with a quadratic multipli
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
-  modes are, assuming the 2/3 anti-aliasing rule for quadratic
-  interactions.
+Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
+modes are, assuming the 2/3 anti-aliasing rule for quadratic
+interactions.
 
-  Technically one needs only restrict to 2/3s in each
-  wavenumber direction. However, we prefer to maintain an
-  isotropic effective grid size and instead restrict to a
-  circle.
+Technically one needs only restrict to 2/3s in each
+wavenumber direction. However, we prefer to maintain an
+isotropic effective grid size and instead restrict to a
+circle.
 
-  Basic usage,
-  ```matlab
-  antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  alias with a quadratic multiplication.
+Basic usage,
+```matlab
+antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+alias with a quadratic multiplication.

--- a/docs/classes/transforms/wvtransformbarotropicqg/maskforconjugatefouriercoefficients.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/maskforconjugatefouriercoefficients.md
@@ -28,13 +28,13 @@ a mask indicate the components that are redundant conjugates
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where
-  the non-primary Hermitian conjugates are located in the DFT
-  matrix.
+Returns a 'mask' (matrices with 1s or 0s) indicating where
+the non-primary Hermitian conjugates are located in the DFT
+matrix.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
-  ```
-  will return a mask that contains 1 at the locations of the
-  modes assumed conjugate.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
+```
+will return a mask that contains 1 at the locations of the
+modes assumed conjugate.

--- a/docs/classes/transforms/wvtransformbarotropicqg/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/maskfornyquistmodes.md
@@ -28,13 +28,13 @@ returns a mask with locations of modes that are not fully resolved
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located in a standard FFT matrix. A direction has
-  a Nyquist coordinate only when its grid size is even.
+Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
+modes are located in a standard FFT matrix. A direction has
+a Nyquist coordinate only when its grid size is even.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForNyquistModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  are at the Nyquist frequency of the Fourier transforms.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForNyquistModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+are at the Nyquist frequency of the Fourier transforms.

--- a/docs/classes/transforms/wvtransformbarotropicqg/na0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/na0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 Real valued property with dimension $$kl$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformbarotropicqg/primaryklmodenumberfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/primaryklmodenumberfromklmodenumber.md
@@ -28,8 +28,8 @@ takes any valid WV mode number and returns the primary mode number
 
 ## Discussion
 
-  The function first confirms that the mode numbers are valid,
-  and then converts any conjugate mode numbers to primary mode
-  numbers.
+The function first confirms that the mode numbers are valid,
+and then converts any conjugate mode numbers to primary mode
+numbers.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformbarotropicqg/removeallgeostrophicmotions.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/removeallgeostrophicmotions.md
@@ -20,9 +20,9 @@ remove all geostrophic motions
 ```
 ## Discussion
 
-  All geostrophic motions are removed by setting A0 to zero.
+All geostrophic motions are removed by setting A0 to zero.
 
-  **Note** that this does *not* remove the mean density anomaly
-  (mda) part of the solution, just the geostrophic part. Thus,
-  this function will not clear all parts of a geostrophic
-  streamfunction.
+**Note** that this does *not* remove the mean density anomaly
+(mda) part of the solution, just the geostrophic part. Thus,
+this function will not clear all parts of a geostrophic
+streamfunction.

--- a/docs/classes/transforms/wvtransformbarotropicqg/setgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/setgeostrophicmodes.md
@@ -31,16 +31,16 @@ set amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Set the amplitude of the given geostrophic modes by
-  overwriting any existing amplitudes. The parameters are given
-  as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
-  and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
-  of those modes.
+Set the amplitude of the given geostrophic modes by
+overwriting any existing amplitudes. The parameters are given
+as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
+and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
+of those modes.
 
-  For example,
+For example,
 
-  ```matlab
-  wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
-  ```
+```matlab
+wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
+```
 
-  will add a geostrophic mode.
+will add a geostrophic mode.

--- a/docs/classes/transforms/wvtransformbarotropicqg/setgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/setgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ set a geostrophic streamfunction
 
 ## Discussion
 
-  Clears A0 by setting a geostrophic streamfunction
+Clears A0 by setting a geostrophic streamfunction
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.setGeostrophicStreamfunction(psi);
-  ```
+wvt.setGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformbarotropicqg/totalenstrophyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/totalenstrophyspatiallyintegrated.md
@@ -23,5 +23,5 @@ Return horizontally averaged barotropic potential enstrophy.
 
 ## Discussion
 
-  The spatial invariant is
-  $$Z = \frac{h}{2}\langle q_{\mathrm{QG}}^2\rangle.$$
+The spatial invariant is
+$$Z = \frac{h}{2}\langle q_{\mathrm{QG}}^2\rangle.$$

--- a/docs/classes/transforms/wvtransformbarotropicqg/transformfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/transformfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ convert from DFT to WV grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a DFT grid to one on a WV grid. The WV grid will
-  respect the conditions set when this class was initialized
-  (shouldAntialias, shouldExcludeNyquist,
-  shouldExcludeConjugates).
+This function will reformat the memory layout of a data
+structure on a DFT grid to one on a WV grid. The WV grid will
+respect the conditions set when this class was initialized
+(shouldAntialias, shouldExcludeNyquist,
+shouldExcludeConjugates).
 
-  This function is not the fastest way to reformat your data.
-  If high performance is required, you should
+This function is not the fastest way to reformat your data.
+If high performance is required, you should

--- a/docs/classes/transforms/wvtransformbarotropicqg/transformfromspatialdomaintodftgrid.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/transformfromspatialdomaintodftgrid.md
@@ -26,5 +26,5 @@ transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
 
 ## Discussion
 
-  Performs a Fourier transform in the x and y direction. The
-  resulting matrix is on the DFT grid.
+Performs a Fourier transform in the x and y direction. The
+resulting matrix is on the DFT grid.

--- a/docs/classes/transforms/wvtransformbarotropicqg/transformfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/transformfromwvgridtodftgrid.md
@@ -27,7 +27,7 @@ convert from a WV to DFT grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a WV grid to one on a DFT grid. If the option
-  isHalfComplex is selected, then it will not set values for
-  iL>Ny/2, which are ignored by a 'symmetric' fft.
+This function will reformat the memory layout of a data
+structure on a WV grid to one on a DFT grid. If the option
+isHalfComplex is selected, then it will not set values for
+iL>Ny/2, which are ignored by a 'symmetric' fft.

--- a/docs/classes/transforms/wvtransformbarotropicqg/transformtoklaxes.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/transformtoklaxes.md
@@ -26,13 +26,12 @@ transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
 
 ## Discussion
 
+The following example takes the total energy of the wave part of
+flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
+along the mode (j) dimension.
 
-  The following example takes the total energy of the wave part of
-  flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
-  along the mode (j) dimension.
-
-  ```matlab
-  figure
-  TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
-  pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
-  ```
+```matlab
+figure
+TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
+pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
+```

--- a/docs/classes/transforms/wvtransformbarotropicqg/transformtoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/transformtoradialwavenumber.md
@@ -26,18 +26,18 @@ transforms in the spectral domain from (j,kl) to (j,kRadial)
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kRadial`.
+Sums all the variance/energy in radial bins `kRadial`.
 
-  The following example takes the total energy of the geostrophic part of
-  flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
-  it with pcolor. The next plot then sums over all wavenumber, and produces
-  plots the total energy spectrum as a function of vertical mode $$j$$
-  only.
+The following example takes the total energy of the geostrophic part of
+flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
+it with pcolor. The next plot then sums over all wavenumber, and produces
+plots the total energy spectrum as a function of vertical mode $$j$$
+only.
 
-  ```matlab
-  figure
-  tiledlayout('flow')
-  Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
-  nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
-  nexttile, plot(wvt.j,sum(Ekj,2))
-  ```
+```matlab
+figure
+tiledlayout('flow')
+Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
+nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
+nexttile, plot(wvt.j,sum(Ekj,2))
+```

--- a/docs/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgrid.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgrid.md
@@ -26,5 +26,5 @@ transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
 
 ## Discussion
 
-  Performs an inverse Fourier transform to take a matrix from
-  the DFT grid back to the spatial domain.
+Performs an inverse Fourier transform to take a matrix from
+the DFT grid back to the spatial domain.

--- a/docs/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgridatposition.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgridatposition.md
@@ -26,6 +26,6 @@ transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
 
 ## Discussion
 
-  Performs an inverse non-uniform Fourier transform to take a
-  matrix from the DFT grid back to the spatial domain at any
-  set of points (x,y).
+Performs an inverse non-uniform Fourier transform to take a
+matrix from the DFT grid back to the spatial domain at any
+set of points (x,y).

--- a/docs/classes/transforms/wvtransformbarotropicqg/ua0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/ua0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 Complex valued property with dimension $$kl$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 1, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformbarotropicqg/va0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/va0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 Complex valued property with dimension $$kl$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 2, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformbarotropicqg/wvtransformbarotropicqg.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/wvtransformbarotropicqg.md
@@ -9,27 +9,29 @@ mathjax: true
 
 #  WVTransformBarotropicQG
 
-create geometry for 2D barotropic flow
+Create an equivalent-barotropic quasigeostrophic transform.
 
 
 ---
 
 ## Declaration
 ```matlab
- wvt = Cartesian2DBarotropic(Lxyz, Nxyz, options)
+ wvt = WVTransformBarotropicQG(Lxy,Nxy,options)
 ```
 ## Parameters
 + `Lxy`  length of the domain (in meters) in the two coordinate directions, e.g. [Lx Ly]
 + `Nxy`  number of grid points in the two coordinate directions, e.g. [Nx Ny]
 + `shouldAntialias`  (optional) whether or not to de-alias for quadratic multiplications
++ `options.h`  equivalent depth in meters; default `0.8`
++ `options.latitude`  latitude in the supported domain; default `33`
 
 ## Returns
-+ `wvt`  a new Cartesian2DBarotropic instance
++ `wvt`  new `WVTransformBarotropicQG` instance
 
 ## Discussion
 
-  ```matlab
-  Lxy = 50e3;
-  Nxy = 256;
-  wvt = Cartesian2DBarotropic([Lxy, Lxy], [Nxy, Nxy]);
-  ```
+```matlab
+Lxy = 50e3;
+Nxy = 256;
+wvt = WVTransformBarotropicQG([Lxy,Lxy],[Nxy,Nxy],h=0.8,latitude=30);
+```

--- a/docs/classes/transforms/wvtransformboussinesq/a0n.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0n.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/a0t.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0t.md
@@ -9,16 +9,19 @@ mathjax: true
 
 #  A0t
 
-geostrophic coefficients time t
+zero-frequency coefficients at current time t
 
 
 ---
 
 ## Description
-Complex valued property with dimensions $$(j,kl)$$ and units of $$m$$.
+Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+`A0t` is the zero-frequency coefficient array evaluated at the current transform time. On the supported $$f$$-plane transforms, `A0` has no linear phase winding and therefore
 
-These are the *time dependent* coefficients of the geostrophic flow, denoted  $$A_0$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_0^{k\ell j}(t) = A_0^{k\ell j}(t_0).
+$$
 
-These geostrophic coefficients do not have any linear time dependence on the $$f$$-plane and thus are identical to `A0`.
+Consequently, `A0t` returns the current stored `A0` coefficients.

--- a/docs/classes/transforms/wvtransformboussinesq/a0u.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0u.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/a0v.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0v.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/addgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/addgeostrophicmodes.md
@@ -31,4 +31,4 @@ add amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformboussinesq/addgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformboussinesq/addgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ add a geostrophic streamfunction to existing geostrophic motions
 
 ## Discussion
 
-  The geostrophic streamfunction is added to the existing values in `A0`
+The geostrophic streamfunction is added to the existing values in `A0`
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.addGeostrophicStreamfunction(psi);
-  ```
+wvt.addGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformboussinesq/addinertialmotions.md
+++ b/docs/classes/transforms/wvtransformboussinesq/addinertialmotions.md
@@ -24,21 +24,21 @@ add inertial motions to existing inertial motions
 
 ## Discussion
 
-  The amplitudes of the inertial part of the flow will be added
-  to the existing inertial part of the flow.
+The amplitudes of the inertial part of the flow will be added
+to the existing inertial part of the flow.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.addInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.addInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.
 
-  The new inertial motions are added to the existing inertial motions
+The new inertial motions are added to the existing inertial motions

--- a/docs/classes/transforms/wvtransformboussinesq/addmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformboussinesq/addmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  addMeanDensityAnomaly
 
-add inertial motions to existing inertial motions
+Add a mean-density anomaly to the existing fluid state.
 
 
 ---
@@ -23,21 +23,16 @@ add inertial motions to existing inertial motions
 
 ## Discussion
 
-  The amplitudes of the inertial part of the flow will be added
-  to the existing inertial part of the flow.
+The supplied horizontally uniform isopycnal displacement is
+projected onto the internal mean-density-anomaly modes and
+added to their `A0` coefficients.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.addMeanDensityAnomaly(eta);
+```
 
-  wvt.addInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
-
-  The new inertial motions are added to the existing inertial motions
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformboussinesq/addwavemodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/addwavemodes.md
@@ -33,4 +33,4 @@ add amplitudes of the given wave modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformboussinesq/addwaveswithfrequencyspectrum.md
+++ b/docs/classes/transforms/wvtransformboussinesq/addwaveswithfrequencyspectrum.md
@@ -25,20 +25,20 @@ add waves with a specified frequency spectrum
 
 ## Discussion
 
-  This allows you to initialize the wave field (Ap,Am matrices)
-  with a spectrum specified in terms of vertical mode j and
-  frequency $\omega$. This allows us to initialize with a
-  Garrett-Munk spectrum, for example, using code like,
+This allows you to initialize the wave field (Ap,Am matrices)
+with a spectrum specified in terms of vertical mode j and
+frequency $\omega$. This allows us to initialize with a
+Garrett-Munk spectrum, for example, using code like,
 
-  ```matlab
-  GM = @(omega,j) E*H(j) .* B(omega);
-  ```
+```matlab
+GM = @(omega,j) E*H(j) .* B(omega);
+```
 
-  Because the model has limited resolution, there will not
-  necessarily be many modes in a given frequency band. This
-  means that the ensemble may be over a very low number of
-  realization, and thus might not converge to the requested
-  spectrum. For this reason, the option
-  shouldOnlyRandomizeOrientations may be useful. This will only
-  randomize the phases of the waves, while fixing the
-  amplitudes so that the desired spectrum will be achieved.
+Because the model has limited resolution, there will not
+necessarily be many modes in a given frequency band. This
+means that the ensemble may be over a very low number of
+realization, and thus might not converge to the requested
+spectrum. For this reason, the option
+shouldOnlyRandomizeOrientations may be useful. This will only
+randomize the phases of the waves, while fixing the
+amplitudes so that the desired spectrum will be achieved.

--- a/docs/classes/transforms/wvtransformboussinesq/amt.md
+++ b/docs/classes/transforms/wvtransformboussinesq/amt.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Amt
 
-negative wave coefficients at reference time t
+negative-frequency coefficients at current time t
 
 
 ---
@@ -18,7 +18,10 @@ negative wave coefficients at reference time t
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+`Amt` is the negative-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_- e^{-i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_-^{k\ell j}(t) = A_-^{k\ell j}(t_0) e^{-i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Am`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Am`, `t`, `t0`, and modal frequency without changing `Am`.

--- a/docs/classes/transforms/wvtransformboussinesq/apt.md
+++ b/docs/classes/transforms/wvtransformboussinesq/apt.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Apt
 
-positive wave coefficients at reference time t
+positive-frequency coefficients at current time t
 
 
 ---
@@ -18,7 +18,10 @@ positive wave coefficients at reference time t
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+`Apt` is the positive-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_+ e^{i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_+^{k\ell j}(t) = A_+^{k\ell j}(t_0) e^{i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Ap`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Ap`, `t`, `t0`, and modal frequency without changing `Ap`.

--- a/docs/classes/transforms/wvtransformboussinesq/degreesoffreedomforcomplexmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/degreesoffreedomforcomplexmatrix.md
@@ -27,7 +27,7 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A complex valued matrix A defined on a grid of size [Nx Ny]
-  would has 2*Nx*Ny degrees-of-freedom at each grid point. In
-  the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
-  each grid point.
+A complex valued matrix A defined on a grid of size [Nx Ny]
+would has 2*Nx*Ny degrees-of-freedom at each grid point. In
+the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
+each grid point.

--- a/docs/classes/transforms/wvtransformboussinesq/degreesoffreedomforrealmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/degreesoffreedomforrealmatrix.md
@@ -28,10 +28,10 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A real-valued matrix A defined on a grid of size [Nx Ny] has
-  Nx*Ny degrees of freedom, one at each grid point. In the
-  Fourier domain these degrees-of-freedom are more complicated,
-  because some modes are strictly real-valued (k=l=0 and
-  Nyquist), while others are complex, and there are redundant
-  Hermitian conjugates. Nyquist coordinates contribute
-  self-conjugate modes only in even-sized dimensions.
+A real-valued matrix A defined on a grid of size [Nx Ny] has
+Nx*Ny degrees of freedom, one at each grid point. In the
+Fourier domain these degrees-of-freedom are more complicated,
+because some modes are strictly real-valued (k=l=0 and
+Nyquist), while others are complex, and there are redundant
+Hermitian conjugates. Nyquist coordinates contribute
+self-conjugate modes only in even-sized dimensions.

--- a/docs/classes/transforms/wvtransformboussinesq/diffzf.md
+++ b/docs/classes/transforms/wvtransformboussinesq/diffzf.md
@@ -27,6 +27,6 @@ Differentiate an F-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return a G-representation and even orders return
-  an F-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return a G-representation and even orders return
+an F-representation.

--- a/docs/classes/transforms/wvtransformboussinesq/diffzg.md
+++ b/docs/classes/transforms/wvtransformboussinesq/diffzg.md
@@ -27,6 +27,6 @@ Differentiate a G-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return an F-representation and even orders return
-  a G-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return an F-representation and even orders return
+a G-representation.

--- a/docs/classes/transforms/wvtransformboussinesq/effectivehorizontalgridresolution.md
+++ b/docs/classes/transforms/wvtransformboussinesq/effectivehorizontalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformboussinesq/effectiveverticalgridresolution.md
+++ b/docs/classes/transforms/wvtransformboussinesq/effectiveverticalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective vertical grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformboussinesq/fwinvmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/fwinvmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$F_w^{-1}$$
 
 ## Discussion
 
-  A matrix that transforms a vector of igw amplitudes from
-  vertical mode space to physical space.
+A matrix that transforms a vector of igw amplitudes from
+vertical mode space to physical space.

--- a/docs/classes/transforms/wvtransformboussinesq/fwmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/fwmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$F_w$$
 
 ## Discussion
 
-  A matrix that transforms a vector in physical space to IGW
-  mode space
+A matrix that transforms a vector in physical space to IGW
+mode space

--- a/docs/classes/transforms/wvtransformboussinesq/gwinvmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/gwinvmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$G_w^{-1}$$
 
 ## Discussion
 
-  A matrix that transforms a vector of igw amplitudes from
-  vertical mode space to physical space.
+A matrix that transforms a vector of igw amplitudes from
+vertical mode space to physical space.

--- a/docs/classes/transforms/wvtransformboussinesq/gwmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/gwmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$G_w$$
 
 ## Discussion
 
-  A matrix that transforms a vector in physical space to IGW
-  mode space
+A matrix that transforms a vector in physical space to IGW
+mode space

--- a/docs/classes/transforms/wvtransformboussinesq/index.md
+++ b/docs/classes/transforms/wvtransformboussinesq/index.md
@@ -11,7 +11,7 @@ nav_order: 2
 
 #  WVTransformBoussinesq
 
-A class for disentangling nonhydrostatic waves and vortices in variable stratification
+Decompose nonhydrostatic variable-stratification flow into wave and geostrophic components.
 
 
 ---
@@ -23,15 +23,20 @@ A class for disentangling nonhydrostatic waves and vortices in variable stratifi
 ## Overview
 
 To initialize an instance of the WVTransformBoussinesq class you
-must specific the domain size, the number of grid points and *either*
+must specify the domain size, the number of grid points, and either
 the density profile or the stratification profile.
 
 ```matlab
 N0 = 3*2*pi/3600;
 L_gm = 1300;
 N2 = @(z) N0*N0*exp(2*z/L_gm);
-wvt = WVTransformBoussinesq([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30);
+wvt = WVTransformBoussinesq([100e3,100e3,4000],[64,64,65],N2Function=N2,latitude=30);
 ```
+
+The Stable transform state is stored in [`Ap`](/classes/transforms/wvtransform/ap.html),
+[`Am`](/classes/transforms/wvtransform/am.html), and
+[`A0`](/classes/transforms/wvtransform/a0.html). Their current-time
+views are `Apt`, `Amt`, and `A0t`.
 
 
 
@@ -39,7 +44,12 @@ wvt = WVTransformBoussinesq([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30
 
 ## Topics
 + Initialization
-  + [`WVTransformBoussinesq`](/classes/transforms/wvtransformboussinesq/wvtransformboussinesq.html) create a wave-vortex transform for variable stratification
+  + [`WVTransformBoussinesq`](/classes/transforms/wvtransformboussinesq/wvtransformboussinesq.html) Create a nonhydrostatic wave-vortex transform for variable stratification.
++ Wave-vortex coefficients
+  + At current time
+    + [`A0t`](/classes/transforms/wvtransformboussinesq/a0t.html) zero-frequency coefficients at current time t
+    + [`Amt`](/classes/transforms/wvtransformboussinesq/amt.html) negative-frequency coefficients at current time t
+    + [`Apt`](/classes/transforms/wvtransformboussinesq/apt.html) positive-frequency coefficients at current time t
 + Primary flow components
   + [`geostrophicComponent`](/classes/transforms/wvtransformboussinesq/geostrophiccomponent.html) returns the geostrophic flow component
   + [`waveComponent`](/classes/transforms/wvtransformboussinesq/wavecomponent.html) returns the internal gravity wave flow component
@@ -73,10 +83,10 @@ wvt = WVTransformBoussinesq([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30
     + [`removeAllInertialMotions`](/classes/transforms/wvtransformboussinesq/removeallinertialmotions.html) remove all inertial motions
     + [`setInertialMotions`](/classes/transforms/wvtransformboussinesq/setinertialmotions.html) set inertial motions
   + Mean density anomaly
-    + [`addMeanDensityAnomaly`](/classes/transforms/wvtransformboussinesq/addmeandensityanomaly.html) add inertial motions to existing inertial motions
-    + [`initWithMeanDensityAnomaly`](/classes/transforms/wvtransformboussinesq/initwithmeandensityanomaly.html) initialize with inertial motions
+    + [`addMeanDensityAnomaly`](/classes/transforms/wvtransformboussinesq/addmeandensityanomaly.html) Add a mean-density anomaly to the existing fluid state.
+    + [`initWithMeanDensityAnomaly`](/classes/transforms/wvtransformboussinesq/initwithmeandensityanomaly.html) Initialize the fluid state with a mean-density anomaly.
     + [`removeAllMeanDensityAnomaly`](/classes/transforms/wvtransformboussinesq/removeallmeandensityanomaly.html) remove all mean density anomalies
-    + [`setMeanDensityAnomaly`](/classes/transforms/wvtransformboussinesq/setmeandensityanomaly.html) set inertial motions
+    + [`setMeanDensityAnomaly`](/classes/transforms/wvtransformboussinesq/setmeandensityanomaly.html) Set the mean-density-anomaly component.
 + Operations
   + Transformations
     + [`FwInvMatrix`](/classes/transforms/wvtransformboussinesq/fwinvmatrix.html) transformation matrix $$F_w^{-1}$$
@@ -104,28 +114,8 @@ wvt = WVTransformBoussinesq([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30
     + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformboussinesq/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
     + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
     + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
-+ Wave-vortex sorting matrix
-  + inverse components ($$S^{-1}$$)
-    + [`A0N`](/classes/transforms/wvtransformboussinesq/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
-    + [`A0U`](/classes/transforms/wvtransformboussinesq/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
-    + [`A0V`](/classes/transforms/wvtransformboussinesq/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
-  + components of $$S$$
-    + [`NA0`](/classes/transforms/wvtransformboussinesq/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
-    + [`NAm`](/classes/transforms/wvtransformboussinesq/nam.html)
-    + [`NAp`](/classes/transforms/wvtransformboussinesq/nap.html)
-    + [`UA0`](/classes/transforms/wvtransformboussinesq/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
-    + [`UAm`](/classes/transforms/wvtransformboussinesq/uam.html)
-    + [`UAp`](/classes/transforms/wvtransformboussinesq/uap.html)
-    + [`VA0`](/classes/transforms/wvtransformboussinesq/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
-    + [`VAm`](/classes/transforms/wvtransformboussinesq/vam.html)
-    + [`VAp`](/classes/transforms/wvtransformboussinesq/vap.html)
-    + [`WAm`](/classes/transforms/wvtransformboussinesq/wam.html)
-    + [`WAp`](/classes/transforms/wvtransformboussinesq/wap.html)
-+ Wave-vortex coefficients
-  + at time $$t$$
-    + [`A0t`](/classes/transforms/wvtransformboussinesq/a0t.html) geostrophic coefficients time t
-    + [`Amt`](/classes/transforms/wvtransformboussinesq/amt.html) negative wave coefficients at reference time t
-    + [`Apt`](/classes/transforms/wvtransformboussinesq/apt.html) positive wave coefficients at reference time t
++ Developer
+  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformboussinesq/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + Domain Attributes
   + [`f`](/classes/transforms/wvtransformboussinesq/f.html) Coriolis parameter
   + [`g`](/classes/transforms/wvtransformboussinesq/g.html) gravity of Earth
@@ -222,8 +212,6 @@ wvt = WVTransformBoussinesq([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30
   + [`maskForNyquistModes`](/classes/transforms/wvtransformboussinesq/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
 + Utilities
   + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformboussinesq/placeparticlesonisopycnal.html) places Lagrangian particles along a specified isopycnal
-+ Developer
-  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformboussinesq/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + State Variables
   + [`psi`](/classes/transforms/wvtransformboussinesq/psi.html) geostrophic streamfunction
   + [`ssu`](/classes/transforms/wvtransformboussinesq/ssu.html) x-component of the fluid velocity at the surface
@@ -352,6 +340,29 @@ wvt = WVTransformBoussinesq([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30
   + [`zeta_x`](/classes/transforms/wvtransformboussinesq/zeta_x.html) x-component component of relative vorticity
   + [`zeta_y`](/classes/transforms/wvtransformboussinesq/zeta_y.html) y-component component of relative vorticity
   + [`zeta_z`](/classes/transforms/wvtransformboussinesq/zeta_z.html) vertical component of relative vorticity
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Wave-vortex coefficients
++ Stratification
++ Developer
+  + Projection coefficients
+    + [`A0N`](/classes/transforms/wvtransformboussinesq/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
+    + [`A0U`](/classes/transforms/wvtransformboussinesq/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
+    + [`A0V`](/classes/transforms/wvtransformboussinesq/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
+  + Reconstruction coefficients
+    + [`NA0`](/classes/transforms/wvtransformboussinesq/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
+    + [`NAm`](/classes/transforms/wvtransformboussinesq/nam.html)
+    + [`NAp`](/classes/transforms/wvtransformboussinesq/nap.html)
+    + [`UA0`](/classes/transforms/wvtransformboussinesq/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
+    + [`UAm`](/classes/transforms/wvtransformboussinesq/uam.html)
+    + [`UAp`](/classes/transforms/wvtransformboussinesq/uap.html)
+    + [`VA0`](/classes/transforms/wvtransformboussinesq/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
+    + [`VAm`](/classes/transforms/wvtransformboussinesq/vam.html)
+    + [`VAp`](/classes/transforms/wvtransformboussinesq/vap.html)
+    + [`WAm`](/classes/transforms/wvtransformboussinesq/wam.html)
+    + [`WAp`](/classes/transforms/wvtransformboussinesq/wap.html)
 
 
 ---

--- a/docs/classes/transforms/wvtransformboussinesq/indexfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/indexfromklmodenumber.md
@@ -27,8 +27,8 @@ return the linear index into k_wv and l_wv from a mode number
 
 ## Discussion
 
-  This function will return the linear index into the (k_wv,l_wv) arrays,
-  given the mode numbers (kMode,lMode). Note that this will
-  *not* normalize the mode to the primary mode number, but will
-  throw an error. Scalar and column-vector inputs preserve their
-  shape and ordering.
+This function will return the linear index into the (k_wv,l_wv) arrays,
+given the mode numbers (kMode,lMode). Note that this will
+*not* normalize the mode to the primary mode number, but will
+throw an error. Scalar and column-vector inputs preserve their
+shape and ordering.

--- a/docs/classes/transforms/wvtransformboussinesq/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/indexfrommodenumber.md
@@ -28,7 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 
 ## Discussion
 
-  This function will return the linear index in a spectral
-  matrix given a mode number. Scalar and column-vector inputs preserve
-  their shape and ordering; conjugate mode numbers map to their primary
-  coefficient.
+This function will return the linear index in a spectral
+matrix given a mode number. Scalar and column-vector inputs preserve
+their shape and ordering; conjugate mode numbers map to their primary
+coefficient.

--- a/docs/classes/transforms/wvtransformboussinesq/indicesfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/indicesfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ indices to convert from DFT to WV grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a DFT grid to one on a WV grid.
-  The resulting WV grid will respect the conditions set when
-  this class was initialized (shouldAntialias,
-  shouldExcludeNyquist, shouldExcludeConjugates).
+This function returns indices to quickly reformat the memory
+layout of a data structure on a DFT grid to one on a WV grid.
+The resulting WV grid will respect the conditions set when
+this class was initialized (shouldAntialias,
+shouldExcludeNyquist, shouldExcludeConjugates).
 
-  This function is should generally be faster than the function
-  transformFromDFTGridToWVGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromDFTGridToWVGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformboussinesq/indicesfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/indicesfromwvgridtodftgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformboussinesq/indicesfromwvgridtofftwgrid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/indicesfromwvgridtofftwgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformboussinesq/initwaveswithfrequencyspectrum.md
+++ b/docs/classes/transforms/wvtransformboussinesq/initwaveswithfrequencyspectrum.md
@@ -25,20 +25,20 @@ initialize with waves of a specified frequency spectrum
 
 ## Discussion
 
-  This allows you to initialize the wave field (Ap,Am matrices)
-  with a spectrum specified in terms of vertical mode j and
-  frequency $\omega$. This allows us to initialize with a
-  Garrett-Munk spectrum, for example, using code like,
+This allows you to initialize the wave field (Ap,Am matrices)
+with a spectrum specified in terms of vertical mode j and
+frequency $\omega$. This allows us to initialize with a
+Garrett-Munk spectrum, for example, using code like,
 
-  ```matlab
-  GM = @(omega,j) E*H(j) .* B(omega);
-  ```
+```matlab
+GM = @(omega,j) E*H(j) .* B(omega);
+```
 
-  Because the model has limited resolution, there will not
-  necessarily be many modes in a given frequency band. This
-  means that the ensemble may be over a very low number of
-  realization, and thus might not converge to the requested
-  spectrum. For this reason, the option
-  shouldOnlyRandomizeOrientations may be useful. This will only
-  randomize the phases of the waves, while fixing the
-  amplitudes so that the desired spectrum will be achieved.
+Because the model has limited resolution, there will not
+necessarily be many modes in a given frequency band. This
+means that the ensemble may be over a very low number of
+realization, and thus might not converge to the requested
+spectrum. For this reason, the option
+shouldOnlyRandomizeOrientations may be useful. This will only
+randomize the phases of the waves, while fixing the
+amplitudes so that the desired spectrum will be achieved.

--- a/docs/classes/transforms/wvtransformboussinesq/initwithalternativespectrum.md
+++ b/docs/classes/transforms/wvtransformboussinesq/initwithalternativespectrum.md
@@ -25,4 +25,4 @@ initialize with an alternative formulation of the GM spectrum in the wavenumber 
 
 ## Discussion
 
-  This only initializes the wave components, A0 is left untouched.
+This only initializes the wave components, A0 is left untouched.

--- a/docs/classes/transforms/wvtransformboussinesq/initwithgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformboussinesq/initwithgeostrophicstreamfunction.md
@@ -23,42 +23,42 @@ initialize with a geostrophic streamfunction
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets the geostrophic
-  streamfunction.
+Clears variables Ap,Am,A0 and then sets the geostrophic
+streamfunction.
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.initWithGeostrophicStreamfunction(psi);
-  ```
+wvt.initWithGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformboussinesq/initwithinertialmotions.md
+++ b/docs/classes/transforms/wvtransformboussinesq/initwithinertialmotions.md
@@ -24,18 +24,18 @@ initialize with inertial motions
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets inertial motions.
+Clears variables Ap,Am,A0 and then sets inertial motions.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.initWithInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.initWithInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformboussinesq/initwithmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformboussinesq/initwithmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  initWithMeanDensityAnomaly
 
-initialize with inertial motions
+Initialize the fluid state with a mean-density anomaly.
 
 
 ---
@@ -23,18 +23,16 @@ initialize with inertial motions
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets inertial motions.
+Clear `Ap`, `Am`, and `A0`, then project the supplied
+horizontally uniform isopycnal displacement onto the internal
+mean-density-anomaly modes.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.initWithMeanDensityAnomaly(eta);
+```
 
-  wvt.initWithInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformboussinesq/initwithwavemodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/initwithwavemodes.md
@@ -33,8 +33,8 @@ initialize with the given wave modes
 
 ## Discussion
 
-  $$
-  sin(k*x+l*y)*F_j*sin(omega*t + phi)
-  $$
+$$
+sin(k*x+l*y)*F_j*sin(omega*t + phi)
+$$
 
-  Clears variables Ap,Am,A0 and then sets the given wave modes.
+Clears variables Ap,Am,A0 and then sets the given wave modes.

--- a/docs/classes/transforms/wvtransformboussinesq/intzf.md
+++ b/docs/classes/transforms/wvtransformboussinesq/intzf.md
@@ -27,8 +27,8 @@ Return the first antiderivative of an F-representation.
 
 ## Discussion
 
-  The result is the antiderivative representable in G space. The
-  barotropic F mode is removed because it has no corresponding G mode, so
-  the result vanishes at both vertical boundaries. `u` may use the gridded
-  layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
-  array preserves that layout.
+The result is the antiderivative representable in G space. The
+barotropic F mode is removed because it has no corresponding G mode, so
+the result vanishes at both vertical boundaries. `u` may use the gridded
+layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
+array preserves that layout.

--- a/docs/classes/transforms/wvtransformboussinesq/intzg.md
+++ b/docs/classes/transforms/wvtransformboussinesq/intzg.md
@@ -27,7 +27,7 @@ Return the bottom-zero first antiderivative of a G-representation.
 
 ## Discussion
 
-  A G-to-F antiderivative is defined up to an additive constant. This
-  method selects the representative that vanishes at the bottom boundary.
-  `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
-  `[Nz N]`; the returned array preserves that layout.
+A G-to-F antiderivative is defined up to an additive constant. This
+method selects the representative that vanishes at the bottom boundary.
+`w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
+`[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformboussinesq/isdensityinvalidrange.md
+++ b/docs/classes/transforms/wvtransformboussinesq/isdensityinvalidrange.md
@@ -23,4 +23,4 @@ checks if the density field is a valid adiabatic re-arrangement of the base stat
 
 ## Discussion
 
-  This is probably best re-defined as a dynamical variable.
+This is probably best re-defined as a dynamical variable.

--- a/docs/classes/transforms/wvtransformboussinesq/ishermitian.md
+++ b/docs/classes/transforms/wvtransformboussinesq/ishermitian.md
@@ -27,12 +27,12 @@ Check if the matrix is Hermitian. Report errors.
 
 ## Discussion
 
-  This algorithm checks whether any 2 or 3 dimensional matrix
-  is Hermitian in the first two dimensions, following the data
-  structure of a 2D DFT algorithm. The third dimension can be
-  any length, including length 1.
+This algorithm checks whether any 2 or 3 dimensional matrix
+is Hermitian in the first two dimensions, following the data
+structure of a 2D DFT algorithm. The third dimension can be
+any length, including length 1.
 
-  Errors can be reported indicating which entries are not
-  conjugate.
+Errors can be reported indicating which entries are not
+conjugate.
 
-  This algorithm is not fast.
+This algorithm is not fast.

--- a/docs/classes/transforms/wvtransformboussinesq/isvalidconjugateklmodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/isvalidconjugateklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid conjugate WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *conjugate* WV mode number. Even if a mode number is
-  available in the DFT matrix, it does not mean it is a valid
-  WV mode number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*conjugate* WV mode number. Even if a mode number is
+available in the DFT matrix, it does not mean it is a valid
+WV mode number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformboussinesq/isvalidconjugatemodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/isvalidconjugatemodenumber.md
@@ -28,8 +28,8 @@ returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+conjugate mode number according to how the property
+conjugateDimension is set.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformboussinesq/isvalidklmodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/isvalidklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid WV mode
-  number. Even if a mode number is available in the DFT matrix,
-  it does not mean it is a valid WV mode number, e.g., it may
-  be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid WV mode
+number. Even if a mode number is available in the DFT matrix,
+it does not mean it is a valid WV mode number, e.g., it may
+be removed due to aliasing.
 
-  A valid mode number can be either primary or conjugate, and
-  thus the result is not affected by the chosen
-  conjugateDimension.
+A valid mode number can be either primary or conjugate, and
+thus the result is not affected by the chosen
+conjugateDimension.

--- a/docs/classes/transforms/wvtransformboussinesq/isvalidmodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/transforms/wvtransformboussinesq/isvalidprimaryklmodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/isvalidprimaryklmodenumber.md
@@ -27,9 +27,9 @@ return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *primary* WV mode number. Even if a mode number is available
-  in the DFT matrix, it does not mean it is a valid WV mode
-  number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*primary* WV mode number. Even if a mode number is available
+in the DFT matrix, it does not mean it is a valid WV mode
+number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformboussinesq/isvalidprimarymodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/isvalidprimarymodenumber.md
@@ -28,6 +28,6 @@ returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  non-conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+non-conjugate mode number according to how the property
+conjugateDimension is set.

--- a/docs/classes/transforms/wvtransformboussinesq/klmodenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/klmodenumberfromindex.md
@@ -27,6 +27,6 @@ return mode number from a linear index into a WV matrix
 
 ## Discussion
 
-  This function will return the mode numbers (kMode,lMode)
-  given some linear index into a WV structured matrix. Scalar
-  and column-vector inputs preserve their shape and ordering.
+This function will return the mode numbers (kMode,lMode)
+given some linear index into a WV structured matrix. Scalar
+and column-vector inputs preserve their shape and ordering.

--- a/docs/classes/transforms/wvtransformboussinesq/maskforaliasedmodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/maskforaliasedmodes.md
@@ -28,18 +28,18 @@ returns a mask with locations of modes that will alias with a quadratic multipli
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
-  modes are, assuming the 2/3 anti-aliasing rule for quadratic
-  interactions.
+Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
+modes are, assuming the 2/3 anti-aliasing rule for quadratic
+interactions.
 
-  Technically one needs only restrict to 2/3s in each
-  wavenumber direction. However, we prefer to maintain an
-  isotropic effective grid size and instead restrict to a
-  circle.
+Technically one needs only restrict to 2/3s in each
+wavenumber direction. However, we prefer to maintain an
+isotropic effective grid size and instead restrict to a
+circle.
 
-  Basic usage,
-  ```matlab
-  antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  alias with a quadratic multiplication.
+Basic usage,
+```matlab
+antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+alias with a quadratic multiplication.

--- a/docs/classes/transforms/wvtransformboussinesq/maskforconjugatefouriercoefficients.md
+++ b/docs/classes/transforms/wvtransformboussinesq/maskforconjugatefouriercoefficients.md
@@ -28,13 +28,13 @@ a mask indicate the components that are redundant conjugates
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where
-  the non-primary Hermitian conjugates are located in the DFT
-  matrix.
+Returns a 'mask' (matrices with 1s or 0s) indicating where
+the non-primary Hermitian conjugates are located in the DFT
+matrix.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
-  ```
-  will return a mask that contains 1 at the locations of the
-  modes assumed conjugate.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
+```
+will return a mask that contains 1 at the locations of the
+modes assumed conjugate.

--- a/docs/classes/transforms/wvtransformboussinesq/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/maskfornyquistmodes.md
@@ -28,13 +28,13 @@ returns a mask with locations of modes that are not fully resolved
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located in a standard FFT matrix. A direction has
-  a Nyquist coordinate only when its grid size is even.
+Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
+modes are located in a standard FFT matrix. A direction has
+a Nyquist coordinate only when its grid size is even.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForNyquistModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  are at the Nyquist frequency of the Fourier transforms.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForNyquistModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+are at the Nyquist frequency of the Fourier transforms.

--- a/docs/classes/transforms/wvtransformboussinesq/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/modenumberfromindex.md
@@ -28,5 +28,5 @@ Return mode numbers for spectral linear indices.
 
 ## Discussion
 
-  Scalar and column-vector inputs preserve their shape and ordering. Each
-  index must lie within the current spectral matrix.
+Scalar and column-vector inputs preserve their shape and ordering. Each
+index must lie within the current spectral matrix.

--- a/docs/classes/transforms/wvtransformboussinesq/na0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/na0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/nam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/nam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/nap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/nap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 3, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/placeparticlesonisopycnal.md
+++ b/docs/classes/transforms/wvtransformboussinesq/placeparticlesonisopycnal.md
@@ -28,20 +28,20 @@ places Lagrangian particles along a specified isopycnal
 
 ## Discussion
 
-  Given particle position (x,y), `zNoMotion` is used to determine the target
-  isopycnal using the no-motion density,
+Given particle position (x,y), `zNoMotion` is used to determine the target
+isopycnal using the no-motion density,
 
-  ```matlab
-  targetRho = wvt.rhoFunction(zNoMotion);
-  ```
+```matlab
+targetRho = wvt.rhoFunction(zNoMotion);
+```
 
-  and a minimization algorithm is used to find zIsopycnal such that
+and a minimization algorithm is used to find zIsopycnal such that
 
-  ```matlab
-  zIsopycnal = rho(targetRho);
-  ```
+```matlab
+zIsopycnal = rho(targetRho);
+```
 
-  where rho is the current total density field of the fluid.
+where rho is the current total density field of the fluid.
 
-  Note that the density is not necessarily monotonic, so the answer is not
-  necessarily unique.
+Note that the density is not necessarily monotonic, so the answer is not
+necessarily unique.

--- a/docs/classes/transforms/wvtransformboussinesq/primaryklmodenumberfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/primaryklmodenumberfromklmodenumber.md
@@ -28,8 +28,8 @@ takes any valid WV mode number and returns the primary mode number
 
 ## Discussion
 
-  The function first confirms that the mode numbers are valid,
-  and then converts any conjugate mode numbers to primary mode
-  numbers.
+The function first confirms that the mode numbers are valid,
+and then converts any conjugate mode numbers to primary mode
+numbers.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformboussinesq/quadraturepointsforstratifiedflow.md
+++ b/docs/classes/transforms/wvtransformboussinesq/quadraturepointsforstratifiedflow.md
@@ -23,5 +23,5 @@ return the quadrature points for a given stratification
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformboussinesq/removeallgeostrophicmotions.md
+++ b/docs/classes/transforms/wvtransformboussinesq/removeallgeostrophicmotions.md
@@ -20,9 +20,9 @@ remove all geostrophic motions
 ```
 ## Discussion
 
-  All geostrophic motions are removed by setting A0 to zero.
+All geostrophic motions are removed by setting A0 to zero.
 
-  **Note** that this does *not* remove the mean density anomaly
-  (mda) part of the solution, just the geostrophic part. Thus,
-  this function will not clear all parts of a geostrophic
-  streamfunction.
+**Note** that this does *not* remove the mean density anomaly
+(mda) part of the solution, just the geostrophic part. Thus,
+this function will not clear all parts of a geostrophic
+streamfunction.

--- a/docs/classes/transforms/wvtransformboussinesq/removeallinertialmotions.md
+++ b/docs/classes/transforms/wvtransformboussinesq/removeallinertialmotions.md
@@ -20,4 +20,4 @@ remove all inertial motions
 ```
 ## Discussion
 
-  All inertial motions are removed. Other components of the flow will remain unaffected.
+All inertial motions are removed. Other components of the flow will remain unaffected.

--- a/docs/classes/transforms/wvtransformboussinesq/removeallmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformboussinesq/removeallmeandensityanomaly.md
@@ -20,4 +20,4 @@ remove all mean density anomalies
 ```
 ## Discussion
 
-  All mean density anomalies are removed. Other components of the flow will remain unaffected.
+All mean density anomalies are removed. Other components of the flow will remain unaffected.

--- a/docs/classes/transforms/wvtransformboussinesq/removeallwaves.md
+++ b/docs/classes/transforms/wvtransformboussinesq/removeallwaves.md
@@ -16,4 +16,4 @@ removes all wave from the model, including inertial oscillations
 
 ## Discussion
 
-  Simply sets Ap and Am to zero.
+Simply sets Ap and Am to zero.

--- a/docs/classes/transforms/wvtransformboussinesq/setgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/setgeostrophicmodes.md
@@ -31,16 +31,16 @@ set amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Set the amplitude of the given geostrophic modes by
-  overwriting any existing amplitudes. The parameters are given
-  as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
-  and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
-  of those modes.
+Set the amplitude of the given geostrophic modes by
+overwriting any existing amplitudes. The parameters are given
+as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
+and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
+of those modes.
 
-  For example,
+For example,
 
-  ```matlab
-  wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
-  ```
+```matlab
+wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
+```
 
-  will add a geostrophic mode.
+will add a geostrophic mode.

--- a/docs/classes/transforms/wvtransformboussinesq/setgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformboussinesq/setgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ set a geostrophic streamfunction
 
 ## Discussion
 
-  Clears A0 by setting a geostrophic streamfunction
+Clears A0 by setting a geostrophic streamfunction
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.setGeostrophicStreamfunction(psi);
-  ```
+wvt.setGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformboussinesq/setinertialmotions.md
+++ b/docs/classes/transforms/wvtransformboussinesq/setinertialmotions.md
@@ -24,19 +24,19 @@ set inertial motions
 
 ## Discussion
 
-  % Overwrites existing inertial motions with the new values.
-  Other components of the flow will remain unaffected.
+% Overwrites existing inertial motions with the new values.
+Other components of the flow will remain unaffected.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.setInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.setInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformboussinesq/setmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformboussinesq/setmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  setMeanDensityAnomaly
 
-set inertial motions
+Set the mean-density-anomaly component.
 
 
 ---
@@ -23,19 +23,16 @@ set inertial motions
 
 ## Discussion
 
-  Overwrites existing inertial motions with the new values.
-  Other components of the flow will remain unaffected.
+Overwrite existing mean-density-anomaly coefficients with the
+projection of `eta` while preserving other flow components.
+Other components of the flow will remain unaffected.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.setMeanDensityAnomaly(eta);
+```
 
-  wvt.setInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformboussinesq/setwavemodes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/setwavemodes.md
@@ -33,4 +33,4 @@ set amplitudes of the given wave modes
 
 ## Discussion
 
-  Overwrite any existing wave modes with the given new values
+Overwrite any existing wave modes with the given new values

--- a/docs/classes/transforms/wvtransformboussinesq/throwerrorifdensityviolation.md
+++ b/docs/classes/transforms/wvtransformboussinesq/throwerrorifdensityviolation.md
@@ -16,6 +16,6 @@ checks if the proposed coefficients are a valid adiabatic re-arrangement of the 
 
 ## Discussion
 
-  Given some proposed new set of values for A0, Ap, Am, will
-  the fluid state violate our density condition? If yes, then
-  throw an error and tell the user about it.
+Given some proposed new set of values for A0, Ap, Am, will
+the fluid state violate our density condition? If yes, then
+throw an error and tell the user about it.

--- a/docs/classes/transforms/wvtransformboussinesq/transformfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ convert from DFT to WV grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a DFT grid to one on a WV grid. The WV grid will
-  respect the conditions set when this class was initialized
-  (shouldAntialias, shouldExcludeNyquist,
-  shouldExcludeConjugates).
+This function will reformat the memory layout of a data
+structure on a DFT grid to one on a WV grid. The WV grid will
+respect the conditions set when this class was initialized
+(shouldAntialias, shouldExcludeNyquist,
+shouldExcludeConjugates).
 
-  This function is not the fastest way to reformat your data.
-  If high performance is required, you should
+This function is not the fastest way to reformat your data.
+If high performance is required, you should

--- a/docs/classes/transforms/wvtransformboussinesq/transformfromspatialdomaintodftgrid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformfromspatialdomaintodftgrid.md
@@ -26,5 +26,5 @@ transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
 
 ## Discussion
 
-  Performs a Fourier transform in the x and y direction. The
-  resulting matrix is on the DFT grid.
+Performs a Fourier transform in the x and y direction. The
+resulting matrix is on the DFT grid.

--- a/docs/classes/transforms/wvtransformboussinesq/transformfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformfromwvgridtodftgrid.md
@@ -27,7 +27,7 @@ convert from a WV to DFT grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a WV grid to one on a DFT grid. If the option
-  isHalfComplex is selected, then it will not set values for
-  iL>Ny/2, which are ignored by a 'symmetric' fft.
+This function will reformat the memory layout of a data
+structure on a WV grid to one on a DFT grid. If the option
+isHalfComplex is selected, then it will not set values for
+iL>Ny/2, which are ignored by a 'symmetric' fft.

--- a/docs/classes/transforms/wvtransformboussinesq/transformtoklaxes.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtoklaxes.md
@@ -26,13 +26,12 @@ transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
 
 ## Discussion
 
+The following example takes the total energy of the wave part of
+flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
+along the mode (j) dimension.
 
-  The following example takes the total energy of the wave part of
-  flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
-  along the mode (j) dimension.
-
-  ```matlab
-  figure
-  TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
-  pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
-  ```
+```matlab
+figure
+TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
+pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
+```

--- a/docs/classes/transforms/wvtransformboussinesq/transformtoomegaaxis.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtoomegaaxis.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to omegaAxis
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformboussinesq/transformtopseudoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtopseudoradialwavenumber.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformboussinesq/transformtopseudoradialwavenumbera0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtopseudoradialwavenumbera0.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformboussinesq/transformtopseudoradialwavenumberapm.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtopseudoradialwavenumberapm.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformboussinesq/transformtoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtoradialwavenumber.md
@@ -26,18 +26,18 @@ transforms in the spectral domain from (j,kl) to (j,kRadial)
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kRadial`.
+Sums all the variance/energy in radial bins `kRadial`.
 
-  The following example takes the total energy of the geostrophic part of
-  flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
-  it with pcolor. The next plot then sums over all wavenumber, and produces
-  plots the total energy spectrum as a function of vertical mode $$j$$
-  only.
+The following example takes the total energy of the geostrophic part of
+flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
+it with pcolor. The next plot then sums over all wavenumber, and produces
+plots the total energy spectrum as a function of vertical mode $$j$$
+only.
 
-  ```matlab
-  figure
-  tiledlayout('flow')
-  Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
-  nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
-  nexttile, plot(wvt.j,sum(Ekj,2))
-  ```
+```matlab
+figure
+tiledlayout('flow')
+Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
+nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
+nexttile, plot(wvt.j,sum(Ekj,2))
+```

--- a/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgrid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgrid.md
@@ -26,5 +26,5 @@ transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
 
 ## Discussion
 
-  Performs an inverse Fourier transform to take a matrix from
-  the DFT grid back to the spatial domain.
+Performs an inverse Fourier transform to take a matrix from
+the DFT grid back to the spatial domain.

--- a/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgridatposition.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgridatposition.md
@@ -26,6 +26,6 @@ transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
 
 ## Discussion
 
-  Performs an inverse non-uniform Fourier transform to take a
-  matrix from the DFT grid back to the spatial domain at any
-  set of points (x,y).
+Performs an inverse non-uniform Fourier transform to take a
+matrix from the DFT grid back to the spatial domain at any
+set of points (x,y).

--- a/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainwithfg.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainwithfg.md
@@ -16,5 +16,5 @@ arguments
 
 ## Discussion
 self WVTransform {mustBeNonempty}
-      u_bar
-  end
+    u_bar
+end

--- a/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainwithgg.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformtospatialdomainwithgg.md
@@ -16,8 +16,8 @@ arguments
 
 ## Discussion
 self WVTransform {mustBeNonempty}
-      w_bar
-  end
-  simply changing QG0inv to PF0inv dramatically increases the
-  speed of the downstream function transformFromWVGridToDFTGrid.
-  Why?
+    w_bar
+end
+simply changing QG0inv to PF0inv dramatically increases the
+speed of the downstream function transformFromWVGridToDFTGrid.
+Why?

--- a/docs/classes/transforms/wvtransformboussinesq/transformuvwetatowavevortex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/transformuvwetatowavevortex.md
@@ -32,4 +32,5 @@ transform momentum variables $$(u,v,w,\eta)$$ to wave-vortex coefficients $$(A_+
 
 ## Discussion
 
-  This function tuned for constant stratification.
+This implementation uses the nonhydrostatic variable-stratification
+projection operators.

--- a/docs/classes/transforms/wvtransformboussinesq/ua0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/ua0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 1, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/uam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/uam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 1, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/uap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/uap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 1, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/va0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/va0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 2, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/vam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/vam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 2, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/vap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/vap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 2, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/verticalprojectionoperatorswithrigidlid.md
+++ b/docs/classes/transforms/wvtransformboussinesq/verticalprojectionoperatorswithrigidlid.md
@@ -30,5 +30,5 @@ return the normalized projection operators with prefactors
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformboussinesq/wam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/wam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 4, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/wap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/wap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 4, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformboussinesq/wavemodeverticalstructureatindex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/wavemodeverticalstructureatindex.md
@@ -27,16 +27,16 @@ Return wave vertical-structure factors at one vertical grid index.
 
 ## Discussion
 
-  For a wave coefficient matrix `Apm`, the horizontal Fourier values of
-  the corresponding $$F$$ field and the vertical derivative of the
-  corresponding $$G$$ field at `z(iZ)` are
+For a wave coefficient matrix `Apm`, the horizontal Fourier values of
+the corresponding $$F$$ field and the vertical derivative of the
+corresponding $$G$$ field at `z(iZ)` are
 
-  $$
-  \widehat F(z_{iZ}) = \sum_j F_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}},
-  \qquad
-  \partial_z\widehat G(z_{iZ}) =
-  \sum_j \partial_zG_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}}.
-  $$
+$$
+\widehat F(z_{iZ}) = \sum_j F_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}},
+\qquad
+\partial_z\widehat G(z_{iZ}) =
+\sum_j \partial_zG_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}}.
+$$
 
-  Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
-  the derivative factors are not needed.
+Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
+the derivative factors are not needed.

--- a/docs/classes/transforms/wvtransformboussinesq/wvtransformboussinesq.md
+++ b/docs/classes/transforms/wvtransformboussinesq/wvtransformboussinesq.md
@@ -9,31 +9,34 @@ mathjax: true
 
 #  WVTransformBoussinesq
 
-create a wave-vortex transform for variable stratification
+Create a nonhydrostatic wave-vortex transform for variable stratification.
 
 
 ---
 
 ## Declaration
 ```matlab
- wvt = WVTransformHydrostatic(Lxyz, Nxyz, options)
+ wvt = WVTransformBoussinesq(Lxyz,Nxyz,options)
 ```
 ## Parameters
 + `Lxyz`  length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
 + `Nxyz`  number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-+ `rho`   (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-+ `stratification`   (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-+ `latitude`  (optional) latitude of the domain (default is 33 degrees north)
-+ `rho0`  (optional) density at the surface z=0 (default is 1025 kg/m^3)
++ `options.N2Function`  function returning squared buoyancy frequency on `[-Lz,0]`
++ `options.rhoFunction`  function returning density on `[-Lz,0]`
++ `options.latitude`  latitude in the supported domain; default `33`
++ `options.shouldAntialias`  exclude quadratically aliased modes; default `true`
++ `options.rho0`  reference density in kilograms per cubic meter; default `1025`
 
 ## Returns
-+ `wvt`  a new WVTransformHydrostatic instance
++ `wvt`  new `WVTransformBoussinesq` instance
 
 ## Discussion
 
-  Creates a new instance of the WVTransformBoussinesq class
-  appropriate for disentangling nonhydrostatic waves and vortices
-  in variable stratification
+Creates a new instance of the WVTransformBoussinesq class
+appropriate for disentangling nonhydrostatic waves and vortices
+in variable stratification
 
-  You must initialization by passing *either* the density
-  profile or the stratification profile.
+Supply either `N2Function` or `rhoFunction`. The additional
+modal arrays accepted by the constructor are reconstruction
+state used by the persistence factories rather than ordinary
+user construction options.

--- a/docs/classes/transforms/wvtransformconstantstratification/a0n.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0n.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/a0t.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0t.md
@@ -9,16 +9,19 @@ mathjax: true
 
 #  A0t
 
-geostrophic coefficients time t
+zero-frequency coefficients at current time t
 
 
 ---
 
 ## Description
-Complex valued property with dimensions $$(j,kl)$$ and units of $$m$$.
+Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+`A0t` is the zero-frequency coefficient array evaluated at the current transform time. On the supported $$f$$-plane transforms, `A0` has no linear phase winding and therefore
 
-These are the *time dependent* coefficients of the geostrophic flow, denoted  $$A_0$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_0^{k\ell j}(t) = A_0^{k\ell j}(t_0).
+$$
 
-These geostrophic coefficients do not have any linear time dependence on the $$f$$-plane and thus are identical to `A0`.
+Consequently, `A0t` returns the current stored `A0` coefficients.

--- a/docs/classes/transforms/wvtransformconstantstratification/a0u.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0u.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/a0v.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0v.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/addgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/addgeostrophicmodes.md
@@ -31,4 +31,4 @@ add amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformconstantstratification/addgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/addgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ add a geostrophic streamfunction to existing geostrophic motions
 
 ## Discussion
 
-  The geostrophic streamfunction is added to the existing values in `A0`
+The geostrophic streamfunction is added to the existing values in `A0`
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.addGeostrophicStreamfunction(psi);
-  ```
+wvt.addGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformconstantstratification/addinertialmotions.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/addinertialmotions.md
@@ -24,21 +24,21 @@ add inertial motions to existing inertial motions
 
 ## Discussion
 
-  The amplitudes of the inertial part of the flow will be added
-  to the existing inertial part of the flow.
+The amplitudes of the inertial part of the flow will be added
+to the existing inertial part of the flow.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.addInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.addInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.
 
-  The new inertial motions are added to the existing inertial motions
+The new inertial motions are added to the existing inertial motions

--- a/docs/classes/transforms/wvtransformconstantstratification/addmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/addmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  addMeanDensityAnomaly
 
-add inertial motions to existing inertial motions
+Add a mean-density anomaly to the existing fluid state.
 
 
 ---
@@ -23,21 +23,16 @@ add inertial motions to existing inertial motions
 
 ## Discussion
 
-  The amplitudes of the inertial part of the flow will be added
-  to the existing inertial part of the flow.
+The supplied horizontally uniform isopycnal displacement is
+projected onto the internal mean-density-anomaly modes and
+added to their `A0` coefficients.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.addMeanDensityAnomaly(eta);
+```
 
-  wvt.addInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
-
-  The new inertial motions are added to the existing inertial motions
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformconstantstratification/addwavemodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/addwavemodes.md
@@ -33,4 +33,4 @@ add amplitudes of the given wave modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformconstantstratification/addwaveswithfrequencyspectrum.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/addwaveswithfrequencyspectrum.md
@@ -25,20 +25,20 @@ add waves with a specified frequency spectrum
 
 ## Discussion
 
-  This allows you to initialize the wave field (Ap,Am matrices)
-  with a spectrum specified in terms of vertical mode j and
-  frequency $\omega$. This allows us to initialize with a
-  Garrett-Munk spectrum, for example, using code like,
+This allows you to initialize the wave field (Ap,Am matrices)
+with a spectrum specified in terms of vertical mode j and
+frequency $\omega$. This allows us to initialize with a
+Garrett-Munk spectrum, for example, using code like,
 
-  ```matlab
-  GM = @(omega,j) E*H(j) .* B(omega);
-  ```
+```matlab
+GM = @(omega,j) E*H(j) .* B(omega);
+```
 
-  Because the model has limited resolution, there will not
-  necessarily be many modes in a given frequency band. This
-  means that the ensemble may be over a very low number of
-  realization, and thus might not converge to the requested
-  spectrum. For this reason, the option
-  shouldOnlyRandomizeOrientations may be useful. This will only
-  randomize the phases of the waves, while fixing the
-  amplitudes so that the desired spectrum will be achieved.
+Because the model has limited resolution, there will not
+necessarily be many modes in a given frequency band. This
+means that the ensemble may be over a very low number of
+realization, and thus might not converge to the requested
+spectrum. For this reason, the option
+shouldOnlyRandomizeOrientations may be useful. This will only
+randomize the phases of the waves, while fixing the
+amplitudes so that the desired spectrum will be achieved.

--- a/docs/classes/transforms/wvtransformconstantstratification/amt.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/amt.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Amt
 
-negative wave coefficients at reference time t
+negative-frequency coefficients at current time t
 
 
 ---
@@ -18,7 +18,10 @@ negative wave coefficients at reference time t
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+`Amt` is the negative-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_- e^{-i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_-^{k\ell j}(t) = A_-^{k\ell j}(t_0) e^{-i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Am`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Am`, `t`, `t0`, and modal frequency without changing `Am`.

--- a/docs/classes/transforms/wvtransformconstantstratification/apt.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/apt.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Apt
 
-positive wave coefficients at reference time t
+positive-frequency coefficients at current time t
 
 
 ---
@@ -18,7 +18,10 @@ positive wave coefficients at reference time t
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+`Apt` is the positive-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_+ e^{i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_+^{k\ell j}(t) = A_+^{k\ell j}(t_0) e^{i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Ap`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Ap`, `t`, `t0`, and modal frequency without changing `Ap`.

--- a/docs/classes/transforms/wvtransformconstantstratification/cosinetransformbackmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/cosinetransformbackmatrix.md
@@ -16,5 +16,5 @@ Discrete Cosine Transform (DCT-I) matrix
 
 ## Discussion
 
-  This matrix exactly matches CosineTransformBack. See its documentation
-  for details.
+This matrix exactly matches CosineTransformBack. See its documentation
+for details.

--- a/docs/classes/transforms/wvtransformconstantstratification/cosinetransformforwardmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/cosinetransformforwardmatrix.md
@@ -16,5 +16,5 @@ Discrete Cosine Transform (DCT-I) matrix
 
 ## Discussion
 
-  This matrix exactly matches CosineTransformForward. See its documentation
-  for details.
+This matrix exactly matches CosineTransformForward. See its documentation
+for details.

--- a/docs/classes/transforms/wvtransformconstantstratification/degreesoffreedomforcomplexmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/degreesoffreedomforcomplexmatrix.md
@@ -27,7 +27,7 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A complex valued matrix A defined on a grid of size [Nx Ny]
-  would has 2*Nx*Ny degrees-of-freedom at each grid point. In
-  the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
-  each grid point.
+A complex valued matrix A defined on a grid of size [Nx Ny]
+would has 2*Nx*Ny degrees-of-freedom at each grid point. In
+the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
+each grid point.

--- a/docs/classes/transforms/wvtransformconstantstratification/degreesoffreedomforrealmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/degreesoffreedomforrealmatrix.md
@@ -28,10 +28,10 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A real-valued matrix A defined on a grid of size [Nx Ny] has
-  Nx*Ny degrees of freedom, one at each grid point. In the
-  Fourier domain these degrees-of-freedom are more complicated,
-  because some modes are strictly real-valued (k=l=0 and
-  Nyquist), while others are complex, and there are redundant
-  Hermitian conjugates. Nyquist coordinates contribute
-  self-conjugate modes only in even-sized dimensions.
+A real-valued matrix A defined on a grid of size [Nx Ny] has
+Nx*Ny degrees of freedom, one at each grid point. In the
+Fourier domain these degrees-of-freedom are more complicated,
+because some modes are strictly real-valued (k=l=0 and
+Nyquist), while others are complex, and there are redundant
+Hermitian conjugates. Nyquist coordinates contribute
+self-conjugate modes only in even-sized dimensions.

--- a/docs/classes/transforms/wvtransformconstantstratification/diffzf.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/diffzf.md
@@ -27,6 +27,6 @@ Differentiate an F-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return a G-representation and even orders return
-  an F-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return a G-representation and even orders return
+an F-representation.

--- a/docs/classes/transforms/wvtransformconstantstratification/diffzg.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/diffzg.md
@@ -27,6 +27,6 @@ Differentiate a G-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return an F-representation and even orders return
-  a G-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return an F-representation and even orders return
+a G-representation.

--- a/docs/classes/transforms/wvtransformconstantstratification/effectivehorizontalgridresolution.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/effectivehorizontalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformconstantstratification/effectiveverticalgridresolution.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/effectiveverticalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective vertical grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformconstantstratification/fwinvmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/fwinvmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$F_w^{-1}$$
 
 ## Discussion
 
-  A matrix that transforms a vector of igw amplitudes from
-  vertical mode space to physical space.
+A matrix that transforms a vector of igw amplitudes from
+vertical mode space to physical space.

--- a/docs/classes/transforms/wvtransformconstantstratification/fwmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/fwmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$F_w$$
 
 ## Discussion
 
-  A matrix that transforms a vector in physical space to IGW
-  mode space
+A matrix that transforms a vector in physical space to IGW
+mode space

--- a/docs/classes/transforms/wvtransformconstantstratification/gwinvmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/gwinvmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$G_w^{-1}$$
 
 ## Discussion
 
-  A matrix that transforms a vector of igw amplitudes from
-  vertical mode space to physical space.
+A matrix that transforms a vector of igw amplitudes from
+vertical mode space to physical space.

--- a/docs/classes/transforms/wvtransformconstantstratification/gwmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/gwmatrix.md
@@ -23,5 +23,5 @@ transformation matrix $$G_w$$
 
 ## Discussion
 
-  A matrix that transforms a vector in physical space to IGW
-  mode space
+A matrix that transforms a vector in physical space to IGW
+mode space

--- a/docs/classes/transforms/wvtransformconstantstratification/index.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/index.md
@@ -11,7 +11,7 @@ nav_order: 4
 
 #  WVTransformConstantStratification
 
-A class for disentangling waves and vortices in constant stratification
+Decompose constant-stratification flow into wave and geostrophic components.
 
 
 ---
@@ -28,8 +28,14 @@ and the constant buoyancy frequency.
 
 ```matlab
 N0 = 3*2*pi/3600;
-wvt = WVTransformConstantStratification([100e3, 100e3, 4000],[64, 64, 65],N0=N0,latitude=30);
+wvt = WVTransformConstantStratification([100e3,100e3,4000],[64,64,65],N0=N0,latitude=30);
+wvtHydrostatic = WVTransformConstantStratification([100e3,100e3,4000],[64,64,65],N0=N0,latitude=30,isHydrostatic=true);
 ```
+
+The Stable transform state is stored in [`Ap`](/classes/transforms/wvtransform/ap.html),
+[`Am`](/classes/transforms/wvtransform/am.html), and
+[`A0`](/classes/transforms/wvtransform/a0.html). Their current-time
+views are `Apt`, `Amt`, and `A0t`.
 
 
 
@@ -37,7 +43,12 @@ wvt = WVTransformConstantStratification([100e3, 100e3, 4000],[64, 64, 65],N0=N0,
 
 ## Topics
 + Initialization
-  + [`WVTransformConstantStratification`](/classes/transforms/wvtransformconstantstratification/wvtransformconstantstratification.html) create a wave-vortex transform for constant stratification
+  + [`WVTransformConstantStratification`](/classes/transforms/wvtransformconstantstratification/wvtransformconstantstratification.html) Create a wave-vortex transform for constant stratification.
++ Wave-vortex coefficients
+  + At current time
+    + [`A0t`](/classes/transforms/wvtransformconstantstratification/a0t.html) zero-frequency coefficients at current time t
+    + [`Amt`](/classes/transforms/wvtransformconstantstratification/amt.html) negative-frequency coefficients at current time t
+    + [`Apt`](/classes/transforms/wvtransformconstantstratification/apt.html) positive-frequency coefficients at current time t
 + Primary flow components
   + [`geostrophicComponent`](/classes/transforms/wvtransformconstantstratification/geostrophiccomponent.html) returns the geostrophic flow component
   + [`waveComponent`](/classes/transforms/wvtransformconstantstratification/wavecomponent.html) returns the internal gravity wave flow component
@@ -71,10 +82,10 @@ wvt = WVTransformConstantStratification([100e3, 100e3, 4000],[64, 64, 65],N0=N0,
     + [`removeAllInertialMotions`](/classes/transforms/wvtransformconstantstratification/removeallinertialmotions.html) remove all inertial motions
     + [`setInertialMotions`](/classes/transforms/wvtransformconstantstratification/setinertialmotions.html) set inertial motions
   + Mean density anomaly
-    + [`addMeanDensityAnomaly`](/classes/transforms/wvtransformconstantstratification/addmeandensityanomaly.html) add inertial motions to existing inertial motions
-    + [`initWithMeanDensityAnomaly`](/classes/transforms/wvtransformconstantstratification/initwithmeandensityanomaly.html) initialize with inertial motions
+    + [`addMeanDensityAnomaly`](/classes/transforms/wvtransformconstantstratification/addmeandensityanomaly.html) Add a mean-density anomaly to the existing fluid state.
+    + [`initWithMeanDensityAnomaly`](/classes/transforms/wvtransformconstantstratification/initwithmeandensityanomaly.html) Initialize the fluid state with a mean-density anomaly.
     + [`removeAllMeanDensityAnomaly`](/classes/transforms/wvtransformconstantstratification/removeallmeandensityanomaly.html) remove all mean density anomalies
-    + [`setMeanDensityAnomaly`](/classes/transforms/wvtransformconstantstratification/setmeandensityanomaly.html) set inertial motions
+    + [`setMeanDensityAnomaly`](/classes/transforms/wvtransformconstantstratification/setmeandensityanomaly.html) Set the mean-density-anomaly component.
 + Operations
   + Transformations
     + [`FwInvMatrix`](/classes/transforms/wvtransformconstantstratification/fwinvmatrix.html) transformation matrix $$F_w^{-1}$$
@@ -98,28 +109,8 @@ wvt = WVTransformConstantStratification([100e3, 100e3, 4000],[64, 64, 65],N0=N0,
     + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
     + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
     + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
-+ Wave-vortex sorting matrix
-  + inverse components ($$S^{-1}$$)
-    + [`A0N`](/classes/transforms/wvtransformconstantstratification/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
-    + [`A0U`](/classes/transforms/wvtransformconstantstratification/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
-    + [`A0V`](/classes/transforms/wvtransformconstantstratification/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
-  + components of $$S$$
-    + [`NA0`](/classes/transforms/wvtransformconstantstratification/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
-    + [`NAm`](/classes/transforms/wvtransformconstantstratification/nam.html)
-    + [`NAp`](/classes/transforms/wvtransformconstantstratification/nap.html)
-    + [`UA0`](/classes/transforms/wvtransformconstantstratification/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
-    + [`UAm`](/classes/transforms/wvtransformconstantstratification/uam.html)
-    + [`UAp`](/classes/transforms/wvtransformconstantstratification/uap.html)
-    + [`VA0`](/classes/transforms/wvtransformconstantstratification/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
-    + [`VAm`](/classes/transforms/wvtransformconstantstratification/vam.html)
-    + [`VAp`](/classes/transforms/wvtransformconstantstratification/vap.html)
-    + [`WAm`](/classes/transforms/wvtransformconstantstratification/wam.html)
-    + [`WAp`](/classes/transforms/wvtransformconstantstratification/wap.html)
-+ Wave-vortex coefficients
-  + at time $$t$$
-    + [`A0t`](/classes/transforms/wvtransformconstantstratification/a0t.html) geostrophic coefficients time t
-    + [`Amt`](/classes/transforms/wvtransformconstantstratification/amt.html) negative wave coefficients at reference time t
-    + [`Apt`](/classes/transforms/wvtransformconstantstratification/apt.html) positive wave coefficients at reference time t
++ Developer
+  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformconstantstratification/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + Domain Attributes
   + [`f`](/classes/transforms/wvtransformconstantstratification/f.html) Coriolis parameter
   + [`g`](/classes/transforms/wvtransformconstantstratification/g.html) gravity of Earth
@@ -215,8 +206,6 @@ wvt = WVTransformConstantStratification([100e3, 100e3, 4000],[64, 64, 65],N0=N0,
   + [`maskForNyquistModes`](/classes/transforms/wvtransformconstantstratification/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
 + Utilities
   + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformconstantstratification/placeparticlesonisopycnal.html) places Lagrangian particles along a specified isopycnal
-+ Developer
-  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformconstantstratification/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + State Variables
   + [`psi`](/classes/transforms/wvtransformconstantstratification/psi.html) geostrophic streamfunction
   + [`ssu`](/classes/transforms/wvtransformconstantstratification/ssu.html) x-component of the fluid velocity at the surface
@@ -334,6 +323,29 @@ wvt = WVTransformConstantStratification([100e3, 100e3, 4000],[64, 64, 65],N0=N0,
   + [`zeta_x`](/classes/transforms/wvtransformconstantstratification/zeta_x.html) x-component component of relative vorticity
   + [`zeta_y`](/classes/transforms/wvtransformconstantstratification/zeta_y.html) y-component component of relative vorticity
   + [`zeta_z`](/classes/transforms/wvtransformconstantstratification/zeta_z.html) vertical component of relative vorticity
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Wave-vortex coefficients
++ Stratification
++ Developer
+  + Projection coefficients
+    + [`A0N`](/classes/transforms/wvtransformconstantstratification/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
+    + [`A0U`](/classes/transforms/wvtransformconstantstratification/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
+    + [`A0V`](/classes/transforms/wvtransformconstantstratification/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
+  + Reconstruction coefficients
+    + [`NA0`](/classes/transforms/wvtransformconstantstratification/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
+    + [`NAm`](/classes/transforms/wvtransformconstantstratification/nam.html)
+    + [`NAp`](/classes/transforms/wvtransformconstantstratification/nap.html)
+    + [`UA0`](/classes/transforms/wvtransformconstantstratification/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
+    + [`UAm`](/classes/transforms/wvtransformconstantstratification/uam.html)
+    + [`UAp`](/classes/transforms/wvtransformconstantstratification/uap.html)
+    + [`VA0`](/classes/transforms/wvtransformconstantstratification/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
+    + [`VAm`](/classes/transforms/wvtransformconstantstratification/vam.html)
+    + [`VAp`](/classes/transforms/wvtransformconstantstratification/vap.html)
+    + [`WAm`](/classes/transforms/wvtransformconstantstratification/wam.html)
+    + [`WAp`](/classes/transforms/wvtransformconstantstratification/wap.html)
 
 
 ---

--- a/docs/classes/transforms/wvtransformconstantstratification/indexfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/indexfromklmodenumber.md
@@ -27,8 +27,8 @@ return the linear index into k_wv and l_wv from a mode number
 
 ## Discussion
 
-  This function will return the linear index into the (k_wv,l_wv) arrays,
-  given the mode numbers (kMode,lMode). Note that this will
-  *not* normalize the mode to the primary mode number, but will
-  throw an error. Scalar and column-vector inputs preserve their
-  shape and ordering.
+This function will return the linear index into the (k_wv,l_wv) arrays,
+given the mode numbers (kMode,lMode). Note that this will
+*not* normalize the mode to the primary mode number, but will
+throw an error. Scalar and column-vector inputs preserve their
+shape and ordering.

--- a/docs/classes/transforms/wvtransformconstantstratification/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/indexfrommodenumber.md
@@ -28,7 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 
 ## Discussion
 
-  This function will return the linear index in a spectral
-  matrix given a mode number. Scalar and column-vector inputs preserve
-  their shape and ordering; conjugate mode numbers map to their primary
-  coefficient.
+This function will return the linear index in a spectral
+matrix given a mode number. Scalar and column-vector inputs preserve
+their shape and ordering; conjugate mode numbers map to their primary
+coefficient.

--- a/docs/classes/transforms/wvtransformconstantstratification/indicesfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/indicesfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ indices to convert from DFT to WV grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a DFT grid to one on a WV grid.
-  The resulting WV grid will respect the conditions set when
-  this class was initialized (shouldAntialias,
-  shouldExcludeNyquist, shouldExcludeConjugates).
+This function returns indices to quickly reformat the memory
+layout of a data structure on a DFT grid to one on a WV grid.
+The resulting WV grid will respect the conditions set when
+this class was initialized (shouldAntialias,
+shouldExcludeNyquist, shouldExcludeConjugates).
 
-  This function is should generally be faster than the function
-  transformFromDFTGridToWVGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromDFTGridToWVGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformconstantstratification/indicesfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/indicesfromwvgridtodftgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformconstantstratification/indicesfromwvgridtofftwgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/indicesfromwvgridtofftwgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformconstantstratification/initwaveswithfrequencyspectrum.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/initwaveswithfrequencyspectrum.md
@@ -25,20 +25,20 @@ initialize with waves of a specified frequency spectrum
 
 ## Discussion
 
-  This allows you to initialize the wave field (Ap,Am matrices)
-  with a spectrum specified in terms of vertical mode j and
-  frequency $\omega$. This allows us to initialize with a
-  Garrett-Munk spectrum, for example, using code like,
+This allows you to initialize the wave field (Ap,Am matrices)
+with a spectrum specified in terms of vertical mode j and
+frequency $\omega$. This allows us to initialize with a
+Garrett-Munk spectrum, for example, using code like,
 
-  ```matlab
-  GM = @(omega,j) E*H(j) .* B(omega);
-  ```
+```matlab
+GM = @(omega,j) E*H(j) .* B(omega);
+```
 
-  Because the model has limited resolution, there will not
-  necessarily be many modes in a given frequency band. This
-  means that the ensemble may be over a very low number of
-  realization, and thus might not converge to the requested
-  spectrum. For this reason, the option
-  shouldOnlyRandomizeOrientations may be useful. This will only
-  randomize the phases of the waves, while fixing the
-  amplitudes so that the desired spectrum will be achieved.
+Because the model has limited resolution, there will not
+necessarily be many modes in a given frequency band. This
+means that the ensemble may be over a very low number of
+realization, and thus might not converge to the requested
+spectrum. For this reason, the option
+shouldOnlyRandomizeOrientations may be useful. This will only
+randomize the phases of the waves, while fixing the
+amplitudes so that the desired spectrum will be achieved.

--- a/docs/classes/transforms/wvtransformconstantstratification/initwithalternativespectrum.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/initwithalternativespectrum.md
@@ -25,4 +25,4 @@ initialize with an alternative formulation of the GM spectrum in the wavenumber 
 
 ## Discussion
 
-  This only initializes the wave components, A0 is left untouched.
+This only initializes the wave components, A0 is left untouched.

--- a/docs/classes/transforms/wvtransformconstantstratification/initwithgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/initwithgeostrophicstreamfunction.md
@@ -23,42 +23,42 @@ initialize with a geostrophic streamfunction
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets the geostrophic
-  streamfunction.
+Clears variables Ap,Am,A0 and then sets the geostrophic
+streamfunction.
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.initWithGeostrophicStreamfunction(psi);
-  ```
+wvt.initWithGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformconstantstratification/initwithinertialmotions.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/initwithinertialmotions.md
@@ -24,18 +24,18 @@ initialize with inertial motions
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets inertial motions.
+Clears variables Ap,Am,A0 and then sets inertial motions.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.initWithInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.initWithInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformconstantstratification/initwithmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/initwithmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  initWithMeanDensityAnomaly
 
-initialize with inertial motions
+Initialize the fluid state with a mean-density anomaly.
 
 
 ---
@@ -23,18 +23,16 @@ initialize with inertial motions
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets inertial motions.
+Clear `Ap`, `Am`, and `A0`, then project the supplied
+horizontally uniform isopycnal displacement onto the internal
+mean-density-anomaly modes.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.initWithMeanDensityAnomaly(eta);
+```
 
-  wvt.initWithInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformconstantstratification/initwithwavemodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/initwithwavemodes.md
@@ -33,8 +33,8 @@ initialize with the given wave modes
 
 ## Discussion
 
-  $$
-  sin(k*x+l*y)*F_j*sin(omega*t + phi)
-  $$
+$$
+sin(k*x+l*y)*F_j*sin(omega*t + phi)
+$$
 
-  Clears variables Ap,Am,A0 and then sets the given wave modes.
+Clears variables Ap,Am,A0 and then sets the given wave modes.

--- a/docs/classes/transforms/wvtransformconstantstratification/intzf.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/intzf.md
@@ -27,8 +27,8 @@ Return the first antiderivative of an F-representation.
 
 ## Discussion
 
-  The result is the antiderivative representable in G space. The
-  barotropic F mode is removed because it has no corresponding G mode, so
-  the result vanishes at both vertical boundaries. `u` may use the gridded
-  layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
-  array preserves that layout.
+The result is the antiderivative representable in G space. The
+barotropic F mode is removed because it has no corresponding G mode, so
+the result vanishes at both vertical boundaries. `u` may use the gridded
+layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
+array preserves that layout.

--- a/docs/classes/transforms/wvtransformconstantstratification/intzg.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/intzg.md
@@ -27,7 +27,7 @@ Return the bottom-zero first antiderivative of a G-representation.
 
 ## Discussion
 
-  A G-to-F antiderivative is defined up to an additive constant. This
-  method selects the representative that vanishes at the bottom boundary.
-  `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
-  `[Nz N]`; the returned array preserves that layout.
+A G-to-F antiderivative is defined up to an additive constant. This
+method selects the representative that vanishes at the bottom boundary.
+`w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
+`[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformconstantstratification/isdensityinvalidrange.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/isdensityinvalidrange.md
@@ -23,4 +23,4 @@ checks if the density field is a valid adiabatic re-arrangement of the base stat
 
 ## Discussion
 
-  This is probably best re-defined as a dynamical variable.
+This is probably best re-defined as a dynamical variable.

--- a/docs/classes/transforms/wvtransformconstantstratification/ishermitian.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/ishermitian.md
@@ -27,12 +27,12 @@ Check if the matrix is Hermitian. Report errors.
 
 ## Discussion
 
-  This algorithm checks whether any 2 or 3 dimensional matrix
-  is Hermitian in the first two dimensions, following the data
-  structure of a 2D DFT algorithm. The third dimension can be
-  any length, including length 1.
+This algorithm checks whether any 2 or 3 dimensional matrix
+is Hermitian in the first two dimensions, following the data
+structure of a 2D DFT algorithm. The third dimension can be
+any length, including length 1.
 
-  Errors can be reported indicating which entries are not
-  conjugate.
+Errors can be reported indicating which entries are not
+conjugate.
 
-  This algorithm is not fast.
+This algorithm is not fast.

--- a/docs/classes/transforms/wvtransformconstantstratification/isvalidconjugateklmodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/isvalidconjugateklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid conjugate WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *conjugate* WV mode number. Even if a mode number is
-  available in the DFT matrix, it does not mean it is a valid
-  WV mode number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*conjugate* WV mode number. Even if a mode number is
+available in the DFT matrix, it does not mean it is a valid
+WV mode number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformconstantstratification/isvalidconjugatemodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/isvalidconjugatemodenumber.md
@@ -28,8 +28,8 @@ returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+conjugate mode number according to how the property
+conjugateDimension is set.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformconstantstratification/isvalidklmodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/isvalidklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid WV mode
-  number. Even if a mode number is available in the DFT matrix,
-  it does not mean it is a valid WV mode number, e.g., it may
-  be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid WV mode
+number. Even if a mode number is available in the DFT matrix,
+it does not mean it is a valid WV mode number, e.g., it may
+be removed due to aliasing.
 
-  A valid mode number can be either primary or conjugate, and
-  thus the result is not affected by the chosen
-  conjugateDimension.
+A valid mode number can be either primary or conjugate, and
+thus the result is not affected by the chosen
+conjugateDimension.

--- a/docs/classes/transforms/wvtransformconstantstratification/isvalidmodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/transforms/wvtransformconstantstratification/isvalidprimaryklmodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/isvalidprimaryklmodenumber.md
@@ -27,9 +27,9 @@ return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *primary* WV mode number. Even if a mode number is available
-  in the DFT matrix, it does not mean it is a valid WV mode
-  number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*primary* WV mode number. Even if a mode number is available
+in the DFT matrix, it does not mean it is a valid WV mode
+number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformconstantstratification/isvalidprimarymodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/isvalidprimarymodenumber.md
@@ -28,6 +28,6 @@ returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  non-conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+non-conjugate mode number according to how the property
+conjugateDimension is set.

--- a/docs/classes/transforms/wvtransformconstantstratification/klmodenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/klmodenumberfromindex.md
@@ -27,6 +27,6 @@ return mode number from a linear index into a WV matrix
 
 ## Discussion
 
-  This function will return the mode numbers (kMode,lMode)
-  given some linear index into a WV structured matrix. Scalar
-  and column-vector inputs preserve their shape and ordering.
+This function will return the mode numbers (kMode,lMode)
+given some linear index into a WV structured matrix. Scalar
+and column-vector inputs preserve their shape and ordering.

--- a/docs/classes/transforms/wvtransformconstantstratification/maskforaliasedmodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/maskforaliasedmodes.md
@@ -28,18 +28,18 @@ returns a mask with locations of modes that will alias with a quadratic multipli
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
-  modes are, assuming the 2/3 anti-aliasing rule for quadratic
-  interactions.
+Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
+modes are, assuming the 2/3 anti-aliasing rule for quadratic
+interactions.
 
-  Technically one needs only restrict to 2/3s in each
-  wavenumber direction. However, we prefer to maintain an
-  isotropic effective grid size and instead restrict to a
-  circle.
+Technically one needs only restrict to 2/3s in each
+wavenumber direction. However, we prefer to maintain an
+isotropic effective grid size and instead restrict to a
+circle.
 
-  Basic usage,
-  ```matlab
-  antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  alias with a quadratic multiplication.
+Basic usage,
+```matlab
+antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+alias with a quadratic multiplication.

--- a/docs/classes/transforms/wvtransformconstantstratification/maskforconjugatefouriercoefficients.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/maskforconjugatefouriercoefficients.md
@@ -28,13 +28,13 @@ a mask indicate the components that are redundant conjugates
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where
-  the non-primary Hermitian conjugates are located in the DFT
-  matrix.
+Returns a 'mask' (matrices with 1s or 0s) indicating where
+the non-primary Hermitian conjugates are located in the DFT
+matrix.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
-  ```
-  will return a mask that contains 1 at the locations of the
-  modes assumed conjugate.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
+```
+will return a mask that contains 1 at the locations of the
+modes assumed conjugate.

--- a/docs/classes/transforms/wvtransformconstantstratification/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/maskfornyquistmodes.md
@@ -28,13 +28,13 @@ returns a mask with locations of modes that are not fully resolved
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located in a standard FFT matrix. A direction has
-  a Nyquist coordinate only when its grid size is even.
+Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
+modes are located in a standard FFT matrix. A direction has
+a Nyquist coordinate only when its grid size is even.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForNyquistModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  are at the Nyquist frequency of the Fourier transforms.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForNyquistModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+are at the Nyquist frequency of the Fourier transforms.

--- a/docs/classes/transforms/wvtransformconstantstratification/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/modenumberfromindex.md
@@ -28,5 +28,5 @@ Return mode numbers for spectral linear indices.
 
 ## Discussion
 
-  Scalar and column-vector inputs preserve their shape and ordering. Each
-  index must lie within the current spectral matrix.
+Scalar and column-vector inputs preserve their shape and ordering. Each
+index must lie within the current spectral matrix.

--- a/docs/classes/transforms/wvtransformconstantstratification/na0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/na0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/nam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/nam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/nap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/nap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 3, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/placeparticlesonisopycnal.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/placeparticlesonisopycnal.md
@@ -28,20 +28,20 @@ places Lagrangian particles along a specified isopycnal
 
 ## Discussion
 
-  Given particle position (x,y), `zNoMotion` is used to determine the target
-  isopycnal using the no-motion density,
+Given particle position (x,y), `zNoMotion` is used to determine the target
+isopycnal using the no-motion density,
 
-  ```matlab
-  targetRho = wvt.rhoFunction(zNoMotion);
-  ```
+```matlab
+targetRho = wvt.rhoFunction(zNoMotion);
+```
 
-  and a minimization algorithm is used to find zIsopycnal such that
+and a minimization algorithm is used to find zIsopycnal such that
 
-  ```matlab
-  zIsopycnal = rho(targetRho);
-  ```
+```matlab
+zIsopycnal = rho(targetRho);
+```
 
-  where rho is the current total density field of the fluid.
+where rho is the current total density field of the fluid.
 
-  Note that the density is not necessarily monotonic, so the answer is not
-  necessarily unique.
+Note that the density is not necessarily monotonic, so the answer is not
+necessarily unique.

--- a/docs/classes/transforms/wvtransformconstantstratification/primaryklmodenumberfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/primaryklmodenumberfromklmodenumber.md
@@ -28,8 +28,8 @@ takes any valid WV mode number and returns the primary mode number
 
 ## Discussion
 
-  The function first confirms that the mode numbers are valid,
-  and then converts any conjugate mode numbers to primary mode
-  numbers.
+The function first confirms that the mode numbers are valid,
+and then converts any conjugate mode numbers to primary mode
+numbers.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformconstantstratification/quadraturepointsforstratifiedflow.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/quadraturepointsforstratifiedflow.md
@@ -23,5 +23,5 @@ return the quadrature points for a given stratification
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformconstantstratification/removeallgeostrophicmotions.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/removeallgeostrophicmotions.md
@@ -20,9 +20,9 @@ remove all geostrophic motions
 ```
 ## Discussion
 
-  All geostrophic motions are removed by setting A0 to zero.
+All geostrophic motions are removed by setting A0 to zero.
 
-  **Note** that this does *not* remove the mean density anomaly
-  (mda) part of the solution, just the geostrophic part. Thus,
-  this function will not clear all parts of a geostrophic
-  streamfunction.
+**Note** that this does *not* remove the mean density anomaly
+(mda) part of the solution, just the geostrophic part. Thus,
+this function will not clear all parts of a geostrophic
+streamfunction.

--- a/docs/classes/transforms/wvtransformconstantstratification/removeallinertialmotions.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/removeallinertialmotions.md
@@ -20,4 +20,4 @@ remove all inertial motions
 ```
 ## Discussion
 
-  All inertial motions are removed. Other components of the flow will remain unaffected.
+All inertial motions are removed. Other components of the flow will remain unaffected.

--- a/docs/classes/transforms/wvtransformconstantstratification/removeallmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/removeallmeandensityanomaly.md
@@ -20,4 +20,4 @@ remove all mean density anomalies
 ```
 ## Discussion
 
-  All mean density anomalies are removed. Other components of the flow will remain unaffected.
+All mean density anomalies are removed. Other components of the flow will remain unaffected.

--- a/docs/classes/transforms/wvtransformconstantstratification/removeallwaves.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/removeallwaves.md
@@ -16,4 +16,4 @@ removes all wave from the model, including inertial oscillations
 
 ## Discussion
 
-  Simply sets Ap and Am to zero.
+Simply sets Ap and Am to zero.

--- a/docs/classes/transforms/wvtransformconstantstratification/setgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/setgeostrophicmodes.md
@@ -31,16 +31,16 @@ set amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Set the amplitude of the given geostrophic modes by
-  overwriting any existing amplitudes. The parameters are given
-  as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
-  and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
-  of those modes.
+Set the amplitude of the given geostrophic modes by
+overwriting any existing amplitudes. The parameters are given
+as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
+and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
+of those modes.
 
-  For example,
+For example,
 
-  ```matlab
-  wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
-  ```
+```matlab
+wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
+```
 
-  will add a geostrophic mode.
+will add a geostrophic mode.

--- a/docs/classes/transforms/wvtransformconstantstratification/setgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/setgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ set a geostrophic streamfunction
 
 ## Discussion
 
-  Clears A0 by setting a geostrophic streamfunction
+Clears A0 by setting a geostrophic streamfunction
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.setGeostrophicStreamfunction(psi);
-  ```
+wvt.setGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformconstantstratification/setinertialmotions.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/setinertialmotions.md
@@ -24,19 +24,19 @@ set inertial motions
 
 ## Discussion
 
-  % Overwrites existing inertial motions with the new values.
-  Other components of the flow will remain unaffected.
+% Overwrites existing inertial motions with the new values.
+Other components of the flow will remain unaffected.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.setInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.setInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformconstantstratification/setmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/setmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  setMeanDensityAnomaly
 
-set inertial motions
+Set the mean-density-anomaly component.
 
 
 ---
@@ -23,19 +23,16 @@ set inertial motions
 
 ## Discussion
 
-  Overwrites existing inertial motions with the new values.
-  Other components of the flow will remain unaffected.
+Overwrite existing mean-density-anomaly coefficients with the
+projection of `eta` while preserving other flow components.
+Other components of the flow will remain unaffected.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.setMeanDensityAnomaly(eta);
+```
 
-  wvt.setInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformconstantstratification/setwavemodes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/setwavemodes.md
@@ -33,4 +33,4 @@ set amplitudes of the given wave modes
 
 ## Discussion
 
-  Overwrite any existing wave modes with the given new values
+Overwrite any existing wave modes with the given new values

--- a/docs/classes/transforms/wvtransformconstantstratification/sinetransformbackmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/sinetransformbackmatrix.md
@@ -16,5 +16,5 @@ CosineTransformBackMatrix  Discrete Cosine Transform (DCT-I) matrix
 
 ## Discussion
 
-  This matrix exactly matches CosineTransformBack. See its documentation
-  for details.
+This matrix exactly matches CosineTransformBack. See its documentation
+for details.

--- a/docs/classes/transforms/wvtransformconstantstratification/sinetransformforwardmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/sinetransformforwardmatrix.md
@@ -16,5 +16,5 @@ CosineTransformForwardMatrix  Discrete Cosine Transform (DCT-I) matrix
 
 ## Discussion
 
-  This matrix exactly matches CosineTransformForward. See its documentation
-  for details.
+This matrix exactly matches CosineTransformForward. See its documentation
+for details.

--- a/docs/classes/transforms/wvtransformconstantstratification/throwerrorifdensityviolation.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/throwerrorifdensityviolation.md
@@ -16,6 +16,6 @@ checks if the proposed coefficients are a valid adiabatic re-arrangement of the 
 
 ## Discussion
 
-  Given some proposed new set of values for A0, Ap, Am, will
-  the fluid state violate our density condition? If yes, then
-  throw an error and tell the user about it.
+Given some proposed new set of values for A0, Ap, Am, will
+the fluid state violate our density condition? If yes, then
+throw an error and tell the user about it.

--- a/docs/classes/transforms/wvtransformconstantstratification/transformfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ convert from DFT to WV grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a DFT grid to one on a WV grid. The WV grid will
-  respect the conditions set when this class was initialized
-  (shouldAntialias, shouldExcludeNyquist,
-  shouldExcludeConjugates).
+This function will reformat the memory layout of a data
+structure on a DFT grid to one on a WV grid. The WV grid will
+respect the conditions set when this class was initialized
+(shouldAntialias, shouldExcludeNyquist,
+shouldExcludeConjugates).
 
-  This function is not the fastest way to reformat your data.
-  If high performance is required, you should
+This function is not the fastest way to reformat your data.
+If high performance is required, you should

--- a/docs/classes/transforms/wvtransformconstantstratification/transformfromspatialdomaintodftgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformfromspatialdomaintodftgrid.md
@@ -26,5 +26,5 @@ transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
 
 ## Discussion
 
-  Performs a Fourier transform in the x and y direction. The
-  resulting matrix is on the DFT grid.
+Performs a Fourier transform in the x and y direction. The
+resulting matrix is on the DFT grid.

--- a/docs/classes/transforms/wvtransformconstantstratification/transformfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformfromwvgridtodftgrid.md
@@ -27,7 +27,7 @@ convert from a WV to DFT grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a WV grid to one on a DFT grid. If the option
-  isHalfComplex is selected, then it will not set values for
-  iL>Ny/2, which are ignored by a 'symmetric' fft.
+This function will reformat the memory layout of a data
+structure on a WV grid to one on a DFT grid. If the option
+isHalfComplex is selected, then it will not set values for
+iL>Ny/2, which are ignored by a 'symmetric' fft.

--- a/docs/classes/transforms/wvtransformconstantstratification/transformtoklaxes.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformtoklaxes.md
@@ -26,13 +26,12 @@ transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
 
 ## Discussion
 
+The following example takes the total energy of the wave part of
+flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
+along the mode (j) dimension.
 
-  The following example takes the total energy of the wave part of
-  flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
-  along the mode (j) dimension.
-
-  ```matlab
-  figure
-  TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
-  pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
-  ```
+```matlab
+figure
+TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
+pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
+```

--- a/docs/classes/transforms/wvtransformconstantstratification/transformtoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformtoradialwavenumber.md
@@ -26,18 +26,18 @@ transforms in the spectral domain from (j,kl) to (j,kRadial)
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kRadial`.
+Sums all the variance/energy in radial bins `kRadial`.
 
-  The following example takes the total energy of the geostrophic part of
-  flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
-  it with pcolor. The next plot then sums over all wavenumber, and produces
-  plots the total energy spectrum as a function of vertical mode $$j$$
-  only.
+The following example takes the total energy of the geostrophic part of
+flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
+it with pcolor. The next plot then sums over all wavenumber, and produces
+plots the total energy spectrum as a function of vertical mode $$j$$
+only.
 
-  ```matlab
-  figure
-  tiledlayout('flow')
-  Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
-  nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
-  nexttile, plot(wvt.j,sum(Ekj,2))
-  ```
+```matlab
+figure
+tiledlayout('flow')
+Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
+nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
+nexttile, plot(wvt.j,sum(Ekj,2))
+```

--- a/docs/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgrid.md
@@ -26,5 +26,5 @@ transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
 
 ## Discussion
 
-  Performs an inverse Fourier transform to take a matrix from
-  the DFT grid back to the spatial domain.
+Performs an inverse Fourier transform to take a matrix from
+the DFT grid back to the spatial domain.

--- a/docs/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgridatposition.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgridatposition.md
@@ -26,6 +26,6 @@ transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
 
 ## Discussion
 
-  Performs an inverse non-uniform Fourier transform to take a
-  matrix from the DFT grid back to the spatial domain at any
-  set of points (x,y).
+Performs an inverse non-uniform Fourier transform to take a
+matrix from the DFT grid back to the spatial domain at any
+set of points (x,y).

--- a/docs/classes/transforms/wvtransformconstantstratification/transformuvwetatowavevortex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/transformuvwetatowavevortex.md
@@ -32,4 +32,4 @@ transform momentum variables $$(u,v,w,\eta)$$ to wave-vortex coefficients $$(A_+
 
 ## Discussion
 
-  This function tuned for constant stratification.
+This implementation uses the constant-stratification projection operators.

--- a/docs/classes/transforms/wvtransformconstantstratification/ua0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/ua0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 1, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/uam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/uam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 1, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/uap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/uap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 1, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/va0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/va0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 2, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/vam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/vam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 2, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/vap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/vap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 2, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/verticalprojectionoperatorswithrigidlid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/verticalprojectionoperatorswithrigidlid.md
@@ -30,5 +30,5 @@ return the normalized projection operators with prefactors
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformconstantstratification/wam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 4, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/wap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 4, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformconstantstratification/wavemodeverticalstructureatindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wavemodeverticalstructureatindex.md
@@ -27,16 +27,16 @@ Return wave vertical-structure factors at one vertical grid index.
 
 ## Discussion
 
-  For a wave coefficient matrix `Apm`, the horizontal Fourier values of
-  the corresponding $$F$$ field and the vertical derivative of the
-  corresponding $$G$$ field at `z(iZ)` are
+For a wave coefficient matrix `Apm`, the horizontal Fourier values of
+the corresponding $$F$$ field and the vertical derivative of the
+corresponding $$G$$ field at `z(iZ)` are
 
-  $$
-  \widehat F(z_{iZ}) = \sum_j F_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}},
-  \qquad
-  \partial_z\widehat G(z_{iZ}) =
-  \sum_j \partial_zG_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}}.
-  $$
+$$
+\widehat F(z_{iZ}) = \sum_j F_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}},
+\qquad
+\partial_z\widehat G(z_{iZ}) =
+\sum_j \partial_zG_{j\boldsymbol{k}}(z_{iZ})A_{j\boldsymbol{k}}.
+$$
 
-  Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
-  the derivative factors are not needed.
+Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
+the derivative factors are not needed.

--- a/docs/classes/transforms/wvtransformconstantstratification/wvtransformconstantstratification.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wvtransformconstantstratification.md
@@ -9,31 +9,34 @@ mathjax: true
 
 #  WVTransformConstantStratification
 
-create a wave-vortex transform for constant stratification
+Create a wave-vortex transform for constant stratification.
 
 
 ---
 
 ## Declaration
 ```matlab
- wvt = WVTransformHydrostatic(Lxyz, Nxyz, options)
+ wvt = WVTransformConstantStratification(Lxyz,Nxyz,options)
 ```
 ## Parameters
 + `Lxyz`  length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
 + `Nxyz`  number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-+ `rho`   (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-+ `stratification`   (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-+ `latitude`  (optional) latitude of the domain (default is 33 degrees north)
-+ `rho0`  (optional) density at the surface z=0 (default is 1025 kg/m^3)
++ `options.N0`  constant buoyancy frequency in radians per second; default `5.2e-3`
++ `options.isHydrostatic`  use hydrostatic dynamics; default `false`
++ `options.latitude`  latitude in the supported domain; default `33`
++ `options.shouldAntialias`  exclude quadratically aliased modes; default `true`
++ `options.rho0`  reference density in kilograms per cubic meter; default `1025`
 
 ## Returns
-+ `wvt`  a new WVTransformHydrostatic instance
++ `wvt`  new `WVTransformConstantStratification` instance
 
 ## Discussion
 
-  Creates a new instance of the WVTransformConstantStratification
-  class appropriate for disentangling waves and vortices in
-  constant stratification.
+Creates a new instance of the WVTransformConstantStratification
+class appropriate for disentangling waves and vortices in
+constant stratification.
 
-  You must initialization by passing *either* the density
-  profile or the stratification profile.
+Set `isHydrostatic=true` for hydrostatic dynamics; the default
+is the nonhydrostatic transform. `N0` is the constant buoyancy
+frequency. The remaining geometry options configure the
+rotating, doubly periodic domain.

--- a/docs/classes/transforms/wvtransformhydrostatic/a0n.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0n.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/a0t.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0t.md
@@ -9,16 +9,19 @@ mathjax: true
 
 #  A0t
 
-geostrophic coefficients time t
+zero-frequency coefficients at current time t
 
 
 ---
 
 ## Description
-Complex valued property with dimensions $$(j,kl)$$ and units of $$m$$.
+Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+`A0t` is the zero-frequency coefficient array evaluated at the current transform time. On the supported $$f$$-plane transforms, `A0` has no linear phase winding and therefore
 
-These are the *time dependent* coefficients of the geostrophic flow, denoted  $$A_0$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_0^{k\ell j}(t) = A_0^{k\ell j}(t_0).
+$$
 
-These geostrophic coefficients do not have any linear time dependence on the $$f$$-plane and thus are identical to `A0`.
+Consequently, `A0t` returns the current stored `A0` coefficients.

--- a/docs/classes/transforms/wvtransformhydrostatic/a0u.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0u.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/a0v.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0v.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/addgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/addgeostrophicmodes.md
@@ -31,4 +31,4 @@ add amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformhydrostatic/addgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/addgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ add a geostrophic streamfunction to existing geostrophic motions
 
 ## Discussion
 
-  The geostrophic streamfunction is added to the existing values in `A0`
+The geostrophic streamfunction is added to the existing values in `A0`
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.addGeostrophicStreamfunction(psi);
-  ```
+wvt.addGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformhydrostatic/addinertialmotions.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/addinertialmotions.md
@@ -24,21 +24,21 @@ add inertial motions to existing inertial motions
 
 ## Discussion
 
-  The amplitudes of the inertial part of the flow will be added
-  to the existing inertial part of the flow.
+The amplitudes of the inertial part of the flow will be added
+to the existing inertial part of the flow.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.addInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.addInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.
 
-  The new inertial motions are added to the existing inertial motions
+The new inertial motions are added to the existing inertial motions

--- a/docs/classes/transforms/wvtransformhydrostatic/addmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/addmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  addMeanDensityAnomaly
 
-add inertial motions to existing inertial motions
+Add a mean-density anomaly to the existing fluid state.
 
 
 ---
@@ -23,21 +23,16 @@ add inertial motions to existing inertial motions
 
 ## Discussion
 
-  The amplitudes of the inertial part of the flow will be added
-  to the existing inertial part of the flow.
+The supplied horizontally uniform isopycnal displacement is
+projected onto the internal mean-density-anomaly modes and
+added to their `A0` coefficients.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.addMeanDensityAnomaly(eta);
+```
 
-  wvt.addInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
-
-  The new inertial motions are added to the existing inertial motions
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformhydrostatic/addwavemodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/addwavemodes.md
@@ -33,4 +33,4 @@ add amplitudes of the given wave modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformhydrostatic/addwaveswithfrequencyspectrum.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/addwaveswithfrequencyspectrum.md
@@ -25,20 +25,20 @@ add waves with a specified frequency spectrum
 
 ## Discussion
 
-  This allows you to initialize the wave field (Ap,Am matrices)
-  with a spectrum specified in terms of vertical mode j and
-  frequency $\omega$. This allows us to initialize with a
-  Garrett-Munk spectrum, for example, using code like,
+This allows you to initialize the wave field (Ap,Am matrices)
+with a spectrum specified in terms of vertical mode j and
+frequency $\omega$. This allows us to initialize with a
+Garrett-Munk spectrum, for example, using code like,
 
-  ```matlab
-  GM = @(omega,j) E*H(j) .* B(omega);
-  ```
+```matlab
+GM = @(omega,j) E*H(j) .* B(omega);
+```
 
-  Because the model has limited resolution, there will not
-  necessarily be many modes in a given frequency band. This
-  means that the ensemble may be over a very low number of
-  realization, and thus might not converge to the requested
-  spectrum. For this reason, the option
-  shouldOnlyRandomizeOrientations may be useful. This will only
-  randomize the phases of the waves, while fixing the
-  amplitudes so that the desired spectrum will be achieved.
+Because the model has limited resolution, there will not
+necessarily be many modes in a given frequency band. This
+means that the ensemble may be over a very low number of
+realization, and thus might not converge to the requested
+spectrum. For this reason, the option
+shouldOnlyRandomizeOrientations may be useful. This will only
+randomize the phases of the waves, while fixing the
+amplitudes so that the desired spectrum will be achieved.

--- a/docs/classes/transforms/wvtransformhydrostatic/amt.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/amt.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Amt
 
-negative wave coefficients at reference time t
+negative-frequency coefficients at current time t
 
 
 ---
@@ -18,7 +18,10 @@ negative wave coefficients at reference time t
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+`Amt` is the negative-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_- e^{-i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_-^{k\ell j}(t) = A_-^{k\ell j}(t_0) e^{-i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Am`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Am`, `t`, `t0`, and modal frequency without changing `Am`.

--- a/docs/classes/transforms/wvtransformhydrostatic/apt.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/apt.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Apt
 
-positive wave coefficients at reference time t
+positive-frequency coefficients at current time t
 
 
 ---
@@ -18,7 +18,10 @@ positive wave coefficients at reference time t
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+`Apt` is the positive-frequency coefficient array evaluated at the current transform time:
 
-These are the *time dependent* coefficients of the internal gravity wave and inertial oscillation portion of the flow, denoted  $$A_+ e^{i \omega t} $$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_+^{k\ell j}(t) = A_+^{k\ell j}(t_0) e^{i\omega^{k\ell j}(t-t_0)}.
+$$
 
-Unlike `Ap`, these coefficients do not have their phases wound to time $$t_0$$ (`t0`), and **do** change for linear dynamics.
+It is computed from the stored `Ap`, `t`, `t0`, and modal frequency without changing `Ap`.

--- a/docs/classes/transforms/wvtransformhydrostatic/degreesoffreedomforcomplexmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/degreesoffreedomforcomplexmatrix.md
@@ -27,7 +27,7 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A complex valued matrix A defined on a grid of size [Nx Ny]
-  would has 2*Nx*Ny degrees-of-freedom at each grid point. In
-  the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
-  each grid point.
+A complex valued matrix A defined on a grid of size [Nx Ny]
+would has 2*Nx*Ny degrees-of-freedom at each grid point. In
+the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
+each grid point.

--- a/docs/classes/transforms/wvtransformhydrostatic/degreesoffreedomforrealmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/degreesoffreedomforrealmatrix.md
@@ -28,10 +28,10 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A real-valued matrix A defined on a grid of size [Nx Ny] has
-  Nx*Ny degrees of freedom, one at each grid point. In the
-  Fourier domain these degrees-of-freedom are more complicated,
-  because some modes are strictly real-valued (k=l=0 and
-  Nyquist), while others are complex, and there are redundant
-  Hermitian conjugates. Nyquist coordinates contribute
-  self-conjugate modes only in even-sized dimensions.
+A real-valued matrix A defined on a grid of size [Nx Ny] has
+Nx*Ny degrees of freedom, one at each grid point. In the
+Fourier domain these degrees-of-freedom are more complicated,
+because some modes are strictly real-valued (k=l=0 and
+Nyquist), while others are complex, and there are redundant
+Hermitian conjugates. Nyquist coordinates contribute
+self-conjugate modes only in even-sized dimensions.

--- a/docs/classes/transforms/wvtransformhydrostatic/diffzf.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/diffzf.md
@@ -27,6 +27,6 @@ Differentiate an F-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return a G-representation and even orders return
-  an F-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return a G-representation and even orders return
+an F-representation.

--- a/docs/classes/transforms/wvtransformhydrostatic/diffzg.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/diffzg.md
@@ -27,6 +27,6 @@ Differentiate a G-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return an F-representation and even orders return
-  a G-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return an F-representation and even orders return
+a G-representation.

--- a/docs/classes/transforms/wvtransformhydrostatic/effectivehorizontalgridresolution.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/effectivehorizontalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformhydrostatic/effectiveverticalgridresolution.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/effectiveverticalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective vertical grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformhydrostatic/index.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/index.md
@@ -11,7 +11,7 @@ nav_order: 3
 
 #  WVTransformHydrostatic
 
-A class for disentangling hydrostatic waves and vortices in variable stratification
+Decompose hydrostatic variable-stratification flow into wave and geostrophic components.
 
 
 ---
@@ -22,16 +22,21 @@ A class for disentangling hydrostatic waves and vortices in variable stratificat
 
 ## Overview
 
-To initialization an instance of the WVTransformHydrostatic class you
-must specific the domain size, the number of grid points and *either*
+To initialize `WVTransformHydrostatic`, specify the domain size, the
+number of grid points, and either
 the density profile or the stratification profile.
 
 ```matlab
 N0 = 3*2*pi/3600;
 L_gm = 1300;
 N2 = @(z) N0*N0*exp(2*z/L_gm);
-wvt = WVTransformHydrostatic([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30);
+wvt = WVTransformHydrostatic([100e3,100e3,4000],[64,64,65],N2Function=N2,latitude=30);
 ```
+
+The Stable transform state is stored in [`Ap`](/classes/transforms/wvtransform/ap.html),
+[`Am`](/classes/transforms/wvtransform/am.html), and
+[`A0`](/classes/transforms/wvtransform/a0.html). Their current-time
+views are `Apt`, `Amt`, and `A0t`.
 
 
 
@@ -39,7 +44,12 @@ wvt = WVTransformHydrostatic([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=3
 
 ## Topics
 + Initialization
-  + [`WVTransformHydrostatic`](/classes/transforms/wvtransformhydrostatic/wvtransformhydrostatic.html) create a wave-vortex transform for variable stratification
+  + [`WVTransformHydrostatic`](/classes/transforms/wvtransformhydrostatic/wvtransformhydrostatic.html) Create a hydrostatic wave-vortex transform for variable stratification.
++ Wave-vortex coefficients
+  + At current time
+    + [`A0t`](/classes/transforms/wvtransformhydrostatic/a0t.html) zero-frequency coefficients at current time t
+    + [`Amt`](/classes/transforms/wvtransformhydrostatic/amt.html) negative-frequency coefficients at current time t
+    + [`Apt`](/classes/transforms/wvtransformhydrostatic/apt.html) positive-frequency coefficients at current time t
 + Primary flow components
   + [`geostrophicComponent`](/classes/transforms/wvtransformhydrostatic/geostrophiccomponent.html) returns the geostrophic flow component
   + [`waveComponent`](/classes/transforms/wvtransformhydrostatic/wavecomponent.html) returns the internal gravity wave flow component
@@ -73,10 +83,10 @@ wvt = WVTransformHydrostatic([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=3
     + [`removeAllInertialMotions`](/classes/transforms/wvtransformhydrostatic/removeallinertialmotions.html) remove all inertial motions
     + [`setInertialMotions`](/classes/transforms/wvtransformhydrostatic/setinertialmotions.html) set inertial motions
   + Mean density anomaly
-    + [`addMeanDensityAnomaly`](/classes/transforms/wvtransformhydrostatic/addmeandensityanomaly.html) add inertial motions to existing inertial motions
-    + [`initWithMeanDensityAnomaly`](/classes/transforms/wvtransformhydrostatic/initwithmeandensityanomaly.html) initialize with inertial motions
+    + [`addMeanDensityAnomaly`](/classes/transforms/wvtransformhydrostatic/addmeandensityanomaly.html) Add a mean-density anomaly to the existing fluid state.
+    + [`initWithMeanDensityAnomaly`](/classes/transforms/wvtransformhydrostatic/initwithmeandensityanomaly.html) Initialize the fluid state with a mean-density anomaly.
     + [`removeAllMeanDensityAnomaly`](/classes/transforms/wvtransformhydrostatic/removeallmeandensityanomaly.html) remove all mean density anomalies
-    + [`setMeanDensityAnomaly`](/classes/transforms/wvtransformhydrostatic/setmeandensityanomaly.html) set inertial motions
+    + [`setMeanDensityAnomaly`](/classes/transforms/wvtransformhydrostatic/setmeandensityanomaly.html) Set the mean-density-anomaly component.
 + Operations
   + Calculus
     + [`diffZF`](/classes/transforms/wvtransformhydrostatic/diffzf.html) Differentiate an F-grid field with respect to z.
@@ -99,28 +109,8 @@ wvt = WVTransformHydrostatic([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=3
     + [`transformToPseudoRadialWavenumberApm`](/classes/transforms/wvtransformhydrostatic/transformtopseudoradialwavenumberapm.html) transforms in the from (j,kRadial) to kPseudoRadial
     + [`transformToRadialWavenumber`](/classes/transforms/wvtransformhydrostatic/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
     + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformhydrostatic/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
-+ Wave-vortex sorting matrix
-  + inverse components ($$S^{-1}$$)
-    + [`A0N`](/classes/transforms/wvtransformhydrostatic/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
-    + [`A0U`](/classes/transforms/wvtransformhydrostatic/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
-    + [`A0V`](/classes/transforms/wvtransformhydrostatic/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
-  + components of $$S$$
-    + [`NA0`](/classes/transforms/wvtransformhydrostatic/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
-    + [`NAm`](/classes/transforms/wvtransformhydrostatic/nam.html)
-    + [`NAp`](/classes/transforms/wvtransformhydrostatic/nap.html)
-    + [`UA0`](/classes/transforms/wvtransformhydrostatic/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
-    + [`UAm`](/classes/transforms/wvtransformhydrostatic/uam.html)
-    + [`UAp`](/classes/transforms/wvtransformhydrostatic/uap.html)
-    + [`VA0`](/classes/transforms/wvtransformhydrostatic/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
-    + [`VAm`](/classes/transforms/wvtransformhydrostatic/vam.html)
-    + [`VAp`](/classes/transforms/wvtransformhydrostatic/vap.html)
-    + [`WAm`](/classes/transforms/wvtransformhydrostatic/wam.html)
-    + [`WAp`](/classes/transforms/wvtransformhydrostatic/wap.html)
-+ Wave-vortex coefficients
-  + at time $$t$$
-    + [`A0t`](/classes/transforms/wvtransformhydrostatic/a0t.html) geostrophic coefficients time t
-    + [`Amt`](/classes/transforms/wvtransformhydrostatic/amt.html) negative wave coefficients at reference time t
-    + [`Apt`](/classes/transforms/wvtransformhydrostatic/apt.html) positive wave coefficients at reference time t
++ Developer
+  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformhydrostatic/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + Domain Attributes
   + [`f`](/classes/transforms/wvtransformhydrostatic/f.html) Coriolis parameter
   + [`g`](/classes/transforms/wvtransformhydrostatic/g.html) gravity of Earth
@@ -216,8 +206,6 @@ wvt = WVTransformHydrostatic([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=3
   + [`maskForNyquistModes`](/classes/transforms/wvtransformhydrostatic/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
 + Utilities
   + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformhydrostatic/placeparticlesonisopycnal.html) places Lagrangian particles along a specified isopycnal
-+ Developer
-  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformhydrostatic/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + State Variables
   + [`psi`](/classes/transforms/wvtransformhydrostatic/psi.html) geostrophic streamfunction
   + [`ssu`](/classes/transforms/wvtransformhydrostatic/ssu.html) x-component of the fluid velocity at the surface
@@ -329,6 +317,29 @@ wvt = WVTransformHydrostatic([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=3
   + [`zeta_x`](/classes/transforms/wvtransformhydrostatic/zeta_x.html) x-component component of relative vorticity
   + [`zeta_y`](/classes/transforms/wvtransformhydrostatic/zeta_y.html) y-component component of relative vorticity
   + [`zeta_z`](/classes/transforms/wvtransformhydrostatic/zeta_z.html) vertical component of relative vorticity
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Wave-vortex coefficients
++ Stratification
++ Developer
+  + Projection coefficients
+    + [`A0N`](/classes/transforms/wvtransformhydrostatic/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
+    + [`A0U`](/classes/transforms/wvtransformhydrostatic/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
+    + [`A0V`](/classes/transforms/wvtransformhydrostatic/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
+  + Reconstruction coefficients
+    + [`NA0`](/classes/transforms/wvtransformhydrostatic/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
+    + [`NAm`](/classes/transforms/wvtransformhydrostatic/nam.html)
+    + [`NAp`](/classes/transforms/wvtransformhydrostatic/nap.html)
+    + [`UA0`](/classes/transforms/wvtransformhydrostatic/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
+    + [`UAm`](/classes/transforms/wvtransformhydrostatic/uam.html)
+    + [`UAp`](/classes/transforms/wvtransformhydrostatic/uap.html)
+    + [`VA0`](/classes/transforms/wvtransformhydrostatic/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
+    + [`VAm`](/classes/transforms/wvtransformhydrostatic/vam.html)
+    + [`VAp`](/classes/transforms/wvtransformhydrostatic/vap.html)
+    + [`WAm`](/classes/transforms/wvtransformhydrostatic/wam.html)
+    + [`WAp`](/classes/transforms/wvtransformhydrostatic/wap.html)
 
 
 ---

--- a/docs/classes/transforms/wvtransformhydrostatic/indexfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/indexfromklmodenumber.md
@@ -27,8 +27,8 @@ return the linear index into k_wv and l_wv from a mode number
 
 ## Discussion
 
-  This function will return the linear index into the (k_wv,l_wv) arrays,
-  given the mode numbers (kMode,lMode). Note that this will
-  *not* normalize the mode to the primary mode number, but will
-  throw an error. Scalar and column-vector inputs preserve their
-  shape and ordering.
+This function will return the linear index into the (k_wv,l_wv) arrays,
+given the mode numbers (kMode,lMode). Note that this will
+*not* normalize the mode to the primary mode number, but will
+throw an error. Scalar and column-vector inputs preserve their
+shape and ordering.

--- a/docs/classes/transforms/wvtransformhydrostatic/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/indexfrommodenumber.md
@@ -28,7 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 
 ## Discussion
 
-  This function will return the linear index in a spectral
-  matrix given a mode number. Scalar and column-vector inputs preserve
-  their shape and ordering; conjugate mode numbers map to their primary
-  coefficient.
+This function will return the linear index in a spectral
+matrix given a mode number. Scalar and column-vector inputs preserve
+their shape and ordering; conjugate mode numbers map to their primary
+coefficient.

--- a/docs/classes/transforms/wvtransformhydrostatic/indicesfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/indicesfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ indices to convert from DFT to WV grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a DFT grid to one on a WV grid.
-  The resulting WV grid will respect the conditions set when
-  this class was initialized (shouldAntialias,
-  shouldExcludeNyquist, shouldExcludeConjugates).
+This function returns indices to quickly reformat the memory
+layout of a data structure on a DFT grid to one on a WV grid.
+The resulting WV grid will respect the conditions set when
+this class was initialized (shouldAntialias,
+shouldExcludeNyquist, shouldExcludeConjugates).
 
-  This function is should generally be faster than the function
-  transformFromDFTGridToWVGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromDFTGridToWVGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformhydrostatic/indicesfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/indicesfromwvgridtodftgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformhydrostatic/indicesfromwvgridtofftwgrid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/indicesfromwvgridtofftwgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformhydrostatic/initwaveswithfrequencyspectrum.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/initwaveswithfrequencyspectrum.md
@@ -25,20 +25,20 @@ initialize with waves of a specified frequency spectrum
 
 ## Discussion
 
-  This allows you to initialize the wave field (Ap,Am matrices)
-  with a spectrum specified in terms of vertical mode j and
-  frequency $\omega$. This allows us to initialize with a
-  Garrett-Munk spectrum, for example, using code like,
+This allows you to initialize the wave field (Ap,Am matrices)
+with a spectrum specified in terms of vertical mode j and
+frequency $\omega$. This allows us to initialize with a
+Garrett-Munk spectrum, for example, using code like,
 
-  ```matlab
-  GM = @(omega,j) E*H(j) .* B(omega);
-  ```
+```matlab
+GM = @(omega,j) E*H(j) .* B(omega);
+```
 
-  Because the model has limited resolution, there will not
-  necessarily be many modes in a given frequency band. This
-  means that the ensemble may be over a very low number of
-  realization, and thus might not converge to the requested
-  spectrum. For this reason, the option
-  shouldOnlyRandomizeOrientations may be useful. This will only
-  randomize the phases of the waves, while fixing the
-  amplitudes so that the desired spectrum will be achieved.
+Because the model has limited resolution, there will not
+necessarily be many modes in a given frequency band. This
+means that the ensemble may be over a very low number of
+realization, and thus might not converge to the requested
+spectrum. For this reason, the option
+shouldOnlyRandomizeOrientations may be useful. This will only
+randomize the phases of the waves, while fixing the
+amplitudes so that the desired spectrum will be achieved.

--- a/docs/classes/transforms/wvtransformhydrostatic/initwithalternativespectrum.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/initwithalternativespectrum.md
@@ -25,4 +25,4 @@ initialize with an alternative formulation of the GM spectrum in the wavenumber 
 
 ## Discussion
 
-  This only initializes the wave components, A0 is left untouched.
+This only initializes the wave components, A0 is left untouched.

--- a/docs/classes/transforms/wvtransformhydrostatic/initwithgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/initwithgeostrophicstreamfunction.md
@@ -23,42 +23,42 @@ initialize with a geostrophic streamfunction
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets the geostrophic
-  streamfunction.
+Clears variables Ap,Am,A0 and then sets the geostrophic
+streamfunction.
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.initWithGeostrophicStreamfunction(psi);
-  ```
+wvt.initWithGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformhydrostatic/initwithinertialmotions.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/initwithinertialmotions.md
@@ -24,18 +24,18 @@ initialize with inertial motions
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets inertial motions.
+Clears variables Ap,Am,A0 and then sets inertial motions.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.initWithInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.initWithInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformhydrostatic/initwithmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/initwithmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  initWithMeanDensityAnomaly
 
-initialize with inertial motions
+Initialize the fluid state with a mean-density anomaly.
 
 
 ---
@@ -23,18 +23,16 @@ initialize with inertial motions
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets inertial motions.
+Clear `Ap`, `Am`, and `A0`, then project the supplied
+horizontally uniform isopycnal displacement onto the internal
+mean-density-anomaly modes.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.initWithMeanDensityAnomaly(eta);
+```
 
-  wvt.initWithInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformhydrostatic/initwithwavemodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/initwithwavemodes.md
@@ -33,8 +33,8 @@ initialize with the given wave modes
 
 ## Discussion
 
-  $$
-  sin(k*x+l*y)*F_j*sin(omega*t + phi)
-  $$
+$$
+sin(k*x+l*y)*F_j*sin(omega*t + phi)
+$$
 
-  Clears variables Ap,Am,A0 and then sets the given wave modes.
+Clears variables Ap,Am,A0 and then sets the given wave modes.

--- a/docs/classes/transforms/wvtransformhydrostatic/intzf.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/intzf.md
@@ -27,8 +27,8 @@ Return the first antiderivative of an F-representation.
 
 ## Discussion
 
-  The result is the antiderivative representable in G space. The
-  barotropic F mode is removed because it has no corresponding G mode, so
-  the result vanishes at both vertical boundaries. `u` may use the gridded
-  layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
-  array preserves that layout.
+The result is the antiderivative representable in G space. The
+barotropic F mode is removed because it has no corresponding G mode, so
+the result vanishes at both vertical boundaries. `u` may use the gridded
+layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
+array preserves that layout.

--- a/docs/classes/transforms/wvtransformhydrostatic/intzg.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/intzg.md
@@ -27,7 +27,7 @@ Return the bottom-zero first antiderivative of a G-representation.
 
 ## Discussion
 
-  A G-to-F antiderivative is defined up to an additive constant. This
-  method selects the representative that vanishes at the bottom boundary.
-  `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
-  `[Nz N]`; the returned array preserves that layout.
+A G-to-F antiderivative is defined up to an additive constant. This
+method selects the representative that vanishes at the bottom boundary.
+`w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
+`[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformhydrostatic/isdensityinvalidrange.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/isdensityinvalidrange.md
@@ -23,4 +23,4 @@ checks if the density field is a valid adiabatic re-arrangement of the base stat
 
 ## Discussion
 
-  This is probably best re-defined as a dynamical variable.
+This is probably best re-defined as a dynamical variable.

--- a/docs/classes/transforms/wvtransformhydrostatic/ishermitian.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/ishermitian.md
@@ -27,12 +27,12 @@ Check if the matrix is Hermitian. Report errors.
 
 ## Discussion
 
-  This algorithm checks whether any 2 or 3 dimensional matrix
-  is Hermitian in the first two dimensions, following the data
-  structure of a 2D DFT algorithm. The third dimension can be
-  any length, including length 1.
+This algorithm checks whether any 2 or 3 dimensional matrix
+is Hermitian in the first two dimensions, following the data
+structure of a 2D DFT algorithm. The third dimension can be
+any length, including length 1.
 
-  Errors can be reported indicating which entries are not
-  conjugate.
+Errors can be reported indicating which entries are not
+conjugate.
 
-  This algorithm is not fast.
+This algorithm is not fast.

--- a/docs/classes/transforms/wvtransformhydrostatic/isvalidconjugateklmodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/isvalidconjugateklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid conjugate WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *conjugate* WV mode number. Even if a mode number is
-  available in the DFT matrix, it does not mean it is a valid
-  WV mode number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*conjugate* WV mode number. Even if a mode number is
+available in the DFT matrix, it does not mean it is a valid
+WV mode number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformhydrostatic/isvalidconjugatemodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/isvalidconjugatemodenumber.md
@@ -28,8 +28,8 @@ returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+conjugate mode number according to how the property
+conjugateDimension is set.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformhydrostatic/isvalidklmodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/isvalidklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid WV mode
-  number. Even if a mode number is available in the DFT matrix,
-  it does not mean it is a valid WV mode number, e.g., it may
-  be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid WV mode
+number. Even if a mode number is available in the DFT matrix,
+it does not mean it is a valid WV mode number, e.g., it may
+be removed due to aliasing.
 
-  A valid mode number can be either primary or conjugate, and
-  thus the result is not affected by the chosen
-  conjugateDimension.
+A valid mode number can be either primary or conjugate, and
+thus the result is not affected by the chosen
+conjugateDimension.

--- a/docs/classes/transforms/wvtransformhydrostatic/isvalidmodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/transforms/wvtransformhydrostatic/isvalidprimaryklmodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/isvalidprimaryklmodenumber.md
@@ -27,9 +27,9 @@ return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *primary* WV mode number. Even if a mode number is available
-  in the DFT matrix, it does not mean it is a valid WV mode
-  number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*primary* WV mode number. Even if a mode number is available
+in the DFT matrix, it does not mean it is a valid WV mode
+number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformhydrostatic/isvalidprimarymodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/isvalidprimarymodenumber.md
@@ -28,6 +28,6 @@ returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  non-conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+non-conjugate mode number according to how the property
+conjugateDimension is set.

--- a/docs/classes/transforms/wvtransformhydrostatic/klmodenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/klmodenumberfromindex.md
@@ -27,6 +27,6 @@ return mode number from a linear index into a WV matrix
 
 ## Discussion
 
-  This function will return the mode numbers (kMode,lMode)
-  given some linear index into a WV structured matrix. Scalar
-  and column-vector inputs preserve their shape and ordering.
+This function will return the mode numbers (kMode,lMode)
+given some linear index into a WV structured matrix. Scalar
+and column-vector inputs preserve their shape and ordering.

--- a/docs/classes/transforms/wvtransformhydrostatic/maskforaliasedmodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/maskforaliasedmodes.md
@@ -28,18 +28,18 @@ returns a mask with locations of modes that will alias with a quadratic multipli
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
-  modes are, assuming the 2/3 anti-aliasing rule for quadratic
-  interactions.
+Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
+modes are, assuming the 2/3 anti-aliasing rule for quadratic
+interactions.
 
-  Technically one needs only restrict to 2/3s in each
-  wavenumber direction. However, we prefer to maintain an
-  isotropic effective grid size and instead restrict to a
-  circle.
+Technically one needs only restrict to 2/3s in each
+wavenumber direction. However, we prefer to maintain an
+isotropic effective grid size and instead restrict to a
+circle.
 
-  Basic usage,
-  ```matlab
-  antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  alias with a quadratic multiplication.
+Basic usage,
+```matlab
+antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+alias with a quadratic multiplication.

--- a/docs/classes/transforms/wvtransformhydrostatic/maskforconjugatefouriercoefficients.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/maskforconjugatefouriercoefficients.md
@@ -28,13 +28,13 @@ a mask indicate the components that are redundant conjugates
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where
-  the non-primary Hermitian conjugates are located in the DFT
-  matrix.
+Returns a 'mask' (matrices with 1s or 0s) indicating where
+the non-primary Hermitian conjugates are located in the DFT
+matrix.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
-  ```
-  will return a mask that contains 1 at the locations of the
-  modes assumed conjugate.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
+```
+will return a mask that contains 1 at the locations of the
+modes assumed conjugate.

--- a/docs/classes/transforms/wvtransformhydrostatic/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/maskfornyquistmodes.md
@@ -28,13 +28,13 @@ returns a mask with locations of modes that are not fully resolved
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located in a standard FFT matrix. A direction has
-  a Nyquist coordinate only when its grid size is even.
+Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
+modes are located in a standard FFT matrix. A direction has
+a Nyquist coordinate only when its grid size is even.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForNyquistModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  are at the Nyquist frequency of the Fourier transforms.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForNyquistModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+are at the Nyquist frequency of the Fourier transforms.

--- a/docs/classes/transforms/wvtransformhydrostatic/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/modenumberfromindex.md
@@ -28,5 +28,5 @@ Return mode numbers for spectral linear indices.
 
 ## Discussion
 
-  Scalar and column-vector inputs preserve their shape and ordering. Each
-  index must lie within the current spectral matrix.
+Scalar and column-vector inputs preserve their shape and ordering. Each
+index must lie within the current spectral matrix.

--- a/docs/classes/transforms/wvtransformhydrostatic/na0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/na0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/nam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/nam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/nap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/nap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 3, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/placeparticlesonisopycnal.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/placeparticlesonisopycnal.md
@@ -28,20 +28,20 @@ places Lagrangian particles along a specified isopycnal
 
 ## Discussion
 
-  Given particle position (x,y), `zNoMotion` is used to determine the target
-  isopycnal using the no-motion density,
+Given particle position (x,y), `zNoMotion` is used to determine the target
+isopycnal using the no-motion density,
 
-  ```matlab
-  targetRho = wvt.rhoFunction(zNoMotion);
-  ```
+```matlab
+targetRho = wvt.rhoFunction(zNoMotion);
+```
 
-  and a minimization algorithm is used to find zIsopycnal such that
+and a minimization algorithm is used to find zIsopycnal such that
 
-  ```matlab
-  zIsopycnal = rho(targetRho);
-  ```
+```matlab
+zIsopycnal = rho(targetRho);
+```
 
-  where rho is the current total density field of the fluid.
+where rho is the current total density field of the fluid.
 
-  Note that the density is not necessarily monotonic, so the answer is not
-  necessarily unique.
+Note that the density is not necessarily monotonic, so the answer is not
+necessarily unique.

--- a/docs/classes/transforms/wvtransformhydrostatic/primaryklmodenumberfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/primaryklmodenumberfromklmodenumber.md
@@ -28,8 +28,8 @@ takes any valid WV mode number and returns the primary mode number
 
 ## Discussion
 
-  The function first confirms that the mode numbers are valid,
-  and then converts any conjugate mode numbers to primary mode
-  numbers.
+The function first confirms that the mode numbers are valid,
+and then converts any conjugate mode numbers to primary mode
+numbers.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformhydrostatic/quadraturepointsforstratifiedflow.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/quadraturepointsforstratifiedflow.md
@@ -23,5 +23,5 @@ return the quadrature points for a given stratification
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformhydrostatic/removeallgeostrophicmotions.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/removeallgeostrophicmotions.md
@@ -20,9 +20,9 @@ remove all geostrophic motions
 ```
 ## Discussion
 
-  All geostrophic motions are removed by setting A0 to zero.
+All geostrophic motions are removed by setting A0 to zero.
 
-  **Note** that this does *not* remove the mean density anomaly
-  (mda) part of the solution, just the geostrophic part. Thus,
-  this function will not clear all parts of a geostrophic
-  streamfunction.
+**Note** that this does *not* remove the mean density anomaly
+(mda) part of the solution, just the geostrophic part. Thus,
+this function will not clear all parts of a geostrophic
+streamfunction.

--- a/docs/classes/transforms/wvtransformhydrostatic/removeallinertialmotions.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/removeallinertialmotions.md
@@ -20,4 +20,4 @@ remove all inertial motions
 ```
 ## Discussion
 
-  All inertial motions are removed. Other components of the flow will remain unaffected.
+All inertial motions are removed. Other components of the flow will remain unaffected.

--- a/docs/classes/transforms/wvtransformhydrostatic/removeallmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/removeallmeandensityanomaly.md
@@ -20,4 +20,4 @@ remove all mean density anomalies
 ```
 ## Discussion
 
-  All mean density anomalies are removed. Other components of the flow will remain unaffected.
+All mean density anomalies are removed. Other components of the flow will remain unaffected.

--- a/docs/classes/transforms/wvtransformhydrostatic/removeallwaves.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/removeallwaves.md
@@ -16,4 +16,4 @@ removes all wave from the model, including inertial oscillations
 
 ## Discussion
 
-  Simply sets Ap and Am to zero.
+Simply sets Ap and Am to zero.

--- a/docs/classes/transforms/wvtransformhydrostatic/setgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/setgeostrophicmodes.md
@@ -31,16 +31,16 @@ set amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Set the amplitude of the given geostrophic modes by
-  overwriting any existing amplitudes. The parameters are given
-  as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
-  and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
-  of those modes.
+Set the amplitude of the given geostrophic modes by
+overwriting any existing amplitudes. The parameters are given
+as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
+and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
+of those modes.
 
-  For example,
+For example,
 
-  ```matlab
-  wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
-  ```
+```matlab
+wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
+```
 
-  will add a geostrophic mode.
+will add a geostrophic mode.

--- a/docs/classes/transforms/wvtransformhydrostatic/setgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/setgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ set a geostrophic streamfunction
 
 ## Discussion
 
-  Clears A0 by setting a geostrophic streamfunction
+Clears A0 by setting a geostrophic streamfunction
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.setGeostrophicStreamfunction(psi);
-  ```
+wvt.setGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformhydrostatic/setinertialmotions.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/setinertialmotions.md
@@ -24,19 +24,19 @@ set inertial motions
 
 ## Discussion
 
-  % Overwrites existing inertial motions with the new values.
-  Other components of the flow will remain unaffected.
+% Overwrites existing inertial motions with the new values.
+Other components of the flow will remain unaffected.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+U_io = 0.2;
+Ld = wvt.Lz/5;
+u_NIO = @(z) U_io*exp((z/Ld));
+v_NIO = @(z) zeros(size(z));
 
-  wvt.setInertialMotions(u_NIO,v_NIO);
-  ```
+wvt.setInertialMotions(u_NIO,v_NIO);
+```
 
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformhydrostatic/setmeandensityanomaly.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/setmeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  setMeanDensityAnomaly
 
-set inertial motions
+Set the mean-density-anomaly component.
 
 
 ---
@@ -23,19 +23,16 @@ set inertial motions
 
 ## Discussion
 
-  Overwrites existing inertial motions with the new values.
-  Other components of the flow will remain unaffected.
+Overwrite existing mean-density-anomaly coefficients with the
+projection of `eta` while preserving other flow components.
+Other components of the flow will remain unaffected.
 
-  ```matlab
-  U_io = 0.2;
-  Ld = wvt.Lz/5;
-  u_NIO = @(z) U_io*exp((z/Ld));
-  v_NIO = @(z) zeros(size(z));
+```matlab
+eta = @(z) 10*sin(pi*(z+wvt.Lz)/wvt.Lz);
+wvt.setMeanDensityAnomaly(eta);
+```
 
-  wvt.setInertialMotions(u_NIO,v_NIO);
-  ```
-
-  It is important to note that because the WVTransform
-  de-aliases by default, you will not likely get exactly the
-  same function out that you put in. The high-modes are
-  removed.
+It is important to note that because the WVTransform
+de-aliases by default, you will not likely get exactly the
+same function out that you put in. The high-modes are
+removed.

--- a/docs/classes/transforms/wvtransformhydrostatic/setwavemodes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/setwavemodes.md
@@ -33,4 +33,4 @@ set amplitudes of the given wave modes
 
 ## Discussion
 
-  Overwrite any existing wave modes with the given new values
+Overwrite any existing wave modes with the given new values

--- a/docs/classes/transforms/wvtransformhydrostatic/throwerrorifdensityviolation.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/throwerrorifdensityviolation.md
@@ -16,6 +16,6 @@ checks if the proposed coefficients are a valid adiabatic re-arrangement of the 
 
 ## Discussion
 
-  Given some proposed new set of values for A0, Ap, Am, will
-  the fluid state violate our density condition? If yes, then
-  throw an error and tell the user about it.
+Given some proposed new set of values for A0, Ap, Am, will
+the fluid state violate our density condition? If yes, then
+throw an error and tell the user about it.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ convert from DFT to WV grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a DFT grid to one on a WV grid. The WV grid will
-  respect the conditions set when this class was initialized
-  (shouldAntialias, shouldExcludeNyquist,
-  shouldExcludeConjugates).
+This function will reformat the memory layout of a data
+structure on a DFT grid to one on a WV grid. The WV grid will
+respect the conditions set when this class was initialized
+(shouldAntialias, shouldExcludeNyquist,
+shouldExcludeConjugates).
 
-  This function is not the fastest way to reformat your data.
-  If high performance is required, you should
+This function is not the fastest way to reformat your data.
+If high performance is required, you should

--- a/docs/classes/transforms/wvtransformhydrostatic/transformfromspatialdomaintodftgrid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformfromspatialdomaintodftgrid.md
@@ -26,5 +26,5 @@ transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
 
 ## Discussion
 
-  Performs a Fourier transform in the x and y direction. The
-  resulting matrix is on the DFT grid.
+Performs a Fourier transform in the x and y direction. The
+resulting matrix is on the DFT grid.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformfromwvgridtodftgrid.md
@@ -27,7 +27,7 @@ convert from a WV to DFT grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a WV grid to one on a DFT grid. If the option
-  isHalfComplex is selected, then it will not set values for
-  iL>Ny/2, which are ignored by a 'symmetric' fft.
+This function will reformat the memory layout of a data
+structure on a WV grid to one on a DFT grid. If the option
+isHalfComplex is selected, then it will not set values for
+iL>Ny/2, which are ignored by a 'symmetric' fft.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtoklaxes.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtoklaxes.md
@@ -26,13 +26,12 @@ transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
 
 ## Discussion
 
+The following example takes the total energy of the wave part of
+flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
+along the mode (j) dimension.
 
-  The following example takes the total energy of the wave part of
-  flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
-  along the mode (j) dimension.
-
-  ```matlab
-  figure
-  TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
-  pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
-  ```
+```matlab
+figure
+TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
+pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
+```

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtoomegaaxis.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtoomegaaxis.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to omegaAxis
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtopseudoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtopseudoradialwavenumber.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtopseudoradialwavenumbera0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtopseudoradialwavenumbera0.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtopseudoradialwavenumberapm.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtopseudoradialwavenumberapm.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtoradialwavenumber.md
@@ -26,18 +26,18 @@ transforms in the spectral domain from (j,kl) to (j,kRadial)
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kRadial`.
+Sums all the variance/energy in radial bins `kRadial`.
 
-  The following example takes the total energy of the geostrophic part of
-  flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
-  it with pcolor. The next plot then sums over all wavenumber, and produces
-  plots the total energy spectrum as a function of vertical mode $$j$$
-  only.
+The following example takes the total energy of the geostrophic part of
+flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
+it with pcolor. The next plot then sums over all wavenumber, and produces
+plots the total energy spectrum as a function of vertical mode $$j$$
+only.
 
-  ```matlab
-  figure
-  tiledlayout('flow')
-  Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
-  nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
-  nexttile, plot(wvt.j,sum(Ekj,2))
-  ```
+```matlab
+figure
+tiledlayout('flow')
+Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
+nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
+nexttile, plot(wvt.j,sum(Ekj,2))
+```

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgrid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgrid.md
@@ -26,5 +26,5 @@ transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
 
 ## Discussion
 
-  Performs an inverse Fourier transform to take a matrix from
-  the DFT grid back to the spatial domain.
+Performs an inverse Fourier transform to take a matrix from
+the DFT grid back to the spatial domain.

--- a/docs/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgridatposition.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgridatposition.md
@@ -26,6 +26,6 @@ transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
 
 ## Discussion
 
-  Performs an inverse non-uniform Fourier transform to take a
-  matrix from the DFT grid back to the spatial domain at any
-  set of points (x,y).
+Performs an inverse non-uniform Fourier transform to take a
+matrix from the DFT grid back to the spatial domain at any
+set of points (x,y).

--- a/docs/classes/transforms/wvtransformhydrostatic/ua0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/ua0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 1, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/uam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/uam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 1, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/uap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/uap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 1, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/va0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/va0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 2, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/vam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/vam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 2, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/vap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/vap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 2, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/verticalprojectionoperatorswithrigidlid.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/verticalprojectionoperatorswithrigidlid.md
@@ -30,5 +30,5 @@ return the normalized projection operators with prefactors
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformhydrostatic/wam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/wam.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 4, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/wap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/wap.md
@@ -11,12 +11,13 @@ mathjax: true
 
 
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
 ## Discussion
-
-These are the row 4, column 1 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformhydrostatic/wavemodeverticalstructureatindex.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/wavemodeverticalstructureatindex.md
@@ -27,16 +27,16 @@ Return wave vertical-structure factors at one vertical grid index.
 
 ## Discussion
 
-  For a wave coefficient matrix `Apm`, the horizontal Fourier values of
-  the corresponding $$F$$ field and the vertical derivative of the
-  corresponding $$G$$ field at `z(iZ)` are
+For a wave coefficient matrix `Apm`, the horizontal Fourier values of
+the corresponding $$F$$ field and the vertical derivative of the
+corresponding $$G$$ field at `z(iZ)` are
 
-  $$
-  \widehat F(z_{iZ}) = \sum_j F_j(z_{iZ})A_{j\boldsymbol{k}},
-  \qquad
-  \partial_z\widehat G(z_{iZ}) =
-  \sum_j \partial_zG_j(z_{iZ})A_{j\boldsymbol{k}}.
-  $$
+$$
+\widehat F(z_{iZ}) = \sum_j F_j(z_{iZ})A_{j\boldsymbol{k}},
+\qquad
+\partial_z\widehat G(z_{iZ}) =
+\sum_j \partial_zG_j(z_{iZ})A_{j\boldsymbol{k}}.
+$$
 
-  Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
-  the derivative factors are not needed.
+Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
+the derivative factors are not needed.

--- a/docs/classes/transforms/wvtransformhydrostatic/wvtransformhydrostatic.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/wvtransformhydrostatic.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVTransformHydrostatic
 
-create a wave-vortex transform for variable stratification
+Create a hydrostatic wave-vortex transform for variable stratification.
 
 
 ---
@@ -21,19 +21,22 @@ create a wave-vortex transform for variable stratification
 ## Parameters
 + `Lxyz`  length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
 + `Nxyz`  number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-+ `rho`   (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-+ `stratification`   (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-+ `latitude`  (optional) latitude of the domain (default is 33 degrees north)
-+ `rho0`  (optional) density at the surface z=0 (default is 1025 kg/m^3)
++ `options.N2Function`  function returning squared buoyancy frequency on `[-Lz,0]`
++ `options.rhoFunction`  function returning density on `[-Lz,0]`
++ `options.latitude`  latitude in the supported domain; default `33`
++ `options.shouldAntialias`  exclude quadratically aliased modes; default `true`
++ `options.rho0`  reference density in kilograms per cubic meter; default `1025`
 
 ## Returns
-+ `wvt`  a new WVTransformHydrostatic instance
++ `wvt`  new `WVTransformHydrostatic` instance
 
 ## Discussion
 
-  Creates a new instance of the WVTransformHydrostatic class
-  appropriate for disentangling hydrostatic waves and vortices
-  in variable stratification
+Creates a new instance of the WVTransformHydrostatic class
+appropriate for disentangling hydrostatic waves and vortices
+in variable stratification
 
-  You must initialization by passing *either* the density
-  profile or the stratification profile.
+Supply either `N2Function` or `rhoFunction`. The additional
+modal arrays accepted by the constructor are reconstruction
+state used by the persistence factories rather than ordinary
+user construction options.

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0n.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0n.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 3 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0t.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0t.md
@@ -9,16 +9,19 @@ mathjax: true
 
 #  A0t
 
-geostrophic coefficients time t
+zero-frequency coefficients at current time t
 
 
 ---
 
 ## Description
-Complex valued property with dimensions $$(j,kl)$$ and units of $$m$$.
+Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+`A0t` is the zero-frequency coefficient array evaluated at the current transform time. On the supported $$f$$-plane transforms, `A0` has no linear phase winding and therefore
 
-These are the *time dependent* coefficients of the geostrophic flow, denoted  $$A_0$$ in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995).
+$$
+A_0^{k\ell j}(t) = A_0^{k\ell j}(t_0).
+$$
 
-These geostrophic coefficients do not have any linear time dependence on the $$f$$-plane and thus are identical to `A0`.
+Consequently, `A0t` returns the current stored `A0` coefficients.

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0u.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0u.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 1 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0v.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0v.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [inverse wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as $$S^{-1}$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C5.
+These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/addgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/addgeostrophicmodes.md
@@ -31,4 +31,4 @@ add amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Add new amplitudes to any existing amplitudes
+Add new amplitudes to any existing amplitudes

--- a/docs/classes/transforms/wvtransformstratifiedqg/addgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/addgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ add a geostrophic streamfunction to existing geostrophic motions
 
 ## Discussion
 
-  The geostrophic streamfunction is added to the existing values in `A0`
+The geostrophic streamfunction is added to the existing values in `A0`
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.addGeostrophicStreamfunction(psi);
-  ```
+wvt.addGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformstratifiedqg/degreesoffreedomforcomplexmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/degreesoffreedomforcomplexmatrix.md
@@ -27,7 +27,7 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A complex valued matrix A defined on a grid of size [Nx Ny]
-  would has 2*Nx*Ny degrees-of-freedom at each grid point. In
-  the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
-  each grid point.
+A complex valued matrix A defined on a grid of size [Nx Ny]
+would has 2*Nx*Ny degrees-of-freedom at each grid point. In
+the Fourier domain, it also has 2*Nx*Ny degrees-of-freedom at
+each grid point.

--- a/docs/classes/transforms/wvtransformstratifiedqg/degreesoffreedomforrealmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/degreesoffreedomforrealmatrix.md
@@ -28,10 +28,10 @@ a matrix with the number of degrees-of-freedom at each entry
 
 ## Discussion
 
-  A real-valued matrix A defined on a grid of size [Nx Ny] has
-  Nx*Ny degrees of freedom, one at each grid point. In the
-  Fourier domain these degrees-of-freedom are more complicated,
-  because some modes are strictly real-valued (k=l=0 and
-  Nyquist), while others are complex, and there are redundant
-  Hermitian conjugates. Nyquist coordinates contribute
-  self-conjugate modes only in even-sized dimensions.
+A real-valued matrix A defined on a grid of size [Nx Ny] has
+Nx*Ny degrees of freedom, one at each grid point. In the
+Fourier domain these degrees-of-freedom are more complicated,
+because some modes are strictly real-valued (k=l=0 and
+Nyquist), while others are complex, and there are redundant
+Hermitian conjugates. Nyquist coordinates contribute
+self-conjugate modes only in even-sized dimensions.

--- a/docs/classes/transforms/wvtransformstratifiedqg/diffzf.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/diffzf.md
@@ -27,6 +27,6 @@ Differentiate an F-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return a G-representation and even orders return
-  an F-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return a G-representation and even orders return
+an F-representation.

--- a/docs/classes/transforms/wvtransformstratifiedqg/diffzg.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/diffzg.md
@@ -27,6 +27,6 @@ Differentiate a G-grid field with respect to z.
 
 ## Discussion
 
-  `u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
-  supported. Odd orders return an F-representation and even orders return
-  a G-representation.
+`u` must use the gridded layout `[Nx Ny Nz]`. Orders 1 through 4 are
+supported. Odd orders return an F-representation and even orders return
+a G-representation.

--- a/docs/classes/transforms/wvtransformstratifiedqg/effectivehorizontalgridresolution.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/effectivehorizontalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformstratifiedqg/effectiveverticalgridresolution.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/effectiveverticalgridresolution.md
@@ -23,7 +23,7 @@ returns the effective vertical grid resolution in meters
 
 ## Discussion
 
-  The effective grid resolution is the highest fully resolved
-  wavelength in the model. This value takes into account
-  anti-aliasing, and is thus appropriate for setting damping
-  operators.
+The effective grid resolution is the highest fully resolved
+wavelength in the model. This value takes into account
+anti-aliasing, and is thus appropriate for setting damping
+operators.

--- a/docs/classes/transforms/wvtransformstratifiedqg/index.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/index.md
@@ -11,7 +11,7 @@ nav_order: 6
 
 #  WVTransformStratifiedQG
 
-A quasigeostrophic transform for variable stratification
+Represent stratified quasigeostrophic flow with variable stratification.
 
 
 ---
@@ -23,15 +23,19 @@ A quasigeostrophic transform for variable stratification
 ## Overview
 
 To initialize an instance of the WVTransformStratifiedQG class you
-must specific the domain size, the number of grid points and *either*
+must specify the domain size, the number of grid points, and either
 the density profile or the stratification profile.
 
 ```matlab
 N0 = 3*2*pi/3600;
 L_gm = 1300;
 N2 = @(z) N0*N0*exp(2*z/L_gm);
-wvt = WVTransformStratifiedQG([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=30);
+wvt = WVTransformStratifiedQG([100e3,100e3,4000],[64,64,65],N2Function=N2,latitude=30);
 ```
+
+The Stable quasigeostrophic state is stored in
+[`A0`](/classes/transforms/wvtransform/a0.html), with current-time view
+`A0t`. This transform has no active `Ap`, `Am`, `Apt`, or `Amt` content.
 
 
 
@@ -39,7 +43,10 @@ wvt = WVTransformStratifiedQG([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=
 
 ## Topics
 + Initialization
-  + [`WVTransformStratifiedQG`](/classes/transforms/wvtransformstratifiedqg/wvtransformstratifiedqg.html) create a wave-vortex transform for variable stratification
+  + [`WVTransformStratifiedQG`](/classes/transforms/wvtransformstratifiedqg/wvtransformstratifiedqg.html) Create a stratified quasigeostrophic transform.
++ Wave-vortex coefficients
+  + At current time
+    + [`A0t`](/classes/transforms/wvtransformstratifiedqg/a0t.html) zero-frequency coefficients at current time t
 + Primary flow components
   + [`geostrophicComponent`](/classes/transforms/wvtransformstratifiedqg/geostrophiccomponent.html) returns the geostrophic flow component
 + Stratification
@@ -76,18 +83,8 @@ wvt = WVTransformStratifiedQG([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=
     + [`transformToPseudoRadialWavenumberApm`](/classes/transforms/wvtransformstratifiedqg/transformtopseudoradialwavenumberapm.html) transforms in the from (j,kRadial) to kPseudoRadial
     + [`transformToRadialWavenumber`](/classes/transforms/wvtransformstratifiedqg/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
     + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformstratifiedqg/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
-+ Wave-vortex sorting matrix
-  + inverse components ($$S^{-1}$$)
-    + [`A0N`](/classes/transforms/wvtransformstratifiedqg/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
-    + [`A0U`](/classes/transforms/wvtransformstratifiedqg/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
-    + [`A0V`](/classes/transforms/wvtransformstratifiedqg/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
-  + components of $$S$$
-    + [`NA0`](/classes/transforms/wvtransformstratifiedqg/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
-    + [`UA0`](/classes/transforms/wvtransformstratifiedqg/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
-    + [`VA0`](/classes/transforms/wvtransformstratifiedqg/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
-+ Wave-vortex coefficients
-  + at time $$t$$
-    + [`A0t`](/classes/transforms/wvtransformstratifiedqg/a0t.html) geostrophic coefficients time t
++ Developer
+  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformstratifiedqg/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + Domain Attributes
   + [`f`](/classes/transforms/wvtransformstratifiedqg/f.html) Coriolis parameter
   + [`g`](/classes/transforms/wvtransformstratifiedqg/g.html) gravity of Earth
@@ -180,8 +177,6 @@ wvt = WVTransformStratifiedQG([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=
   + [`maskForNyquistModes`](/classes/transforms/wvtransformstratifiedqg/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
 + Utilities
   + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformstratifiedqg/placeparticlesonisopycnal.html) places Lagrangian particles along a specified isopycnal
-+ Developer
-  + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformstratifiedqg/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
 + State Variables
   + [`psi`](/classes/transforms/wvtransformstratifiedqg/psi.html) geostrophic streamfunction
   + [`ssu`](/classes/transforms/wvtransformstratifiedqg/ssu.html) x-component of the fluid velocity at the surface
@@ -269,6 +264,21 @@ wvt = WVTransformStratifiedQG([100e3, 100e3, 4000],[64, 64, 65], N2=N2,latitude=
   + [`xyzGrid`](/classes/transforms/wvtransformstratifiedqg/xyzgrid.html)
   + [`z_int`](/classes/transforms/wvtransformstratifiedqg/z_int.html) Quadrature weights for the vertical grid
   + [`zeta_z`](/classes/transforms/wvtransformstratifiedqg/zeta_z.html) vertical component of relative vorticity
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Wave-vortex coefficients
++ Stratification
++ Developer
+  + Projection coefficients
+    + [`A0N`](/classes/transforms/wvtransformstratifiedqg/a0n.html) matrix component that multiplies $$\tilde{\eta}$$ to compute $$A_0$$.
+    + [`A0U`](/classes/transforms/wvtransformstratifiedqg/a0u.html) matrix component that multiplies $$\tilde{u}$$ to compute $$A_0$$.
+    + [`A0V`](/classes/transforms/wvtransformstratifiedqg/a0v.html) matrix component that multiplies $$\tilde{v}$$ to compute $$A_0$$.
+  + Reconstruction coefficients
+    + [`NA0`](/classes/transforms/wvtransformstratifiedqg/na0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
+    + [`UA0`](/classes/transforms/wvtransformstratifiedqg/ua0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
+    + [`VA0`](/classes/transforms/wvtransformstratifiedqg/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 
 
 ---

--- a/docs/classes/transforms/wvtransformstratifiedqg/indexfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/indexfromklmodenumber.md
@@ -27,8 +27,8 @@ return the linear index into k_wv and l_wv from a mode number
 
 ## Discussion
 
-  This function will return the linear index into the (k_wv,l_wv) arrays,
-  given the mode numbers (kMode,lMode). Note that this will
-  *not* normalize the mode to the primary mode number, but will
-  throw an error. Scalar and column-vector inputs preserve their
-  shape and ordering.
+This function will return the linear index into the (k_wv,l_wv) arrays,
+given the mode numbers (kMode,lMode). Note that this will
+*not* normalize the mode to the primary mode number, but will
+throw an error. Scalar and column-vector inputs preserve their
+shape and ordering.

--- a/docs/classes/transforms/wvtransformstratifiedqg/indexfrommodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/indexfrommodenumber.md
@@ -28,7 +28,7 @@ return the linear index into a spectral matrix given (k,l,j)
 
 ## Discussion
 
-  This function will return the linear index in a spectral
-  matrix given a mode number. Scalar and column-vector inputs preserve
-  their shape and ordering; conjugate mode numbers map to their primary
-  coefficient.
+This function will return the linear index in a spectral
+matrix given a mode number. Scalar and column-vector inputs preserve
+their shape and ordering; conjugate mode numbers map to their primary
+coefficient.

--- a/docs/classes/transforms/wvtransformstratifiedqg/indicesfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/indicesfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ indices to convert from DFT to WV grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a DFT grid to one on a WV grid.
-  The resulting WV grid will respect the conditions set when
-  this class was initialized (shouldAntialias,
-  shouldExcludeNyquist, shouldExcludeConjugates).
+This function returns indices to quickly reformat the memory
+layout of a data structure on a DFT grid to one on a WV grid.
+The resulting WV grid will respect the conditions set when
+this class was initialized (shouldAntialias,
+shouldExcludeNyquist, shouldExcludeConjugates).
 
-  This function is should generally be faster than the function
-  transformFromDFTGridToWVGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromDFTGridToWVGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformstratifiedqg/indicesfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/indicesfromwvgridtodftgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformstratifiedqg/indicesfromwvgridtofftwgrid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/indicesfromwvgridtofftwgrid.md
@@ -30,8 +30,8 @@ indices to convert from WV to DFT grid
 
 ## Discussion
 
-  This function returns indices to quickly reformat the memory
-  layout of a data structure on a WV grid to one on a DFT grid.
+This function returns indices to quickly reformat the memory
+layout of a data structure on a WV grid to one on a DFT grid.
 
-  This function is should generally be faster than the function
-  transformFromWVGridToDFTGrid if you cache these indices.
+This function is should generally be faster than the function
+transformFromWVGridToDFTGrid if you cache these indices.

--- a/docs/classes/transforms/wvtransformstratifiedqg/initwithgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/initwithgeostrophicstreamfunction.md
@@ -23,42 +23,42 @@ initialize with a geostrophic streamfunction
 
 ## Discussion
 
-  Clears variables Ap,Am,A0 and then sets the geostrophic
-  streamfunction.
+Clears variables Ap,Am,A0 and then sets the geostrophic
+streamfunction.
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.initWithGeostrophicStreamfunction(psi);
-  ```
+wvt.initWithGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformstratifiedqg/intzf.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/intzf.md
@@ -27,8 +27,8 @@ Return the first antiderivative of an F-representation.
 
 ## Discussion
 
-  The result is the antiderivative representable in G space. The
-  barotropic F mode is removed because it has no corresponding G mode, so
-  the result vanishes at both vertical boundaries. `u` may use the gridded
-  layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
-  array preserves that layout.
+The result is the antiderivative representable in G space. The
+barotropic F mode is removed because it has no corresponding G mode, so
+the result vanishes at both vertical boundaries. `u` may use the gridded
+layout `[Nx Ny Nz]` or a vertical-first matrix `[Nz N]`; the returned
+array preserves that layout.

--- a/docs/classes/transforms/wvtransformstratifiedqg/intzg.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/intzg.md
@@ -27,7 +27,7 @@ Return the bottom-zero first antiderivative of a G-representation.
 
 ## Discussion
 
-  A G-to-F antiderivative is defined up to an additive constant. This
-  method selects the representative that vanishes at the bottom boundary.
-  `w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
-  `[Nz N]`; the returned array preserves that layout.
+A G-to-F antiderivative is defined up to an additive constant. This
+method selects the representative that vanishes at the bottom boundary.
+`w` may use the gridded layout `[Nx Ny Nz]` or a vertical-first matrix
+`[Nz N]`; the returned array preserves that layout.

--- a/docs/classes/transforms/wvtransformstratifiedqg/isdensityinvalidrange.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/isdensityinvalidrange.md
@@ -23,4 +23,4 @@ checks if the density field is a valid adiabatic re-arrangement of the base stat
 
 ## Discussion
 
-  This is probably best re-defined as a dynamical variable.
+This is probably best re-defined as a dynamical variable.

--- a/docs/classes/transforms/wvtransformstratifiedqg/ishermitian.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/ishermitian.md
@@ -27,12 +27,12 @@ Check if the matrix is Hermitian. Report errors.
 
 ## Discussion
 
-  This algorithm checks whether any 2 or 3 dimensional matrix
-  is Hermitian in the first two dimensions, following the data
-  structure of a 2D DFT algorithm. The third dimension can be
-  any length, including length 1.
+This algorithm checks whether any 2 or 3 dimensional matrix
+is Hermitian in the first two dimensions, following the data
+structure of a 2D DFT algorithm. The third dimension can be
+any length, including length 1.
 
-  Errors can be reported indicating which entries are not
-  conjugate.
+Errors can be reported indicating which entries are not
+conjugate.
 
-  This algorithm is not fast.
+This algorithm is not fast.

--- a/docs/classes/transforms/wvtransformstratifiedqg/isvalidconjugateklmodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/isvalidconjugateklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid conjugate WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *conjugate* WV mode number. Even if a mode number is
-  available in the DFT matrix, it does not mean it is a valid
-  WV mode number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*conjugate* WV mode number. Even if a mode number is
+available in the DFT matrix, it does not mean it is a valid
+WV mode number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformstratifiedqg/isvalidconjugatemodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/isvalidconjugatemodenumber.md
@@ -28,8 +28,8 @@ returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+conjugate mode number according to how the property
+conjugateDimension is set.
 
-  Any valid self-conjugate modes (i.e., k=l=0) will return 1.
+Any valid self-conjugate modes (i.e., k=l=0) will return 1.

--- a/docs/classes/transforms/wvtransformstratifiedqg/isvalidklmodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/isvalidklmodenumber.md
@@ -27,11 +27,11 @@ return a boolean indicating whether (k,l) is a valid WV mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid WV mode
-  number. Even if a mode number is available in the DFT matrix,
-  it does not mean it is a valid WV mode number, e.g., it may
-  be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid WV mode
+number. Even if a mode number is available in the DFT matrix,
+it does not mean it is a valid WV mode number, e.g., it may
+be removed due to aliasing.
 
-  A valid mode number can be either primary or conjugate, and
-  thus the result is not affected by the chosen
-  conjugateDimension.
+A valid mode number can be either primary or conjugate, and
+thus the result is not affected by the chosen
+conjugateDimension.

--- a/docs/classes/transforms/wvtransformstratifiedqg/isvalidmodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/isvalidmodenumber.md
@@ -28,5 +28,5 @@ returns a boolean indicating whether (k,l,j) is a valid mode number
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid mode
-  number
+returns a boolean indicating whether (k,l,j) is a valid mode
+number

--- a/docs/classes/transforms/wvtransformstratifiedqg/isvalidprimaryklmodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/isvalidprimaryklmodenumber.md
@@ -27,9 +27,9 @@ return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l) is a valid
-  *primary* WV mode number. Even if a mode number is available
-  in the DFT matrix, it does not mean it is a valid WV mode
-  number, e.g., it may be removed due to aliasing.
+returns a boolean indicating whether (k,l) is a valid
+*primary* WV mode number. Even if a mode number is available
+in the DFT matrix, it does not mean it is a valid WV mode
+number, e.g., it may be removed due to aliasing.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformstratifiedqg/isvalidprimarymodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/isvalidprimarymodenumber.md
@@ -28,6 +28,6 @@ returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) 
 
 ## Discussion
 
-  returns a boolean indicating whether (k,l,j) is a valid
-  non-conjugate mode number according to how the property
-  conjugateDimension is set.
+returns a boolean indicating whether (k,l,j) is a valid
+non-conjugate mode number according to how the property
+conjugateDimension is set.

--- a/docs/classes/transforms/wvtransformstratifiedqg/klmodenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/klmodenumberfromindex.md
@@ -27,6 +27,6 @@ return mode number from a linear index into a WV matrix
 
 ## Discussion
 
-  This function will return the mode numbers (kMode,lMode)
-  given some linear index into a WV structured matrix. Scalar
-  and column-vector inputs preserve their shape and ordering.
+This function will return the mode numbers (kMode,lMode)
+given some linear index into a WV structured matrix. Scalar
+and column-vector inputs preserve their shape and ordering.

--- a/docs/classes/transforms/wvtransformstratifiedqg/maskforaliasedmodes.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/maskforaliasedmodes.md
@@ -28,18 +28,18 @@ returns a mask with locations of modes that will alias with a quadratic multipli
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
-  modes are, assuming the 2/3 anti-aliasing rule for quadratic
-  interactions.
+Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
+modes are, assuming the 2/3 anti-aliasing rule for quadratic
+interactions.
 
-  Technically one needs only restrict to 2/3s in each
-  wavenumber direction. However, we prefer to maintain an
-  isotropic effective grid size and instead restrict to a
-  circle.
+Technically one needs only restrict to 2/3s in each
+wavenumber direction. However, we prefer to maintain an
+isotropic effective grid size and instead restrict to a
+circle.
 
-  Basic usage,
-  ```matlab
-  antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  alias with a quadratic multiplication.
+Basic usage,
+```matlab
+antialiasMask = WVGeometryDoublyPeriodic.maskForAliasedModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+alias with a quadratic multiplication.

--- a/docs/classes/transforms/wvtransformstratifiedqg/maskforconjugatefouriercoefficients.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/maskforconjugatefouriercoefficients.md
@@ -28,13 +28,13 @@ a mask indicate the components that are redundant conjugates
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where
-  the non-primary Hermitian conjugates are located in the DFT
-  matrix.
+Returns a 'mask' (matrices with 1s or 0s) indicating where
+the non-primary Hermitian conjugates are located in the DFT
+matrix.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
-  ```
-  will return a mask that contains 1 at the locations of the
-  modes assumed conjugate.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForConjugateFourierCoefficients(8,8,conjugateDimension=2);
+```
+will return a mask that contains 1 at the locations of the
+modes assumed conjugate.

--- a/docs/classes/transforms/wvtransformstratifiedqg/maskfornyquistmodes.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/maskfornyquistmodes.md
@@ -28,13 +28,13 @@ returns a mask with locations of modes that are not fully resolved
 
 ## Discussion
 
-  Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
-  modes are located in a standard FFT matrix. A direction has
-  a Nyquist coordinate only when its grid size is even.
+Returns a 'mask' (matrices with 1s or 0s) indicating where Nyquist
+modes are located in a standard FFT matrix. A direction has
+a Nyquist coordinate only when its grid size is even.
 
-  Basic usage,
-  ```matlab
-  NyquistMask = wvm.maskForNyquistModes(8,8);
-  ```
-  will return a mask that contains 1 at the locations of modes that will
-  are at the Nyquist frequency of the Fourier transforms.
+Basic usage,
+```matlab
+NyquistMask = wvm.maskForNyquistModes(8,8);
+```
+will return a mask that contains 1 at the locations of modes that will
+are at the Nyquist frequency of the Fourier transforms.

--- a/docs/classes/transforms/wvtransformstratifiedqg/modenumberfromindex.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/modenumberfromindex.md
@@ -28,5 +28,5 @@ Return mode numbers for spectral linear indices.
 
 ## Discussion
 
-  Scalar and column-vector inputs preserve their shape and ordering. Each
-  index must lie within the current spectral matrix.
+Scalar and column-vector inputs preserve their shape and ordering. Each
+index must lie within the current spectral matrix.

--- a/docs/classes/transforms/wvtransformstratifiedqg/na0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/na0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{\eta}$$.
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
-
-These are the row 3, column 2 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/placeparticlesonisopycnal.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/placeparticlesonisopycnal.md
@@ -28,20 +28,20 @@ places Lagrangian particles along a specified isopycnal
 
 ## Discussion
 
-  Given particle position (x,y), `zNoMotion` is used to determine the target
-  isopycnal using the no-motion density,
+Given particle position (x,y), `zNoMotion` is used to determine the target
+isopycnal using the no-motion density,
 
-  ```matlab
-  targetRho = wvt.rhoFunction(zNoMotion);
-  ```
+```matlab
+targetRho = wvt.rhoFunction(zNoMotion);
+```
 
-  and a minimization algorithm is used to find zIsopycnal such that
+and a minimization algorithm is used to find zIsopycnal such that
 
-  ```matlab
-  zIsopycnal = rho(targetRho);
-  ```
+```matlab
+zIsopycnal = rho(targetRho);
+```
 
-  where rho is the current total density field of the fluid.
+where rho is the current total density field of the fluid.
 
-  Note that the density is not necessarily monotonic, so the answer is not
-  necessarily unique.
+Note that the density is not necessarily monotonic, so the answer is not
+necessarily unique.

--- a/docs/classes/transforms/wvtransformstratifiedqg/primaryklmodenumberfromklmodenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/primaryklmodenumberfromklmodenumber.md
@@ -28,8 +28,8 @@ takes any valid WV mode number and returns the primary mode number
 
 ## Discussion
 
-  The function first confirms that the mode numbers are valid,
-  and then converts any conjugate mode numbers to primary mode
-  numbers.
+The function first confirms that the mode numbers are valid,
+and then converts any conjugate mode numbers to primary mode
+numbers.
 
-  The result is affected by the chosen conjugateDimension.
+The result is affected by the chosen conjugateDimension.

--- a/docs/classes/transforms/wvtransformstratifiedqg/quadraturepointsforstratifiedflow.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/quadraturepointsforstratifiedflow.md
@@ -23,5 +23,5 @@ return the quadrature points for a given stratification
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformstratifiedqg/removeallgeostrophicmotions.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/removeallgeostrophicmotions.md
@@ -20,9 +20,9 @@ remove all geostrophic motions
 ```
 ## Discussion
 
-  All geostrophic motions are removed by setting A0 to zero.
+All geostrophic motions are removed by setting A0 to zero.
 
-  **Note** that this does *not* remove the mean density anomaly
-  (mda) part of the solution, just the geostrophic part. Thus,
-  this function will not clear all parts of a geostrophic
-  streamfunction.
+**Note** that this does *not* remove the mean density anomaly
+(mda) part of the solution, just the geostrophic part. Thus,
+this function will not clear all parts of a geostrophic
+streamfunction.

--- a/docs/classes/transforms/wvtransformstratifiedqg/setgeostrophicmodes.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/setgeostrophicmodes.md
@@ -31,16 +31,16 @@ set amplitudes of the given geostrophic modes
 
 ## Discussion
 
-  Set the amplitude of the given geostrophic modes by
-  overwriting any existing amplitudes. The parameters are given
-  as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
-  and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
-  of those modes.
+Set the amplitude of the given geostrophic modes by
+overwriting any existing amplitudes. The parameters are given
+as [horizontal and vertical modes](/users-guide/wavenumber-modes-and-indices.html),
+and the function will return the associated [horizontal wavenumbers](/users-guide/wavenumber-modes-and-indices.html)
+of those modes.
 
-  For example,
+For example,
 
-  ```matlab
-  wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
-  ```
+```matlab
+wvt.addGeostrophicModes(kMode=0,lMode=1,jMode=1,u=0.5);
+```
 
-  will add a geostrophic mode.
+will add a geostrophic mode.

--- a/docs/classes/transforms/wvtransformstratifiedqg/setgeostrophicstreamfunction.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/setgeostrophicstreamfunction.md
@@ -23,41 +23,41 @@ set a geostrophic streamfunction
 
 ## Discussion
 
-  Clears A0 by setting a geostrophic streamfunction
+Clears A0 by setting a geostrophic streamfunction
 
-  The geostrophic streamfunction, $$\psi$$, is defined such that
+The geostrophic streamfunction, $$\psi$$, is defined such that
 
-  $$
-  u= - \frac{\partial \psi}{\partial y}
-  $$
+$$
+u= - \frac{\partial \psi}{\partial y}
+$$
 
-  $$
-  v=\frac{\partial \psi}{\partial x}
-  $$
+$$
+v=\frac{\partial \psi}{\partial x}
+$$
 
-  $$
-  N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
-  $$
+$$
+N^2 \eta = \frac{g}{\rho_0} \rho = - f \frac{\partial \psi}{\partial z}
+$$
 
-  Note that a streamfunction also projects onto the
-  mean-density-anomaly (MDA) component of the flow, and thus it
-  is not strictly geostrophic.
+Note that a streamfunction also projects onto the
+mean-density-anomaly (MDA) component of the flow, and thus it
+is not strictly geostrophic.
 
-  Consider a shallow eddy where the density anomaly sits close to the
-  surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
-  and Lelong (2024)](https://arxiv.org/abs/2403.20269)
+Consider a shallow eddy where the density anomaly sits close to the
+surface. This example was constructed in [Early, Hernández-Dueñas, Smith,
+and Lelong (2024)](https://arxiv.org/abs/2403.20269)
 
-  ```matlab
-  x0 = 3*Lx/4;
-  y0 = Ly/2;
+```matlab
+x0 = 3*Lx/4;
+y0 = Ly/2;
 
-  Le = 80e3;
-  He = 300;
-  U = 0.20; % m/s
+Le = 80e3;
+He = 300;
+U = 0.20; % m/s
 
-  H = @(z) exp(-(z/He/sqrt(2)).^2 );
-  F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
-  psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
+H = @(z) exp(-(z/He/sqrt(2)).^2 );
+F = @(x,y) exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2);
+psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*H(z).*(F(x,y) - (pi*Le*Le/(wvt.Lx*wvt.Ly)));
 
-  wvt.setGeostrophicStreamfunction(psi);
-  ```
+wvt.setGeostrophicStreamfunction(psi);
+```

--- a/docs/classes/transforms/wvtransformstratifiedqg/throwerrorifdensityviolation.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/throwerrorifdensityviolation.md
@@ -16,6 +16,6 @@ checks if the proposed coefficients are a valid adiabatic re-arrangement of the 
 
 ## Discussion
 
-  Given some proposed new set of values for A0, Ap, Am, will
-  the fluid state violate our density condition? If yes, then
-  throw an error and tell the user about it.
+Given some proposed new set of values for A0, Ap, Am, will
+the fluid state violate our density condition? If yes, then
+throw an error and tell the user about it.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformfromdftgridtowvgrid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformfromdftgridtowvgrid.md
@@ -26,11 +26,11 @@ convert from DFT to WV grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a DFT grid to one on a WV grid. The WV grid will
-  respect the conditions set when this class was initialized
-  (shouldAntialias, shouldExcludeNyquist,
-  shouldExcludeConjugates).
+This function will reformat the memory layout of a data
+structure on a DFT grid to one on a WV grid. The WV grid will
+respect the conditions set when this class was initialized
+(shouldAntialias, shouldExcludeNyquist,
+shouldExcludeConjugates).
 
-  This function is not the fastest way to reformat your data.
-  If high performance is required, you should
+This function is not the fastest way to reformat your data.
+If high performance is required, you should

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformfromspatialdomaintodftgrid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformfromspatialdomaintodftgrid.md
@@ -26,5 +26,5 @@ transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
 
 ## Discussion
 
-  Performs a Fourier transform in the x and y direction. The
-  resulting matrix is on the DFT grid.
+Performs a Fourier transform in the x and y direction. The
+resulting matrix is on the DFT grid.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformfromwvgridtodftgrid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformfromwvgridtodftgrid.md
@@ -27,7 +27,7 @@ convert from a WV to DFT grid
 
 ## Discussion
 
-  This function will reformat the memory layout of a data
-  structure on a WV grid to one on a DFT grid. If the option
-  isHalfComplex is selected, then it will not set values for
-  iL>Ny/2, which are ignored by a 'symmetric' fft.
+This function will reformat the memory layout of a data
+structure on a WV grid to one on a DFT grid. If the option
+isHalfComplex is selected, then it will not set values for
+iL>Ny/2, which are ignored by a 'symmetric' fft.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtoklaxes.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtoklaxes.md
@@ -26,13 +26,12 @@ transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
 
 ## Discussion
 
+The following example takes the total energy of the wave part of
+flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
+along the mode (j) dimension.
 
-  The following example takes the total energy of the wave part of
-  flow, transforms it to the (kAxis,lAxis,j) grid, then sums all the energy
-  along the mode (j) dimension.
-
-  ```matlab
-  figure
-  TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
-  pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
-  ```
+```matlab
+figure
+TE = wvt.Apm_TE_factor .* (abs(wvt.Ap).^2 + abs(wvt.Am).^2);
+pcolor(wvt.kAxis,wvt.lAxis,log10(sum(wvt.transformToKLAxes(TE),3)).'), shading flat
+```

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtoomegaaxis.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtoomegaaxis.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to omegaAxis
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtopseudoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtopseudoradialwavenumber.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtopseudoradialwavenumbera0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtopseudoradialwavenumbera0.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtopseudoradialwavenumberapm.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtopseudoradialwavenumberapm.md
@@ -26,4 +26,4 @@ transforms in the from (j,kRadial) to kPseudoRadial
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kPseudoRadial`.
+Sums all the variance/energy in radial bins `kPseudoRadial`.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtoradialwavenumber.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtoradialwavenumber.md
@@ -26,18 +26,18 @@ transforms in the spectral domain from (j,kl) to (j,kRadial)
 
 ## Discussion
 
-  Sums all the variance/energy in radial bins `kRadial`.
+Sums all the variance/energy in radial bins `kRadial`.
 
-  The following example takes the total energy of the geostrophic part of
-  flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
-  it with pcolor. The next plot then sums over all wavenumber, and produces
-  plots the total energy spectrum as a function of vertical mode $$j$$
-  only.
+The following example takes the total energy of the geostrophic part of
+flow, converts it to a one-dimensional spectrum in $$k$$, and then plots
+it with pcolor. The next plot then sums over all wavenumber, and produces
+plots the total energy spectrum as a function of vertical mode $$j$$
+only.
 
-  ```matlab
-  figure
-  tiledlayout('flow')
-  Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
-  nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
-  nexttile, plot(wvt.j,sum(Ekj,2))
-  ```
+```matlab
+figure
+tiledlayout('flow')
+Ekj = wvt.transformToRadialWavenumber( wvt.A0_TE_factor .* abs(wvt.A0).^2 );
+nexttile, pcolor(wvt.kRadial,wvt.j,Ekj), shading flat
+nexttile, plot(wvt.j,sum(Ekj,2))
+```

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgrid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgrid.md
@@ -26,5 +26,5 @@ transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
 
 ## Discussion
 
-  Performs an inverse Fourier transform to take a matrix from
-  the DFT grid back to the spatial domain.
+Performs an inverse Fourier transform to take a matrix from
+the DFT grid back to the spatial domain.

--- a/docs/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgridatposition.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgridatposition.md
@@ -26,6 +26,6 @@ transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
 
 ## Discussion
 
-  Performs an inverse non-uniform Fourier transform to take a
-  matrix from the DFT grid back to the spatial domain at any
-  set of points (x,y).
+Performs an inverse non-uniform Fourier transform to take a
+matrix from the DFT grid back to the spatial domain at any
+set of points (x,y).

--- a/docs/classes/transforms/wvtransformstratifiedqg/ua0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/ua0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{u}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 1, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/va0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/va0.md
@@ -11,6 +11,8 @@ mathjax: true
 
 matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 
+> Developer documentation: this item describes internal implementation details.
+
 
 ---
 
@@ -18,8 +20,7 @@ matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
-
-These are the row 2, column 3 components of the [wave-vortex (S)orting matrix](/mathematical-introduction/transformations.html), referred to as the $$S$$ matrix in [Early, et al. (2021)](https://doi.org/10.1017/jfm.2020.995). The primary internal gravity wave and geostrophic solutions that exist for $$k^2+l^2>0, j>0$$ are summarized in equation C4.
+These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/verticalprojectionoperatorswithrigidlid.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/verticalprojectionoperatorswithrigidlid.md
@@ -30,5 +30,5 @@ return the normalized projection operators with prefactors
 
 ## Discussion
 
-  This function uses InternalModesWKBSpectral to compute the
-  quadrature points of a given stratification profile.
+This function uses InternalModesWKBSpectral to compute the
+quadrature points of a given stratification profile.

--- a/docs/classes/transforms/wvtransformstratifiedqg/wavemodeverticalstructureatindex.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/wavemodeverticalstructureatindex.md
@@ -27,16 +27,16 @@ Return wave vertical-structure factors at one vertical grid index.
 
 ## Discussion
 
-  For a wave coefficient matrix `Apm`, the horizontal Fourier values of
-  the corresponding $$F$$ field and the vertical derivative of the
-  corresponding $$G$$ field at `z(iZ)` are
+For a wave coefficient matrix `Apm`, the horizontal Fourier values of
+the corresponding $$F$$ field and the vertical derivative of the
+corresponding $$G$$ field at `z(iZ)` are
 
-  $$
-  \widehat F(z_{iZ}) = \sum_j F_j(z_{iZ})A_{j\boldsymbol{k}},
-  \qquad
-  \partial_z\widehat G(z_{iZ}) =
-  \sum_j \partial_zG_j(z_{iZ})A_{j\boldsymbol{k}}.
-  $$
+$$
+\widehat F(z_{iZ}) = \sum_j F_j(z_{iZ})A_{j\boldsymbol{k}},
+\qquad
+\partial_z\widehat G(z_{iZ}) =
+\sum_j \partial_zG_j(z_{iZ})A_{j\boldsymbol{k}}.
+$$
 
-  Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
-  the derivative factors are not needed.
+Both returned arrays have dimensions `[Nj Nkl]`. Request only `F` when
+the derivative factors are not needed.

--- a/docs/classes/transforms/wvtransformstratifiedqg/wvtransformstratifiedqg.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/wvtransformstratifiedqg.md
@@ -9,30 +9,33 @@ mathjax: true
 
 #  WVTransformStratifiedQG
 
-create a wave-vortex transform for variable stratification
+Create a stratified quasigeostrophic transform.
 
 
 ---
 
 ## Declaration
 ```matlab
- wvt = WVTransformHydrostatic(Lxyz, Nxyz, options)
+ wvt = WVTransformStratifiedQG(Lxyz,Nxyz,options)
 ```
 ## Parameters
 + `Lxyz`  length of the domain (in meters) in the three coordinate directions, e.g. [Lx Ly Lz]
 + `Nxyz`  number of grid points in the three coordinate directions, e.g. [Nx Ny Nz]
-+ `rho`   (optional) function_handle specifying the density as a function of depth on the domain [-Lz 0]
-+ `stratification`   (optional) function_handle specifying the stratification as a function of depth on the domain [-Lz 0]
-+ `latitude`  (optional) latitude of the domain (default is 33 degrees north)
-+ `rho0`  (optional) density at the surface z=0 (default is 1025 kg/m^3)
++ `options.N2Function`  function returning squared buoyancy frequency on `[-Lz,0]`
++ `options.rhoFunction`  function returning density on `[-Lz,0]`
++ `options.latitude`  latitude in the supported domain; default `33`
++ `options.shouldAntialias`  exclude quadratically aliased modes; default `true`
++ `options.rho0`  reference density in kilograms per cubic meter; default `1025`
 
 ## Returns
-+ `wvt`  a new WVTransformHydrostatic instance
++ `wvt`  new `WVTransformStratifiedQG` instance
 
 ## Discussion
 
-  Creates a new instance of the WVTransformStratifiedQG class
-  for quasigeostrophic flow in variable stratification.
+Creates a new instance of the WVTransformStratifiedQG class
+for quasigeostrophic flow in variable stratification.
 
-  You must initialization by passing *either* the density
-  profile or the stratification profile.
+Supply either `N2Function` or `rhoFunction`. This transform
+represents the geostrophic `A0` coefficients and has no wave
+`Ap` or `Am` content. Additional modal arrays accepted by the
+constructor are reconstruction state used by persistence.

--- a/docs/classes/wvmodel/addnetcdfoutputvariables.md
+++ b/docs/classes/wvmodel/addnetcdfoutputvariables.md
@@ -24,10 +24,10 @@ Add variables to list of variables to be written to the NetCDF variable during t
 ## Discussion
 
 
-  Pass strings of WVTransform state variables of the
-  same name. This must be called before using any of the
-  integrate methods.
+Pass strings of WVTransform state variables of the
+same name. This must be called before using any of the
+integrate methods.
 
-  ```matlab
-  model.addNetCDFOutputVariables('A0','u','v');
-  ```
+```matlab
+model.addNetCDFOutputVariables('A0','u','v');
+```

--- a/docs/classes/wvmodel/floatpositions.md
+++ b/docs/classes/wvmodel/floatpositions.md
@@ -21,24 +21,24 @@ Returns the positions of the floats at the current time as well as the value of 
 ## Discussion
 
 
-  The tracked variable is a structure, with fields named for
-  each of the requested fields being tracked.
+The tracked variable is a structure, with fields named for
+each of the requested fields being tracked.
 
-  In the following example, float positions are set along with
-  one tracked field
-  ```matlab
-  model.setFloatPositions(xFloat,yFloat,zFloat,'rho_total');
+In the following example, float positions are set along with
+one tracked field
+```matlab
+model.setFloatPositions(xFloat,yFloat,zFloat,'rho_total');
 
-  % Set up the integrator
-  nT = model.setupIntegrator(timeStepConstraint="oscillatory", outputInterval=period/10,finalTime=3*period);
+% Set up the integrator
+nT = model.setupIntegrator(timeStepConstraint="oscillatory", outputInterval=period/10,finalTime=3*period);
 
-  % write the float trajectories to memory
-  xFloatT = zeros(nT,nTrajectories);
-  yFloatT = zeros(nT,nTrajectories);
-  zFloatT = zeros(nT,nTrajectories);
-  rhoFloatT = zeros(nT,nTrajectories);
-  t = zeros(nT,1);
+% write the float trajectories to memory
+xFloatT = zeros(nT,nTrajectories);
+yFloatT = zeros(nT,nTrajectories);
+zFloatT = zeros(nT,nTrajectories);
+rhoFloatT = zeros(nT,nTrajectories);
+t = zeros(nT,1);
 
-  [xFloatT(1,:),yFloatT(1,:),zFloatT(1,:),tracked] = model.floatPositions;
-  rhoFloatT(1,:) = tracked.rho_total;
-  ```
+[xFloatT(1,:),yFloatT(1,:),zFloatT(1,:),tracked] = model.floatPositions;
+rhoFloatT(1,:) = tracked.rho_total;
+```

--- a/docs/classes/wvmodel/index.md
+++ b/docs/classes/wvmodel/index.md
@@ -10,53 +10,46 @@ nav_order: 2
 
 #  WVModel
 
-The WVModel is responsible for time-stepping (integrating) the ocean state forward in time, as represented by a WVTransform.
+Integrate a fluid state represented by a WVTransform.
 
 
 ---
 
+## Declaration
+
+<div class="language-matlab highlighter-rouge"><div class="highlight"><pre class="highlight"><code>classdef WVModel < handle</code></pre></div></div>
+
 ## Overview
 
- Assuming you have already initialized a WVTransform, e.g.,
- ```matlab
- wvt = WVTransformConstantStratification([Lx, Ly, Lz], [Nx, Ny, Nz], N0,latitude=latitude);
- ```
- and maybe set some initial conditions, you can then initialize the
- model,
- ```matlab
- model = WVModel(wvt)
- ```
-
- By default the model only takes a linear time-step. To specify a
- nonlinear flux on initialization, for example,
+Construct a transform and use it to initialize the model:
 ```matlab
- model = WVModel(wvt);
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,9],N0=5.2e-3,latitude=45);
+model = WVModel(wvt);
 ```
+By default `WVModel` integrates the transform's nonlinear forcing and
+registers its coefficient observing system. Pass
+`shouldUseLinearDynamics=true` for analytical linear evolution. Use
+`setupIntegrator` to select the Stable fixed or adaptive integrator;
+`adaptive-cell` remains Experimental.
 
- You can also initialize a model from existing output,
- ```matlab
- model = WVModel.modelFromFile('SomeFile.nc');
+Restore a model and its output graph from one restart-capable file:
+```matlab
+model = WVModel.modelFromFile("SomeFile.nc");
 ```
-
- Advanced usage
- --------------
-
- 1. Create 1 or more NetCDFFiles
- 2. Add 1 or more WVModelOutputGroups to each file
- 3. Add 1 or more WVObservingSystems to each output group.
 
 
 
 
 ## Topics
 + Initialization
-  + [`WVModel`](/classes/wvmodel/wvmodel.html) Initialize a model from a WVTransform instance
+  + [`WVModel`](/classes/wvmodel/wvmodel.html) Initialize a model from a WVTransform instance.
   + [`modelFromFile`](/classes/wvmodel/modelfromfile.html) Initialize a model from an existing file
 + Model Properties
   + [`initialTime`](/classes/wvmodel/initialtime.html) Initial model time (seconds)
-  + [`isDynamicsLinear`](/classes/wvmodel/isdynamicslinear.html) Indicates whether or not the model is using linear or nonlinear dynamics.
+  + [`isDynamicsLinear`](/classes/wvmodel/isdynamicslinear.html) Whether the model uses analytical linear dynamics.
+  + [`summarize`](/classes/wvmodel/summarize.html) Print a summary of integrated systems and output files.
   + [`t`](/classes/wvmodel/t.html) Current model time (seconds)
-  + [`wvt`](/classes/wvmodel/wvt.html) The WVTransform instance the represents the ocean state.
+  + [`wvt`](/classes/wvmodel/wvt.html) WVTransform instance representing the ocean state.
 + Integration
   + [`integrateToTime`](/classes/wvmodel/integratetotime.html) Time step the model forward to the requested time.
   + [`setupIntegrator`](/classes/wvmodel/setupintegrator.html) Customize the time-stepping
@@ -117,7 +110,6 @@ The WVModel is responsible for time-stepping (integrating) the ocean state forwa
   + [`showIntegrationFinishDiagnostics`](/classes/wvmodel/showintegrationfinishdiagnostics.html)
   + [`showIntegrationStartDiagnostics`](/classes/wvmodel/showintegrationstartdiagnostics.html)
   + [`showIntegrationTimeDiagnostics`](/classes/wvmodel/showintegrationtimediagnostics.html)
-  + [`summarize`](/classes/wvmodel/summarize.html)
   + [`updateIntegratorValuesFromCellArray`](/classes/wvmodel/updateintegratorvaluesfromcellarray.html) We must set the time here. If we are integrating the
   + [`writeTimeStepToNetCDFFile`](/classes/wvmodel/writetimesteptonetcdffile.html)
 

--- a/docs/classes/wvmodel/initialtime.md
+++ b/docs/classes/wvmodel/initialtime.md
@@ -20,5 +20,5 @@ Initial model time (seconds)
 
 ## Discussion
 The time of the WVTransform when the model was
-  initialized. This also corresponds to the first time in the
-  NetCDF output file.
+initialized. This also corresponds to the first time in the
+NetCDF output file.

--- a/docs/classes/wvmodel/isdynamicslinear.md
+++ b/docs/classes/wvmodel/isdynamicslinear.md
@@ -9,11 +9,12 @@ mathjax: true
 
 #  isDynamicsLinear
 
-Indicates whether or not the model is using linear or nonlinear dynamics.
+Whether the model uses analytical linear dynamics.
 
 
 ---
 
 ## Discussion
-In practice, this is simply checking whether the nonlinearFlux
-  property is nil.
+When `false`, the model integrates registered coefficient and
+observing-system tendencies. When `true`, `integrateToTime`
+advances the transform and output schedule analytically.

--- a/docs/classes/wvmodel/modelfromfile.md
+++ b/docs/classes/wvmodel/modelfromfile.md
@@ -21,14 +21,17 @@ Initialize a model from an existing file
 ## Parameters
 + `path`  path to a NetCDF file
 
+## Returns
++ `model`  restored `WVModel` instance
+
 ## Discussion
 
-  A WVModel will be initialized from the specified path. The model will
-  have this file designated as its only output file. All groups in that
-  file are restored, but other files previously written by the same model
-  are not reconstructed. The file must contain one complete coefficient
-  stream. Linear versus nonlinear dynamics is restored when the model
-  metadata is present; older files retain the nonlinear default.
+A WVModel will be initialized from the specified path. The model will
+have this file designated as its only output file. All groups in that
+file are restored, but other files previously written by the same model
+are not reconstructed. The file must contain one complete coefficient
+stream. Linear versus nonlinear dynamics is restored when the model
+metadata is present; older files retain the nonlinear default.
 
-  Runtime integrator objects are not persisted. Configure the desired
-  fixed or adaptive integrator before continuing the restored model.
+Runtime integrator objects are not persisted. Configure the desired
+fixed or adaptive integrator before continuing the restored model.

--- a/docs/classes/wvmodel/removenetcdfoutputvariables.md
+++ b/docs/classes/wvmodel/removenetcdfoutputvariables.md
@@ -24,10 +24,10 @@ Remove variables from the list of variables to be written to the NetCDF variable
 ## Discussion
 
 
-  Pass strings of WVTransform state variables of the
-  same name. This must be called before using any of the
-  integrate methods.
+Pass strings of WVTransform state variables of the
+same name. This must be called before using any of the
+integrate methods.
 
-  ```matlab
-  model.removeNetCDFOutputVariables('A0','u','v');
-  ```
+```matlab
+model.removeNetCDFOutputVariables('A0','u','v');
+```

--- a/docs/classes/wvmodel/setfloatpositions.md
+++ b/docs/classes/wvmodel/setfloatpositions.md
@@ -31,34 +31,34 @@ Set positions of float-like particles to be advected by the model.
 ## Discussion
 
 
-  Pass the initial positions of particles to be advected by all
-  three components of the velocity field, (u,v,w).
+Pass the initial positions of particles to be advected by all
+three components of the velocity field, (u,v,w).
 
-  Particles move between grid (collocation) points and thus
-  their location must be interpolated. By default the
-  advectionInterpolation is set to "linear" interpolation. For
-  many flows this will have sufficient accuracy and allow you
-  to place float at nearly every grid point without slowing
-  down the model integration. However, if high accuracy is
-  required, you may want to use cubic "spline" interpolation at
-  the expense of computational speed.
+Particles move between grid (collocation) points and thus
+their location must be interpolated. By default the
+advectionInterpolation is set to "linear" interpolation. For
+many flows this will have sufficient accuracy and allow you
+to place float at nearly every grid point without slowing
+down the model integration. However, if high accuracy is
+required, you may want to use cubic "spline" interpolation at
+the expense of computational speed.
 
-  You can track the value of any known WVVariableAnnotation along the
-  particle's flow path, e.g., relative vorticity. These values
-  must also be interpolated using one of the known
-  interpolation methods.
+You can track the value of any known WVVariableAnnotation along the
+particle's flow path, e.g., relative vorticity. These values
+must also be interpolated using one of the known
+interpolation methods.
 
-  ```matlab
-  nTrajectories = 101;
-  xFloat = Lx/2*ones(1,nTrajectories);
-  yFloat = Ly/2*ones(1,nTrajectories);
-  zFloat = linspace(-Lz,0,nTrajectories);
+```matlab
+nTrajectories = 101;
+xFloat = Lx/2*ones(1,nTrajectories);
+yFloat = Ly/2*ones(1,nTrajectories);
+zFloat = linspace(-Lz,0,nTrajectories);
 
-  model.setFloatPositions(xFloat,yFloat,zFloat,'rho_total');
-  ```
+model.setFloatPositions(xFloat,yFloat,zFloat,'rho_total');
+```
 
-  If a NetCDF file is set for output, the particle positions
-  and tracked fields will automatically be written to file
-  during integration. If you are not writing to file you can
-  retrieve the current positions and values of the tracked
-  fields by calling -floatPositions.
+If a NetCDF file is set for output, the particle positions
+and tracked fields will automatically be written to file
+during integration. If you are not writing to file you can
+retrieve the current positions and values of the tracked
+fields by calling -floatPositions.

--- a/docs/classes/wvmodel/setnetcdfoutputvariables.md
+++ b/docs/classes/wvmodel/setnetcdfoutputvariables.md
@@ -24,10 +24,10 @@ Set list of variables to be written to the NetCDF variable during the model run.
 ## Discussion
 
 
-  Pass strings of WVTransform state variables of the
-  same name. This must be called before using any of the
-  integrate methods.
+Pass strings of WVTransform state variables of the
+same name. This must be called before using any of the
+integrate methods.
 
-  ```matlab
-  model.setNetCDFOutputVariables('A0','u','v');
-  ```
+```matlab
+model.setNetCDFOutputVariables('A0','u','v');
+```

--- a/docs/classes/wvmodel/setupintegrator.md
+++ b/docs/classes/wvmodel/setupintegrator.md
@@ -30,26 +30,26 @@ Customize the time-stepping
 
 ## Discussion
 
-  By default the model will use adaptive time stepping with a
-  reasonable choice of values. However, you may find it
-  necessary to customize the time stepping behavior.
+By default the model will use adaptive time stepping with a
+reasonable choice of values. However, you may find it
+necessary to customize the time stepping behavior.
 
-  When setting up the integrator you must choice between
-  "adaptive" and "fixed" integrator types. Depending on which
-  type you choose, you will have different options available.
+When setting up the integrator you must choice between
+"adaptive" and "fixed" integrator types. Depending on which
+type you choose, you will have different options available.
 
-  The "fixed" time-step integrator used a cfl condition based
-  on the advective velocity, but you can change this to use the
-  highest oscillatory frequency. Alternatively, you can simply
-  set deltaT yourself.
+The "fixed" time-step integrator used a cfl condition based
+on the advective velocity, but you can change this to use the
+highest oscillatory frequency. Alternatively, you can simply
+set deltaT yourself.
 
-  The "adaptive" time-step integator uses absolute and relative
-  error tolerances. It is worth reading Matlab's documentation
-  on RelTol and AbsTol as part of odeset to understand what
-  these mean. By default, the adaptive time stepping uses a
-  a relative error tolerance of 1e-3 for everything. However,
-  the absolute error tolerance is less straightforward.
+The "adaptive" time-step integator uses absolute and relative
+error tolerances. It is worth reading Matlab's documentation
+on RelTol and AbsTol as part of odeset to understand what
+these mean. By default, the adaptive time stepping uses a
+a relative error tolerance of 1e-3 for everything. However,
+the absolute error tolerance is less straightforward.
 
-  The absolute tolerance has a meaningful scale with units, and
-  thus must be chosen differently for particle positions (x,y)
-  than for geostrophic coefficients (A0).
+The absolute tolerance has a meaningful scale with units, and
+thus must be chosen differently for particle positions (x,y)
+than for geostrophic coefficients (A0).

--- a/docs/classes/wvmodel/summarize.md
+++ b/docs/classes/wvmodel/summarize.md
@@ -9,7 +9,9 @@ mathjax: true
 
 #  summarize
 
-
+Print a summary of integrated systems and output files.
 
 
 ---
+
+## Discussion

--- a/docs/classes/wvmodel/t.md
+++ b/docs/classes/wvmodel/t.md
@@ -16,4 +16,4 @@ Current model time (seconds)
 
 ## Discussion
 Current time of the ocean state, particle positions, and tracer.
-  This is just a pass-through of wvt.t.
+This is just a pass-through of wvt.t.

--- a/docs/classes/wvmodel/updateintegratorvaluesfromcellarray.md
+++ b/docs/classes/wvmodel/updateintegratorvaluesfromcellarray.md
@@ -16,6 +16,6 @@ We must set the time here. If we are integrating the
 
 ## Discussion
 wave-vortex coefficients, then this is benign because it will
-  immediately get repeated momentarily. But we we are not
-  integrating, and are running linearly, then we need the
-  fields to update.
+immediately get repeated momentarily. But we we are not
+integrating, and are running linearly, then we need the
+fields to update.

--- a/docs/classes/wvmodel/wvmodel.md
+++ b/docs/classes/wvmodel/wvmodel.md
@@ -9,16 +9,20 @@ mathjax: true
 
 #  WVModel
 
-Initialize a model from a WVTransform instance
+Initialize a model from a WVTransform instance.
 
 
 ---
 
 ## Declaration
 ```matlab
- WVModel(wvt,options)
+ model = WVModel(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WaveVortexTranform instance
++ `wvt`  `WVTransform` instance representing the initial fluid state
++ `options.shouldUseLinearDynamics`  use analytical linear evolution; default `false`
+
+## Returns
++ `model`  new `WVModel` instance
 
 ## Discussion

--- a/docs/classes/wvmodel/wvt.md
+++ b/docs/classes/wvmodel/wvt.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  wvt
 
-The WVTransform instance the represents the ocean state.
+WVTransform instance representing the ocean state.
 
 
 ---
 
 ## Discussion
 Set on initialization only, the WVTransform in the model
-  performs all computations necessary to return information about
-  the ocean state at a given time.
+performs all computations necessary to return information about
+the ocean state at a given time.

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -8,6 +8,7 @@ nav_order: 100
 
 ## [Unreleased]
 
+- Corrected the Stable `WVTransform` and `WVModel` API reference, promoted the stored and time-evaluated wave-vortex coefficients, and classified low-level projection and reconstruction arrays as Developer reference.
 - Made documentation generation clean, deterministic, transactional, and reviewable with an exact ClassDocumentation 1.3.0 authoring dependency, canonical build/check tasks, generated hierarchy validation, and case-sensitive internal-route checks.
 - Quarantined disconnected legacy implementations, corrected Internal adaptive-integrator and geometry spelling, retained a narrow 4.x file fallback for `shouldExludeConjugates`, and repaired the retained Internal barotropic FINUFFT path.
 - Stabilized model-output scheduling and NetCDF restart across multiple files and groups; preserved linear dynamics and shared observing systems; and made initialization, writing, restoration, and handle ownership exception-safe.


### PR DESCRIPTION
Closes #62

## Summary
- correct the Stable WVTransform and WVModel API reference and constructor documentation
- make Ap, Am, A0 and their current-time views prominent, while classifying low-level projection and reconstruction arrays as Developer reference
- correct copied transform/MDA prose and the A0t units metadata
- regenerate the complete documentation tree and add focused documentation regressions

## Verification
- focused TestStableAPIDocumentation: 7 passed
- smoke: 127 passed
- full: 589 passed, repeated
- exhaustive: 2440 passed
- buildtool analyze: 0 blocking findings
- repeated docs:check: 1718 files, 3533 routes, 0 failures, no drift
- whitespace, manifest, artifact, and repository-scope checks passed