### PR TITLE
Modernize onboarding and user guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Rewrote the README, homepage, installation instructions, and user guidance around the current `WVTransform` and `WVModel` workflows; completed the NetCDF conventions guide; linked the canonical wavevortexmodel.org site prominently; and adopted the Avenir-first website typography while retaining search.
 - Reorganized the generated API reference around user tasks, moved implementation machinery into Developer Topics, replaced release-status jargon with direct descriptions of capabilities and limitations, and restored authored scientific context, coefficient-occupancy tables, and design rationale.
 - Corrected the `WVTransform` and `WVModel` API reference, promoted the stored and time-evaluated wave-vortex coefficients, and classified low-level projection and reconstruction arrays as Developer reference.
 - Made documentation generation clean, deterministic, transactional, and reviewable with an exact ClassDocumentation 1.3.0 authoring dependency, canonical build/check tasks, generated hierarchy validation, and case-sensitive internal-route checks.

--- a/Documentation/WebsiteDocumentation/_config.yml
+++ b/Documentation/WebsiteDocumentation/_config.yml
@@ -1,5 +1,6 @@
 remote_theme: just-the-docs/just-the-docs
 title: WaveVortexModel
-description: Solve the stratified nonhydrostatic equations of motion and decompose into wave-vortex components
+description: Decompose and model rotating stratified flow with wave-vortex modes
+search_enabled: true
 compress_html:
   blanklines: true

--- a/Documentation/WebsiteDocumentation/_sass/custom/custom.scss
+++ b/Documentation/WebsiteDocumentation/_sass/custom/custom.scss
@@ -1,4 +1,36 @@
 
 @import "./sidebar-upgrades";
 
+body,
+.site-title,
+.site-button,
+.nav-list .nav-list-link,
+.nav-list .nav-list-expander,
+.main-content,
+.search-input,
+.search-result-title,
+.search-result-rel-url,
+.label,
+button,
+input,
+select,
+textarea {
+  font-family: "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.main-content {
+  line-height: 1.65;
+}
+
+.main-content h1,
+.main-content h2,
+.main-content h3,
+.main-content h4,
+.main-content h5,
+.main-content h6,
+.site-title {
+  font-family: "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  letter-spacing: -0.015em;
+}
+
 @import "./matlab-live-script";

--- a/Documentation/WebsiteDocumentation/classes/model-output/index.md
+++ b/Documentation/WebsiteDocumentation/classes/model-output/index.md
@@ -9,5 +9,4 @@ permalink: /classes/model-output
 
 #  Model output
 
-These classes are part of the internal system of reading and writing to file and are considered an advanced topic. The simplest interface is described in the [reading and writing to file users guide](/users-guide/reading-and-writing-to-file.html)
-
+These classes coordinate NetCDF files, output schedules, and observing systems. Start with the [reading and writing files guide](/users-guide/reading-and-writing-to-file.html); use these classes directly when a model needs multiple files, schedules, or bounded output windows.

--- a/Documentation/WebsiteDocumentation/classes/observing-systems/index.md
+++ b/Documentation/WebsiteDocumentation/classes/observing-systems/index.md
@@ -9,5 +9,4 @@ permalink: /classes/observing-systems
 
 #  Observing systems
 
-These classes allows you to *observe* during integration. Specific subclasses include systems for Eulerian fields, Lagrangian particles, tracers, moorings, and even [along-track satellite observations](https://satmapkit.github.io/AlongTrackSimulator/)
-
+These classes let you observe a state during integration. Specific subclasses provide Eulerian fields, Lagrangian particles, tracers, moorings, and [along-track satellite observations](https://satmapkit.github.io/AlongTrackSimulator/).

--- a/Documentation/WebsiteDocumentation/index.md
+++ b/Documentation/WebsiteDocumentation/index.md
@@ -2,15 +2,46 @@
 layout: default
 title: Home
 nav_order: 1
-description: "The WaveVortexModel decomposes a rotating stratified fluid into internal waves and geostrophic vortices"
+description: "Decompose and model rotating stratified flow with wave-vortex modes"
 permalink: /
 ---
 
-WaveVortexModel
-==============
+# WaveVortexModel
 
-The WaveVortexModel decomposes a Boussinesq fluid with arbitrary stratification into geostrophic motions and interia-gravity waves. This model is complete, and therefore also can be time-stepped forward
+WaveVortexModel represents rotating, stratified Boussinesq flow on an energetically orthogonal basis of internal waves, inertial oscillations, geostrophic motions, and mean-density anomalies.
 
-The model is based on the [decomposition described in Early, Lelong and Sundermeyer, 2021](https://doi.org/10.1017/jfm.2020.995);
+Use a [`WVTransform`](/classes/transforms/wvtransform/) to decompose a fluid state, reconstruct physical fields, and calculate diagnostics. Use [`WVModel`](/classes/wvmodel/) to integrate the state while advecting particles and tracers, sampling observing systems, and writing restartable NetCDF output.
 
+## Quick start
 
+Create a small constant-stratification transform, initialize one internal wave, inspect its velocity field, and advance the state with analytical linear dynamics:
+
+```matlab
+wvt = WVTransformConstantStratification( ...
+    [40e3 40e3 1000], [16 16 9], N0=5.2e-3, latitude=45);
+
+[omega,k,l] = wvt.initWithWaveModes( ...
+    kMode=1, lMode=0, j=1, phi=0, u=0.05, sign=1);
+[u,v,w] = wvt.variableWithName('u','v','w');
+
+model = WVModel(wvt,shouldUseLinearDynamics=true);
+model.integrateToTime(600,shouldShowIntegrationDiagnostics=false);
+```
+
+The transform stores the decomposed state in `Ap`, `Am`, and `A0`. Variables such as velocity, density, pressure, energy, and potential vorticity are reconstructed from those coefficients when requested.
+
+## Start here
+
+| Goal | Documentation |
+| --- | --- |
+| Install the package | [Installation](/installation) |
+| Choose and construct a transform | [Using `WVTransform`](/users-guide/using-the-wvtransform.html) |
+| Understand the main objects | [Introduction](/users-guide/introduction.html) |
+| Add forcing and closures | [Adding forcing](/users-guide/adding-forcing.html) |
+| Write output and restart a model | [Reading and writing files](/users-guide/reading-and-writing-to-file.html) |
+| Check a capability or limitation | [Capabilities and limitations](/users-guide/supported-features.html) |
+| Browse classes and methods | [API reference](/classes/) |
+
+## Scientific basis
+
+The generalized decomposition is described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The available-potential-vorticity formulation is described by [Early et al. (2024)](https://doi.org/10.48550/arXiv.2403.20269). See [Acknowledgements and citations](/acknowledgements) for software citation information and BibTeX downloads.

--- a/Documentation/WebsiteDocumentation/installation.md
+++ b/Documentation/WebsiteDocumentation/installation.md
@@ -2,40 +2,48 @@
 layout: default
 title: Installation
 nav_order: 2
-description: Installation instructions"
+description: Install WaveVortexModel and its dependencies
 permalink: /installation
 ---
 
-## Installation
+# Installation
 
-The recommended way to install the model is with [OceanKit](https://github.com/JeffreyEarly/OceanKit).
+WaveVortexModel requires MATLAB R2024b or newer. The package depends on other OceanKit packages and on Chebfun; MPM installs the declared dependencies automatically.
 
-Clone the OceanKit repository
-```
-git clone https://github.com/JeffreyEarly/OceanKit.git
-```
-from the command-line (or download [the zip](https://github.com/JeffreyEarly/OceanKit/archive/refs/heads/main.zip)). Within Matlab, add this folder as an MPM repository,
+## Install from OceanKit
+
+Clone or download the [OceanKit repository](https://github.com/JeffreyEarly/OceanKit), then register its local folder with MPM:
+
 ```matlab
-mpmAddRepository("OceanKit","path/to/folder/OceanKit")
+mpmAddRepository("OceanKit","local/path/to/OceanKit")
 ```
-and then
+
+Install WaveVortexModel and its dependencies:
+
 ```matlab
 mpminstall("WaveVortexModel")
 ```
-will install the [WaveVortexModel](https://wavevortexmodel.org) and its dependencies.
 
-## Advanced
+The installed package can be inspected with:
 
-The WaveVortexModel is highly extensible and rarely needs to be modified directly. However, if you do need to make change to the code you will need to install the model with *Authoring* enabled.
-
-You should still download OceanKit and add the mpm repo as above. However, instead of installing model from the OceanKit, you will install it directly from its github repo.
-
-Clone the WaveVortexModel repository
+```matlab
+mpmlist("WaveVortexModel")
 ```
+
+See [OceanKit installation](https://jeffreyearly.github.io/OceanKit/installation/) for repository management, updates, and removal.
+
+## Install an authoring checkout
+
+Ordinary users should install the released OceanKit package. Clone the authoring repository only when developing WaveVortexModel or rebuilding its documentation:
+
+```text
 git clone https://github.com/JeffreyEarly/wave-vortex-model.git
 ```
-and install with
+
+Install that checkout with authoring files enabled:
+
 ```matlab
-mpminstall("path/to/folder/wave-vortex-model", Authoring=true); 
+mpminstall("local/path/to/wave-vortex-model",Authoring=true)
 ```
-This will still install the dependencies from the mpm repo (and those will not be editable).
+
+Runtime dependencies still come from the registered OceanKit repository. Documentation generation additionally requires the authoring-only package `ClassDocumentation@1.3.0`; it is not a WaveVortexModel runtime dependency.

--- a/Documentation/WebsiteDocumentation/mathematical-introduction/transformations.md
+++ b/Documentation/WebsiteDocumentation/mathematical-introduction/transformations.md
@@ -161,7 +161,7 @@ $$
 
 ## Phase winding
 
-The final step of the transformation is to wind the phases to reference time $$t_0$$. This is done using the the phase winding operator $$T_\omega$$
+The final step of the transformation is to wind the phases to reference time $$t_0$$. This is done using the phase winding operator $$T_\omega$$
 
 $$
     T_\omega = 

--- a/Documentation/WebsiteDocumentation/users-guide/adding-forcing.md
+++ b/Documentation/WebsiteDocumentation/users-guide/adding-forcing.md
@@ -1,18 +1,18 @@
 ---
 layout: default
 title: Adding forcing
-parent: Users guide
+parent: User guide
 nav_order: 4
 mathjax: true
 ---
 
-#  Adding forcing
+# Adding forcing
 
-The `WVTransform` is the linear part of the equations of motion and thus forcing is required for more interesting dynamics.
+A `WVTransform` provides analytical linear evolution of its modes. Nonlinear advection, external tendencies, and closures enter through `WVForcing` objects.
 
 ## Quick start
 
-By default, a `WVTransform` is initialized with exactly one forcing term: nonlinear advection. To see this, initialize a new transform, then `summarizeForcing` to list all right-hand-side terms,
+By default, a `WVTransform` is initialized with exactly one forcing term: nonlinear advection. Initialize a transform, then call `summarizeForcing` to list its right-hand-side terms:
 ```matlab
 wvt = WVTransformHydrostatic([800e3, 800e3, 4000],[64, 64, 65], N2=@(z) (3*2*pi/3600)^2*exp(2*z/1300),latitude=30);
 wvt.summarizeForcing
@@ -25,7 +25,7 @@ wvt.summarizeForcing
     "nonlinear advection"     "false"
  ```
 
-This indicates that the only forcing term is the nonlinear advection. If the goal is to time-step a model, we also require a closure scheme to remove small scale features. For a first pass, we recommend using the `WVAdaptiveDamping`. You add a right-hand-side forcing term with `addForcing`,
+Nonlinear integration also needs a closure to control unresolved small scales. `WVAdaptiveDamping` is a useful first choice. Register it with `addForcing`:
 
 ```matlab
 wvt.addForcing(WVAdaptiveDamping(wvt));
@@ -40,7 +40,7 @@ wvt.summarizeForcing
     "adaptive damping"        "true"
  ```
 
-With this, you could now time-step the `WVTransform` forwards in time with the model,
+The model now includes nonlinear advection and adaptive damping when it advances the transform:
 ```matlab
 model = WVModel(wvt);
 model.integrateToTime(wvt.inertialPeriod);
@@ -82,7 +82,7 @@ $$
 \end{bmatrix}
 $$
 
-is the nonlinear advection. For the hydrostatic model, `WVTransformHydrostatic`, the the vertical momentum equation effectively vanishes, as $$w$$ is determined diagnostically.
+is the nonlinear advection. For hydrostatic dynamics, the vertical momentum equation effectively vanishes because $$w$$ is determined diagnostically.
 
 For the quasigeostrophic transforms, `WVTransformStratifiedQG` and `WVTransformBarotropicQG`, the equation of motion is the evolution of quasigeostrophic potential vorticity (QGPV),
 
@@ -100,7 +100,7 @@ This is also commonly written as a streamfunction, using $\psi = \frac{1}{\rho_0
 
 Adding forcing to a transform with `wvt.addForcing()` adds an additional right-hand-side term, $$\mathcal{S}$$.
 
-The total forcing (at the current time) in the spectral is found by calling `wvt.nonlinearFlux`,
+The total coefficient tendency at the current time is returned by `wvt.nonlinearFlux`:
 ```matlab
 [Fp,Fm,F0] = wvt.nonlinearFlux();
 ```
@@ -127,9 +127,15 @@ By default, the generated tendency is projected outside the exact support of any
 
 ## Creating your own forcing
 
-The model has a number of very useful forcings already built-in; however, it is also very straightforward to add your own forcing.
+Custom forcing subclasses derive from `WVForcing`, declare one or more `WVForcingType` stages, and override the method corresponding to each declared stage. Physical-space forcing modifies velocity and displacement tendencies before projection. Spectral forcing modifies $$(F_+,F_-,F_0)$$ after projection. Spectral-amplitude forcing updates `Ap`, `Am`, and `A0` directly.
+
+For example, horizontal and vertical spectral damping can be expressed as
 
 $$
+
+and implemented by overriding `addSpectralForcing`. Hydrostatic and nonhydrostatic physical forcing instead override `addHydrostaticSpatialForcing` or `addNonhydrostaticSpatialForcing`. QG forcing uses the potential-vorticity variants of the spatial, spectral, or amplitude interfaces.
+
+The transform validates that a forcing stage is compatible with its dynamics, applies stages in physical–spectral–amplitude order, and uses `priority` to order forcing objects within one stage. See [`WVForcing`](/classes/forcing/wvforcing/) and [`WVForcingType`](/classes/forcing/wvforcing/) before implementing a subclass.
     \begin{align}
         \partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
         \partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}

--- a/Documentation/WebsiteDocumentation/users-guide/creating-new-state-variables.md
+++ b/Documentation/WebsiteDocumentation/users-guide/creating-new-state-variables.md
@@ -1,61 +1,62 @@
 ---
 layout: default
 title: Creating new state variables
-parent: Users guide
+parent: User guide
 mathjax: true
 nav_order: 14
 ---
 
-#  Creating new state variables
+# Creating new state variables
 
-The WaveVortexModel allows you to quickly and easily create custom operations to define new variables describing the state of the ocean. These new variables can saved to file and their values can be tracked along particle trajectories using the model.
+Custom `WVOperation` objects add derived variables to a transform. Once registered, those variables participate in ordinary field access, caching, NetCDF output, and particle tracking.
 
-## WVOperation
+## Define and register an operation
 
-The simplest way to add new functionality to the WaveVortexModel is to create a new `WVOperation`. A `WVOperation` instance has two jobs: 1) describe the variable (or variables) that it is capable of producing and 2) implement an operation for computing those variables.
+A `WVVariableAnnotation` describes the output's name, dimensions, units, and meaning. A `WVOperation` associates one or more annotations with the calculation that produces them.
 
-### Creating a new operation
-
-As an example, lets add a new operation to compute relative vorticity. Assuming that `wvt` is a WVTransform instance,
+For example, register the vertical component of relative vorticity:
 
 ```matlab
-outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s^2', 'vertical component of relative vorticity');
-f = @(wvt) wvt.diffX(wvt.v) - wvt.diffY(wvt.u);
-wvt.addOperation(WVOperation('zeta_z',outputVar,f));
+annotation = WVVariableAnnotation( ...
+    'zeta_z',{'x','y','z'},'1/s','vertical component of relative vorticity');
+computeVorticity = @(wvt) wvt.diffX(wvt.v) - wvt.diffY(wvt.u);
+wvt.addOperation(WVOperation('zeta_z',annotation,computeVorticity));
 ```
 
-That's it! The `WVVariableAnnotation` class is used to describe the structure of the the output variable, and the function handle `f` performs the actual computation. The computation is not actually performed until it is needed.
-
-Now that the WVTransform has a recipe for computing `zeta_z`, you can simply call `wvt.zeta_z` at any time. In fact, these operations compose---so you can create a new operation itself calls `wvt.zeta_z` as part of its computation.
-
-### Saving to file
-
-The new variable can be immediately saved to file because it already has a name, dimensions, and units.
-
-Using the variable `zeta_z` from the example above, the transform can be written to file
+The calculation is lazy: registration records how to compute `zeta_z`, but the operation does not run until the value is requested.
 
 ```matlab
-wvt.writeToFile('path/to/file.nc','zeta_z');
+zeta_z = wvt.zeta_z;
 ```
 
-When doing a model simulation, this variable is also available to write to file as part of the time series see, e.g., `setNetCDFOutputVariables`.
+Operations compose, so another operation may use `wvt.zeta_z` as an input. More involved calculations can subclass `WVOperation` and override `compute`.
 
-### Tracking along particle trajectories
+## Control caching
 
-If the output variable has spatial dimension $$(x,y)$$ or $$(x,y,z)$$, then the WVModel can track its value along advected particle trajectories. See the documentation for `addParticles`, `setFloatPositions`, or `setDrifterPositions`. 
+Computed variables are cached. Set the operation's dependency metadata before registration so the transform knows when to invalidate its outputs:
 
-## Notes
+- `isVariableWithLinearTimeStep=true` invalidates the output when transform time changes.
+- `isDependentOnApAmA0=true` invalidates the output when `Ap`, `Am`, or `A0` changes.
 
-In the example above a function handle was used to compute the relative vorticity because it only required a single line of code. However, it is often the case that computations will be more involved. In that case, you should subclass the `WVOperation`.
+Outputs without the relevant dependency remain cached. A multiple-output operation computes and caches its annotations together in annotation order.
 
-Operation names and output-variable names must be unique. By default, `addOperation` rejects a new operation that conflicts with an existing operation and leaves the registry unchanged. To intentionally replace an operation, opt in explicitly:
+Operation names and output-variable names must be unique. Registration rejects conflicts by default. Pass `shouldOverwriteExisting=true` to replace the complete conflicting operation intentionally.
+
+## Write and track the variable
+
+The annotation supplies the metadata needed to write the variable with a transform:
 
 ```matlab
-wvt.addOperation(replacementOperation,shouldOverwriteExisting=true);
+ncfile = wvt.writeToFile('state.nc','zeta_z');
+ncfile.close();
 ```
 
-An operation is registered and removed as a unit. If the replacement conflicts with one output from a multiple-output operation, every output from the displaced operation is removed. When registering an array of operations with replacement enabled, conflicts are resolved in caller order and the last conflicting operation wins.
+For model output, add the variable to the Eulerian field selection:
 
-A `WVOperation` can return multiple variables. Its outputs are returned in annotation order and computed together when any uncached output is requested.
+```matlab
+model.addNetCDFOutputVariables('zeta_z');
+```
 
-All computed variables are cached to avoid unnecessary calculations. Set an operation's dependency metadata before registration: `isVariableWithLinearTimeStep=true` invalidates its outputs when transform time changes, while `isDependentOnApAmA0=true` invalidates them when `Ap`, `Am`, or `A0` changes. Outputs without the relevant dependency remain cached.
+Variables with spatial dimensions $$(x,y)$$ or $$(x,y,z)$$ can also be sampled along particle trajectories. Pass their names to `addParticles`, `setFloatPositions`, or `setDrifterPositions`.
+
+For details about annotations, multiple outputs, replacement, and cache invalidation, see [`WVOperation`](/classes/operations-and-annotations/wvoperation/) and [`WVVariableAnnotation`](/classes/operations-and-annotations/wvvariableannotation/).

--- a/Documentation/WebsiteDocumentation/users-guide/index.md
+++ b/Documentation/WebsiteDocumentation/users-guide/index.md
@@ -1,9 +1,17 @@
 ---
 layout: default
-title: Users guide
+title: User guide
 nav_order: 3
 has_children: true
 permalink: /users-guide
 ---
 
-This document is a users guide to the Matlab implementation of the WaveVortexModel.
+# User guide
+
+The user guide introduces the main WaveVortexModel workflows and connects them to the complete API reference.
+
+- Start with the [Introduction](/users-guide/introduction.html) to understand `WVTransform` and `WVModel`.
+- Use [Using `WVTransform`](/users-guide/using-the-wvtransform.html) to choose a transform, initialize a state, and evaluate physical fields.
+- Consult [Capabilities and limitations](/users-guide/supported-features.html) when choosing interpolation, integration, forcing, output, or extension features.
+- Read [Adding forcing](/users-guide/adding-forcing.html) before integrating nonlinear dynamics.
+- Use [Reading and writing files](/users-guide/reading-and-writing-to-file.html) for transform persistence, model output, and restart.

--- a/Documentation/WebsiteDocumentation/users-guide/introduction.md
+++ b/Documentation/WebsiteDocumentation/users-guide/introduction.md
@@ -1,21 +1,33 @@
 ---
 layout: default
 title: Introduction
-parent: Users guide
+parent: User guide
 mathjax: true
 nav_order: 1
 ---
 
-#  Introduction
+# Introduction
 
-There are two high-level components to the wave-vortex model, the `WVTransform` and the `WVModel`. The `WV` prefix is short for wave-vortex and establishes a namespace for all classes in the model.
+WaveVortexModel separates the representation of a fluid state from its time evolution. The `WV` prefix means wave–vortex and provides a common namespace for the package's classes.
 
-## WVTransform
+## `WVTransform`: represent and diagnose a state
 
-The `WVTransform` subclasses encapsulate data representing the *state* of the ocean at a given instant in time (e.g., $$u$$, $$v$$, $$w$$, and $$\rho$$). The `WVTransform` can be customized to tell you anything you want about the state of the ocean at a point in time.
+A [`WVTransform`](/classes/transforms/wvtransform/) represents the state of a rotating fluid at a reference time. Wave-bearing transforms store that state in the wave–vortex coefficients `Ap`, `Am`, and `A0`; quasigeostrophic transforms use `A0`. The transform reconstructs physical variables such as velocity, density, pressure, and potential vorticity when they are requested.
 
-## WVModel
+Transforms also provide the forward projection from physical fields to coefficients, spectral differentiation and integration, interpolation at periodic off-grid positions, energetics, spectra, and flow-component diagnostics. Choose the transform family to match the desired stratification and dynamical approximation.
 
-A `WVModel` instance uses a `WVTransform` instance to integrate (time-step) the non-linear equations of motion forwad in time. The `WVModel` class adds support for features like particle advection and tracer advection.
+## `WVModel`: evolve and observe a state
 
+A [`WVModel`](/classes/wvmodel/) advances a `WVTransform` in time. Analytical linear evolution is useful for evaluating a prescribed superposition of modes. Fixed-step and adaptive integration evolve active coefficient and observing-system dynamics.
 
+The model coordinates forcing and closures, Lagrangian particles, tracers, moorings, Eulerian fields, and wave–vortex coefficients. Output files and output groups allow these observing systems to be sampled on different schedules and restored for a later restart.
+
+## A typical workflow
+
+1. Construct the appropriate `WVTransform`.
+2. Initialize it from physical fields, individual modes, a spectrum, or a saved file.
+3. Inspect reconstructed fields and diagnostics.
+4. If integrating nonlinear dynamics, configure forcing and a closure.
+5. Construct a `WVModel`, add observing systems or output, and integrate.
+
+Continue with [Using `WVTransform`](/users-guide/using-the-wvtransform.html) for concrete construction and initialization examples.

--- a/Documentation/WebsiteDocumentation/users-guide/netcdf-output.md
+++ b/Documentation/WebsiteDocumentation/users-guide/netcdf-output.md
@@ -1,25 +1,35 @@
 ---
 layout: default
-title: WaveVortexModel NetCDF output
-parent: Users guide
+title: NetCDF conventions
+parent: User guide
 nav_order: 18
 mathjax: true
 ---
 
-#  WaveVortexModel NetCDF output
+# NetCDF conventions
 
-WaveVortexModel NetCDF output follows the [CF metadata conventions](https://cfconventions.org) to "promote the processing and sharing of files created with the NetCDF API". These conventions are (mostly) automatically followed by the code.
+WaveVortexModel writes named dimensions, variables, units, descriptive attributes, transform metadata, and history information through its annotated persistence system. This metadata makes model files self-describing and provides the information required to reconstruct supported transforms, forcing, observing systems, and restart state.
 
-For data that is intended to be distributed, it is also useful to follow the [attribute convention for data discovery](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3). These additional attributes are not added automatically by the WaveVortexModel, but a tool is provided for making this easy.
+## Scientific variables
 
-## Global attributes
+Each registered variable has a `WVVariableAnnotation` that defines its name, dimensions, units, and description. The output system uses those annotations when creating NetCDF dimensions and variables. Eulerian fields, coefficients, particles, tracers, and moorings add the dimensions and metadata needed for their own stored state.
 
-## Dimensions
+The package uses established names and units where they are defined, but the metadata should still be reviewed before a file is distributed or deposited in an archive.
 
-## Variables
+## CF conventions
 
-- `name' name of the variable used by the WVOperation
-- `standard_name' the standard name must come
-- `long_name'
+The [Climate and Forecast metadata conventions](https://cfconventions.org) provide standard names, coordinate rules, and structural guidance for interoperable geoscience data. WaveVortexModel supplies useful CF-oriented metadata, but it does not claim that every possible output configuration is automatically a complete CF-compliant data product.
 
+Users preparing a distributed dataset should verify coordinate attributes, standard names, units, missing-value treatment, and any project-specific requirements with an appropriate CF checker.
 
+## Discovery metadata
+
+The [Attribute Convention for Data Discovery](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3) describes global attributes used by repositories and search systems. Dataset title, summary, creator, institution, spatial and temporal coverage, license, and persistent identifiers depend on the scientific project and are therefore the responsibility of the file producer.
+
+Add project-specific global attributes as part of the output workflow and validate the finished file before publication. WaveVortexModel's automatically recorded class, package version, creation date, references, and history complement this dataset-level metadata but do not replace it.
+
+## Related guidance
+
+- [Reading and writing files](/users-guide/reading-and-writing-to-file.html) covers transform persistence, ordinary model output, and restart.
+- [Reading and writing files: advanced topics](/users-guide/reading-and-writing-to-file-advanced.html) covers multiple files, schedules, observing systems, restoration, and failure behavior.
+- [Creating new state variables](/users-guide/creating-new-state-variables.html) explains how annotations supply names, dimensions, units, and descriptions for custom output variables.

--- a/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file-advanced.md
+++ b/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file-advanced.md
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: Reading and writing to file, advanced topics
-parent: Users guide
+title: Reading and writing files: advanced topics
+parent: User guide
 mathjax: true
 nav_order: 12
 has_toc: true
 ---
 
-#  Reading and writing to file, advanced topics
+# Reading and writing files: advanced topics
 
 The `WVModel` supports multiple output files, groups with different output intervals, and groups that start and stop at different model times.
 
-With these features, it is possible to setup up numerical simulations that "observe" the ocean in different ways, at different intervals. For example, you might place moorings in your simulation that sample the velocity field at a high frequency. You might setup a series of drifter experiments, that deploy and retrieve drifters every five days.
+These features let one simulation observe the fluid in several ways and at several intervals. For example, moorings may sample velocity frequently while a sequence of drifter experiments deploys and retrieves particles in bounded five-day windows.
 
 There are three classes that work together to write to file:
 
@@ -24,13 +24,24 @@ Any `WVObservingSystem` that requires integration is also held by the model. The
 
 ## WVObservingSystem
 
-Observing systems include, e.g., the wave-vortex coefficients, Eulerian fields, Lagrangian particles, tracers, mooring, and satellite along-track data.
+Observing systems include wave–vortex coefficients, Eulerian fields, Lagrangian particles, tracers, moorings, and satellite along-track data.
 
 Subclasses of `WVObservingSystem` describe whether the observing system needs to be integrated in time and how it writes to a `WVModelOutputGroup`. `WVCoefficients` participates in model integration while coefficient storage is provided by the Eulerian field observer. `WVMooring` writes sampled fields without adding integrated state. `WVLagrangianParticles` and `WVTracer` both add integrated state and write their latest state to output.
 
 ## WVModelOutputFile
 
 After creating a `WVModel`, you may add one or more `WVModelOutputFile` instances. The model combines their requested output times so coincident times are integrated once and delivered to every file and group that requested them.
+
+The convenience method `createNetCDFFileForModelOutput` creates one file and one evenly spaced group containing the model's ordinary observing systems. For explicit control, construct the layers separately:
+
+```matlab
+outputFile = model.addNewOutputFile('experiment.nc');
+hourly = outputFile.addNewEvenlySpacedOutputGroup( ...
+    'hourly',initialTime=model.t,finalTime=model.t+86400,outputInterval=3600);
+hourly.addObservingSystem(model.eulerianObservingSystem);
+```
+
+The file remains an in-memory configuration until its first output initialization. This makes it possible to assemble groups and observing systems before any partial file exists on disk.
 
 Each file is an independent restart boundary. `WVModel.modelFromFile(path)` restores the supplied file and all of its groups; it does not reconstruct other files that the original model may also have written. A restart-capable file must contain exactly one group with the complete coefficient stream (`Ap`, `Am`, and `A0` for wave-bearing transforms, or `A0` for QG transforms). Other groups may store fields and observing systems without duplicating that complete coefficient stream.
 

--- a/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file.md
+++ b/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file.md
@@ -1,74 +1,86 @@
 ---
 layout: default
-title: Reading and writing to file
-parent: Users guide
+title: Reading and writing files
+parent: User guide
 mathjax: true
 nav_order: 10
 has_toc: true
 ---
 
-#  Reading and writing to file
+# Reading and writing files
 
-The `WVTransform` and the `WVModel` both read and write to NetCDF files.
+WaveVortexModel uses NetCDF files for transform persistence, model output, and restart. A transform file stores the geometry and wave–vortex state needed to reconstruct a `WVTransform`. A restart-capable model file additionally stores forcing, observing systems, output groups, and the latest integrated state.
 
-## WVTransform
+## Save and restore a transform
 
-After you create a `WVTransform` instance
+Write a transform and close the returned file handle:
+
 ```matlab
-wvt = WVTransformConstantStratification([50e3 50e3 1300], [64 64 32]);
+wvt = WVTransformConstantStratification( ...
+    [50e3 50e3 1300],[32 32 17],N0=5.2e-3,latitude=45);
+wvt.initWithRandomFlow();
+
+ncfile = wvt.writeToFile('transform.nc');
+ncfile.close();
 ```
-you call `writeToFile`
+
+Restore the transform through the static factory. The one-output form closes its read handle before returning:
+
 ```matlab
-wvt.writeToFile('test.nc');
+wvtRestored = WVTransform.waveVortexTransformFromFile('transform.nc');
 ```
-and all the information needed to exactly re-create the `wvt` instance will be written to file.
 
-To create a new `WVTransform` instance from file, call the static method [`waveVortexTransformFromFile`](/classes/transforms/wvtransform/wavevortextransformfromfile.html)
+Pass additional registered variable names to `writeToFile` when physical fields or diagnostics should be stored alongside the reconstructable state:
+
 ```matlab
-wvt2 = WVTransform.waveVortexTransformFromFile('test.nc');
+ncfile = wvt.writeToFile('transform-with-fields.nc','u','v','rho');
+ncfile.close();
 ```
-The two instances `wvt` and `wvt2` are now equivalent. This one-output form closes the NetCDF file before returning.
 
-### Adding variables
+## Read a transform time series
 
-Any variable that the `WVTransform` instance knows about (including [custom variables](/developers-guide/operations-and-variables.html)) can also be written to file, but including its name in the variable argument list. For example, if you want to add the variables $$u$$, $$v$$, and $$\zeta_z$$ then call,
+Model output may contain many time records. Creating the transform once and updating its coefficients is less expensive than reconstructing its geometry for every record.
+
+Request the second output to retain a caller-owned, read-only `NetCDFFile`, and close it explicitly:
+
 ```matlab
-wvt.writeToFile('test.nc','u','v','zeta_z');
-```
-and the data will be written, accessible from anything that reads NetCDF files.
-
-### Reading model output
-
-Model output contains multiple time points from which the a `WVTransform` instance can be initialized. To initialize a `WVTransform` instance from a specific point in the model output, call
-```matlab
-wvt = WVTransform.waveVortexTransformFromFile('test.nc',iTime=100);
-``` 
-where `iTime=100` indicates the index along the time dimension.
-
-It is often the case that for analysis of model output, you want to read the model output at multiple time points. You *could* intialize a new `WVTransform` instance at each time index, but this involves unnecessary computation. Instead, you should update the existing `WVTransform` instance `wvt` with the data from that time point.
-
-First load the NetCDF file, then initialize the existing instance from a specific time point in that file with [`initFromNetCDFFile`](/classes/transforms/wvtransform/initfromnetcdffile.html). For example, a for-loop over all time points written to file, would look like
-```matlab
-[wvt, ncfile] = WVTransform.waveVortexTransformFromFile('test.nc');
+[wvt,ncfile] = WVTransform.waveVortexTransformFromFile('model-output.nc');
 cleanup = onCleanup(@()ncfile.close());
 t = ncfile.readVariables("wave-vortex/t");
 
-for iTime=1:length(t)
+for iTime = 1:numel(t)
     wvt.initFromNetCDFFile(ncfile,iTime=iTime);
-    % do some analysis
+    energy(iTime) = wvt.totalEnergy;
 end
 ```
 
-The returned `ncfile` is read-only by default and must be closed by the caller. Pass `shouldReadOnly=false` explicitly only when writable access is required.
+Use `shouldReadOnly=false` only when the returned file genuinely needs writable access.
 
-## WVModel
+## Write model output
 
-Time series model output is created with
+For a model with one ordinary output schedule, create the file through the convenience method and integrate:
 
 ```matlab
-model = WVModel(wvt);
-model.createNetCDFFileForModelOutput('test.nc',outputInterval=wvt.inertialPeriod);
-model.integrateToTime(10*wvt.inertialPeriod);
+model = WVModel(wvt,shouldUseLinearDynamics=true);
+outputFile = model.createNetCDFFileForModelOutput( ...
+    'model-output.nc',outputInterval=600);
+model.integrateToTime(3600);
+outputFile.closeNetCDFFile();
 ```
 
-which can then be read in using the above commands.
+The physical file is created lazily when output is first initialized. Before integration you may add Eulerian variables, particles, tracers, or other observing systems to the model's output configuration.
+
+## Restore and continue a model
+
+Restore a model from one restart-capable file:
+
+```matlab
+model = WVModel.modelFromFile('model-output.nc');
+model.setupIntegrator();
+model.integrateToTime(model.t + 3600);
+model.outputFiles(1).closeNetCDFFile();
+```
+
+Runtime integrator objects are not persisted, so configure the desired fixed or adaptive settings after restoration. `modelFromFile` restores only the supplied file's output graph; other files written by the original run are independent restart boundaries.
+
+For multiple schedules, bounded output windows, shared observing systems, and handle ownership, continue with [Reading and writing files: advanced topics](/users-guide/reading-and-writing-to-file-advanced.html). For metadata conventions, see [NetCDF conventions](/users-guide/netcdf-output.html).

--- a/Documentation/WebsiteDocumentation/users-guide/supported-features.md
+++ b/Documentation/WebsiteDocumentation/users-guide/supported-features.md
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: Capabilities and limitations
-parent: Users guide
+parent: User guide
 nav_order: 3
 has_toc: true
 ---
 
 # Capabilities and limitations
 
-WaveVortexModel provides five transform families together with model integration, forcing, observing systems, and NetCDF output. This page summarizes the public behavior covered by the package documentation and release tests. Public MATLAB visibility alone does not make an implementation helper a recommended entry point.
+WaveVortexModel provides five transform families together with model integration, forcing, observing systems, and NetCDF output. This page summarizes the documented public behavior and important limitations. Public MATLAB visibility alone does not make an implementation helper a recommended entry point.
 
 ## Transforms
 
@@ -38,7 +38,7 @@ For three-dimensional transforms, `diffZF` and `diffZG` accept derivative orders
 
 `WVModel` provides adaptive and fixed-step integration, tolerance and time-step configuration, segmented integration, model output, and restart. Call `setupIntegrator` to change time-stepping settings.
 
-The `adaptive-cell` option remains available for development but is not exercised by the v4.2.1 release tests. Low-level integrator mixins and `ode45_cell` are implementation machinery rather than model entry points.
+The `adaptive-cell` option is under development and does not have the validation coverage of fixed-step and adaptive integration. Low-level integrator mixins and `ode45_cell` are implementation machinery rather than model entry points.
 
 ## Forcing and closures
 
@@ -56,7 +56,7 @@ The supplied forcing and closure classes are:
 - `WVBetaPlanePVAdvection`
 - `WVPseudoTopographicWaveGeneration`
 
-`WVThermalDamping` remains available for development but does not yet have the same release-test coverage as the classes above. Custom forcing may be implemented through the documented `WVForcing` extension interface.
+`WVThermalDamping` is under development and has more limited validation than the classes above. Custom forcing may be implemented through the documented `WVForcing` extension interface.
 
 ## Observing systems, output, and restart
 
@@ -70,6 +70,4 @@ Custom operations and annotated variables use `WVOperation` and `WVVariableAnnot
 
 Optimization Toolbox is optional. `WVNoMotionProfileOperation` uses `lsqnonlin` when it is available and otherwise uses `fminsearch` with an advisory warning.
 
-FFTW selection and the low-level barotropic FINUFFT path remain active development machinery. They are not selected through the documented transform constructors or public interpolation options, and FINUFFT is not a required package dependency.
-
-New scientific capabilities, new transform families, and broad numerical redesign are outside the v4.2.1 maintenance release.
+FFTW selection and the low-level barotropic FINUFFT path remain development machinery. They are not selected through the documented transform constructors or public interpolation options, and FINUFFT is not a required package dependency.

--- a/Documentation/WebsiteDocumentation/users-guide/using-the-wvtransform.md
+++ b/Documentation/WebsiteDocumentation/users-guide/using-the-wvtransform.md
@@ -1,121 +1,145 @@
 ---
 layout: default
-title: Using the WVTransform
-parent: Users guide
+title: Using WVTransform
+parent: User guide
 mathjax: true
 nav_order: 2
 has_toc: true
 ---
 
-#  Using the WVTransform
+# Using `WVTransform`
 
-At the time of this writing there are five `WVTransform` subclasses with different capabilities,
-- `WVTransformBoussinesq` Non-hydrostatic, variable stratification
-- `WVTransformHydrostatic` Hydrostatic, variable stratification
-- `WVTransformConstantStratification` Non-hydrostatic, constant stratification
-- `WVTransformStratifiedQG` Quasigeostrophic dynamics, variable stratification
-- `WVTransformBarotropicQG` Quasigeostrophic dynamics, equivalent barotropic
+A `WVTransform` represents a fluid state in physical and wave–vortex coordinates. The transform family determines the dynamical approximation, vertical structure, and flow components available to the state.
 
-These `WVTransform` subclasses are used in the same way, but may have different capabilities and requirements for initialization.
+## Choose a transform
 
-## Initialization
+| Transform | Use it for |
+| --- | --- |
+| [`WVTransformConstantStratification`](/classes/transforms/wvtransformconstantstratification/) | Hydrostatic or nonhydrostatic flow with constant buoyancy frequency. |
+| [`WVTransformHydrostatic`](/classes/transforms/wvtransformhydrostatic/) | Hydrostatic flow with variable stratification. |
+| [`WVTransformBoussinesq`](/classes/transforms/wvtransformboussinesq/) | Nonhydrostatic flow with variable stratification. |
+| [`WVTransformStratifiedQG`](/classes/transforms/wvtransformstratifiedqg/) | Three-dimensional stratified quasigeostrophic flow. |
+| [`WVTransformBarotropicQG`](/classes/transforms/wvtransformbarotropicqg/) | Two-dimensional equivalent-barotropic quasigeostrophic flow. |
 
-All transforms require you specify the domain size, number of grid points and latitude.
+All rotating transforms accept latitude in either hemisphere for $$5 \leq |\mathrm{latitude}| \leq 85$$ degrees.
 
-The Boussinesq, hydrostatic and stratified QG transformations require you pass a function handle describing the stratification, e.g.,
+## Construct a transform
+
+Every transform takes the domain size and grid size as its first two arguments. Wave-bearing three-dimensional transforms store `Ap`, `Am`, and `A0`; the QG transforms store their geostrophic state in `A0`.
+
+### Constant stratification
+
+Supply the constant buoyancy frequency `N0`. The default is nonhydrostatic; set `isHydrostatic=true` to use the hydrostatic approximation.
+
 ```matlab
-wvt = WVTransformHydrostatic([Lx, Ly, Lz], [Nx, Ny, Nz], N2=@(z) N0*N0*exp(2*z/L_gm),latitude=33);
-```
-whereas constant stratification transform requies the buoyancy frequency $$N_0$$
-```matlab
-wvt = WVTransformConstantStratification([Lx, Ly, Lz], [Nx, Ny, Nz], N0=5.2e-3,latitude=33);
-```
-The equivalent barotropic transform requires that you specify an equivent depth $$h$$,
-```matlab
-wvt = WVTransformBarotropicQG([Lx, Ly], [Nx, Ny], h=0.80,latitude=33);
-```
-where a typical oceanic value for the first barolinic mode would be around 80 cm.
+Lxyz = [100e3 100e3 4000];
+Nxyz = [64 64 65];
+N0 = 3*2*pi/3600;
 
-## Grids
-
-Note that you do not specify the grids, only the domain size---the grids are determined by the transforms.
-
-The dimensions that result can be accessed with, e.g., `wvt.x` or `wvt.z`. This will be array of size `[Nx 1]` and `[Nz 1]`, respectively. More useful perhaps are the grids, e.g., `wvt.X` or `wvt.Z` which are of size `[Nx Ny Nz]`.
-
-For the current set of transforms $$x$$ and $$y$$ grids will always be evenly spaced grids appropriate for Fourier transforms, while the $$z$$ grid will be evenly spaced for constant stratification (sine and cosine transforms), but will have variable spacing when using variable stratification. **Never create your own grids---always use the built-in functions.**
-
-
-## Initial conditions
-
-Once a tranform is instantiated, it is often the case that one would like to add initial conditions. The [WVTransform](/classes/transforms/wvtransform/) class has numerous methods for adding initial conditions---including very general initialization from any fluid state, as well as initialization specific to waves, inertial oscillations, and geostrophic motions.
-
-### Initializing from $$(u,v,\eta)$$
-
-The most direct methods for initializing the model are [`initWithUVEta`](/classes/transforms/wvtransform/initwithuveta.html) and [`initWithUVRho`](/classes/transforms/wvtransform/initwithuvrho.html) which take either $$(u,v,\eta)$$ or $$(u,v,\rho)$$. As a simple example, let's intialize with an inertial oscillation initial condition, $$(u_0 \exp(z/100),0,0)$$. In code, this is
-```matlab
-wvt.initWithUVEta( 0.2*exp(wvt.Z/100), 0*wvt.X, 0*wvt.X );
+wvt = WVTransformConstantStratification( ...
+    Lxyz,Nxyz,N0=N0,latitude=30);
+wvtHydrostatic = WVTransformConstantStratification( ...
+    Lxyz,Nxyz,N0=N0,latitude=30,isHydrostatic=true);
 ```
 
-These methods can be used to initialize from *any* flow fields that use the same stratification and boundary conditions as the `WVTransform` that is being used. For example, you might use output from another model and use [`initWithUVRho`](/classes/transforms/wvtransform/initwithuvrho.html) to initialize the WaveVortexMode with that output.
+### Variable stratification
 
-### Initializing waves, inertial oscillations, and geostrophic motions
+Supply either `N2Function`, returning the squared buoyancy frequency, or `rhoFunction`, returning the mean density profile on $$[-L_z,0]$$.
 
-The wave-vortex model provides methods for initializing the fluid with specific dynamical solutions, including inertial oscillations, internal gravity waves, and geostrophic (vortex) flows. 
-
-To initialize individual waves, use `initWithWaveModes` and the related methods, e.g.,
 ```matlab
-[omega, k, l] = wvt.initWithWaveModes(kMode=10,lMode=0,j=1,phi=0,u=0.2,sign=1);
+N0 = 3*2*pi/3600;
+Lgm = 1300;
+N2 = @(z) N0*N0*exp(2*z/Lgm);
+
+wvtHydrostatic = WVTransformHydrostatic( ...
+    Lxyz,Nxyz,N2Function=N2,latitude=30);
+wvtBoussinesq = WVTransformBoussinesq( ...
+    Lxyz,Nxyz,N2Function=N2,latitude=30);
+wvtQG = WVTransformStratifiedQG( ...
+    Lxyz,Nxyz,N2Function=N2,latitude=30);
+```
+
+### Equivalent-barotropic QG
+
+The two-dimensional transform takes horizontal dimensions and an equivalent depth `h`:
+
+```matlab
+wvtBarotropic = WVTransformBarotropicQG( ...
+    [100e3 100e3],[64 64],h=0.8,latitude=30);
+```
+
+## Use the transform grids
+
+The transform chooses grids compatible with its spectral representation. Access coordinate vectors through `wvt.x`, `wvt.y`, and, for three-dimensional transforms, `wvt.z`. The arrays `wvt.X`, `wvt.Y`, and `wvt.Z` have the transform's spatial matrix shape.
+
+Horizontal grids are evenly spaced and periodic. Constant-stratification transforms use the sine/cosine vertical grid, while variable-stratification transforms use quadrature points determined by the vertical modes. Use the grids supplied by the transform rather than constructing replacements.
+
+## Initialize a fluid state
+
+Initialization methods follow a common naming convention:
+
+- `initWith...` clears `Ap`, `Am`, and `A0` before initializing the requested state.
+- `set...` replaces one flow component while preserving the others.
+- `add...` superimposes a flow component on the existing state.
+- `removeAll...` removes the named component.
+
+### Project physical fields
+
+For wave-bearing transforms, `initWithUVEta` and `initWithUVRho` project gridded velocity and displacement or density-anomaly fields onto the wave–vortex basis. Inputs must use the transform's spatial grid and boundary conditions.
+
+```matlab
+U = 0.2*exp(wvt.Z/100);
+V = zeros(wvt.spatialMatrixSize);
+eta = zeros(wvt.spatialMatrixSize);
+wvt.initWithUVEta(U,V,eta);
+```
+
+This projection can also decompose output from another numerical model when its fields have been placed on compatible grids with compatible stratification and boundary conditions.
+
+### Initialize analytical components
+
+The component-specific methods initialize internal waves, inertial oscillations, geostrophic motions, and mean-density anomalies. For example, initialize one internal wave by integer horizontal and vertical mode numbers:
+
+```matlab
+[omega,k,l] = wvt.initWithWaveModes( ...
+    kMode=10,lMode=0,j=1,phi=0,u=0.2,sign=1);
 period = 2*pi/omega;
 ```
-will initialize a first baroclinic mode wave with a wavenumber of $$k = 10(2\pi)/L_x$$.
 
-To initialize with a geostrophic stream function, use `initWithGeostrophicStreamfunction` and the related methods, e.g.,
-```matlab
-Le = 35e3;
-z0 = -wvt.Lz/4;
-He = wvt.Lz/10;
-U = 0.25; % m/s
-psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2) .* (erf((z-z0)/He)+1)/2;
+Use `initWithRandomFlow` for a deterministic or random collection of supported components, and use the component-specific API pages for spectral initialization options.
 
-wvt.setGeostrophicStreamfunction(psi);
-```
-creates a deep eddy.
+## Evaluate physical fields
 
-The initialization methods for the [WVTransform](/classes/transforms/wvtransform/) all use the same nomenclature,
+Registered state variables can be accessed through dot syntax:
 
-- `init`---clears ALL variables `Ap`, `Am`, `A0`, then sets/adds
-- `set`---clears only the component requested, and sets with new value.
-- `add`---adds to existing component
-- `removeAll`---remove all features of given type  
-
-### Other initialization methods
-
-It can also be useful to [`initWithRandomFlow`](/classes/transforms/wvtransform/initwithrandomflow.html). Also check out the section on [reading and writing to file](/users-guide/reading-and-writing-to-file.html) for how to use [`initFromNetCDFFile`](/classes/transforms/wvtransform/initfromnetcdffile.html) to quickly read in the ocean state from a saved file.
-
-## Examining the fluid state
-
-Once you have a `WVTransform` instance, you can now query it to return different state variables. The term "state" is used because these variables tell you something about the state of the fluid at the time in question.
-
-Standard variables that are available are documented with the [WVTransform](/classes/transforms/wvtransform/) and include $$(u,v,w,\rho,p)$$, the sea-surface height and velocities, the quasi-geostrophic potential vorticity (qgpv), the nonlinear fluxes $$(F_p, F_m, F_0)$$ and others. The transform has numerous built-in state variables
-```matlab
-wvt.summarizeVariables
-```
-will enumerate all current variables.
-
-There are two ways to access state variables. In the first way, you can query the transform using Matlab's dot syntax, e.g.,
 ```matlab
 u = wvt.u;
+rho = wvt.rho;
 ```
-will return a matrix of the $$u$$ velocity component. This can then be plotted in the usual way, e.g.,
+
+Requesting related variables together avoids repeating shared calculations:
+
 ```matlab
-figure
-pcolor(wvt.y,wvt.z,squeeze(wvt.u(1,:,:)).'), shading interp
+[u,v,w,rho] = wvt.variableWithName('u','v','w','rho');
 ```
-where the properties of the WVTransform `wvt.y` and `wvt.z` refer to those dimensions.
 
-The other way to access variables is to query them in a list using the [`variableWithName`](/classes/transforms/wvtransform/variablewithname.html) method,
- ```matlab
-[u,v,w] = wvt.variableWithName('u','v','w');
+Use `wvt.summarizeVariables` to list the registered variables, their dimensions, and units. Depending on the transform, variables include velocity, density, pressure, sea-surface fields, quasigeostrophic potential vorticity, energy diagnostics, and nonlinear fluxes.
+
+For periodic off-grid queries, use `variableAtPositionWithName` with `linear` or `spline` interpolation:
+
+```matlab
+xq = [0 10e3 20e3];
+yq = [0 15e3 30e3];
+zq = [-100 -300 -500];
+[uq,vq] = wvt.variableAtPositionWithName( ...
+    xq,yq,zq,'u','v',interpolationMethod='spline');
 ```
-this returns all the variables requested at the grid points. However, you can also use the [`variableAtPositionWithName`](/classes/transforms/wvtransform/variableatpositionwithname.html) method to return the value of any variable at *any* set of points in the domain. This method is used to do particle advection by the `WVModel`.
 
+Horizontal query coordinates wrap periodically. The returned arrays retain the query shape.
+
+## Continue from here
+
+- [Wavenumbers, modes, and indices](/users-guide/wavenumber-modes-and-indices.html) explains primary and conjugate mode conventions.
+- [Adding forcing](/users-guide/adding-forcing.html) prepares a transform for nonlinear integration.
+- [Reading and writing files](/users-guide/reading-and-writing-to-file.html) covers transform persistence and model restart.
+- [`WVTransform` API](/classes/transforms/wvtransform/) lists all state variables, diagnostics, and initialization methods.

--- a/Documentation/WebsiteDocumentation/users-guide/wavenumber-modes-and-indices.md
+++ b/Documentation/WebsiteDocumentation/users-guide/wavenumber-modes-and-indices.md
@@ -1,39 +1,39 @@
 ---
 layout: default
 title: Wavenumbers, modes, and indices
-parent: Users guide
+parent: User guide
 mathjax: true
 nav_order: 16
 ---
 
-#  Wavenumbers, modes, and indices
+# Wavenumbers, modes, and indices
 
-Working with the WaveVortexModel requires working with wavenumbers (such as $$k$$ and $$l$$), modes (such as geostrophic modes, or mode number $$j$$), and indices into matrices. There are many best practices and tools for working with wavenumbers, mode, and indices.
+WaveVortexModel distinguishes physical wavenumbers, integer mode numbers, and array indices. Keeping those concepts separate is important when initializing modes or mapping between physical, DFT, and wave–vortex representations.
 
 ## Definitions
 
-A **wavenumber** is a [spatial frequency](https://en.wikipedia.org/wiki/Wavenumber) with units of radians per meter. All WVTransform classes have horizontal wavenumbers $$k$$ and $$l$$, and the constant stratification class also has a vertical wavenumber $$m$$.
+A **wavenumber** is a [spatial frequency](https://en.wikipedia.org/wiki/Wavenumber) with units of radians per meter. Every `WVTransform` has horizontal wavenumbers $$k$$ and $$l$$, and the constant-stratification transform also has vertical wavenumber $$m$$.
 
-A **mode** is a unitless integer quantity. The model refers to `kMode` and `lMode`, and `j` all as unitless modes. Additionally, a geostrophic solution is also a mode (as are the other linear solutions).
+A **mode number** is a dimensionless integer label. `kMode`, `lMode`, and `j` identify a spectral solution independently of its storage location. The word *mode* may also refer to the corresponding geostrophic, wave, inertial, or mean-density-anomaly solution.
 
-An **index** is a location in memory of a particular variable. Matlab uses [subscript indices, linear indices, and logical indexing](https://www.mathworks.com/company/technical-articles/matrix-indexing-in-matlab.html) for different ways of accessing memory. The prefered method of indexing is local indexing.
+An **index** is a storage location in a MATLAB array. MATLAB provides [subscript, linear, and logical indexing](https://www.mathworks.com/company/technical-articles/matrix-indexing-in-matlab.html). Use the transform and flow-component mapping methods instead of assuming a particular internal ordering.
 
 ## More about modes
 
-Each degree-of-freedom in the wave-vortex model is a mode, which, in this case, is specifically a linear solution to the equations of motion. Each degree-of-freedom is identified with a unique set of mode numbers, either `(kMode,lMode)` or `(kMode,lMode,jMode)`, depending on whether the flow is two-dimensional or three-dimensional. There are two aspects of this identification which are important to call out:
+Each degree of freedom in the wave–vortex representation corresponds to a linear solution of the governing equations. A unique set of mode numbers, either `(kMode,lMode)` or `(kMode,lMode,j)`, identifies that solution. Two aspects of this identification are important:
 1. each set of mode numbers identifies a unique solution, and
 2. the choice of mode number for each solution is a matter of convention.
 
-As a consequence of these two aspects, you, the user, cannot know *a priori* what a valid set of mode numbers is unless the notation is established. The terminology used here is that these mode numbers are *primary* mode numbers. Furthermore, there may be other reasonable choices of mode number which are standard and perfectly valid. The terminology used here is that these are *conjugate* mode numbers. If a conjugate mode number exists, then this implies that there is some mapping from the conjugate mode to the primary solution. For these reasons, the all `WVTransform` subclass respond to the follow APIs,
+The unique labels stored by the transform are *primary* mode numbers. A physically equivalent Fourier representation may use a *conjugate* mode number, which maps back to the primary solution with the appropriate conjugation. The transform geometries provide:
 
 - `bool = isValidPrimaryModeNumber(self,kMode,lMode,jMode)`
 - `bool = isValidConjugateModeNumber(self,kMode,lMode,jMode)`
 - `bool = isValidModeNumber(self,kMode,lMode,jMode)`
 
-The function `isValidPrimaryModeNumber` will tell you whether or not that particular set of mode numbers is a valid, unique solution that is part of the basis set being used. The function `isValidConjugateModeNumber` will similarly tell you whether that mode number corresponds to a valid solution, but one which is not primary.
+`isValidPrimaryModeNumber` identifies a unique stored solution. `isValidConjugateModeNumber` identifies a valid equivalent label that is not primary. `isValidModeNumber` accepts either form.
 
-As a concrete example, consider the the modal solution to the periodic harmonic equation, $$u = A \sin\left( n \frac{\pi x}{L} \right)$$. A resonable convention would be to establish that $$n$$ must be an integer such that $$ 1 \leq n \leq 7$$ as the 7 primary mode numbers. Alternatively, it would be perfectly reasonable to choose $$-7 \leq n \leq -1$$ as the mode numbers and thus as a matter of convention we could identify these as conjugate mode numbers. Both are valid sets of mode numbers, and the mapping that exists between these different set of mode numbers requires we change the sign on the amplitude of the solution.
+As a simple analogy, consider the periodic harmonic solution $$u = A \sin(n\pi x/L)$$. One convention could label $$1 \leq n \leq 7$$ as primary, while the equivalent negative labels $$-7 \leq n \leq -1$$ are conjugate. Both label the same physical solution set, but their amplitudes must be mapped consistently.
 
-The situation gets more complicated as the solutions get more complicated. For doubly periodic geometry we now make a choice as to which set of wavenumber in which dimension gets designated as conjugate, and thus `WVGeometryDoublyPeriodic` has a `conjugateDimension` property which gets set upon initialization. Use of the above APIs let this choice be invisible to the user, even though it strongly affects the numerics.
+For doubly periodic geometry, the primary half-plane depends on the geometry's conjugate dimension. The mapping APIs hide that storage convention from ordinary initialization and analysis code.
 
-The modes of the `WVTransform` classes are not solutions to the harmonic equation, but are instead solutions to various linearized equations of motion of geophysical flows. These solutions include the usual geostrophic and internal gravity solutions. The wave-vortex model identifies these solution types using the `WVFlowComponent` subclass `WVPrimaryFlowComponent`. The flow components also respond to the same three APIs listed above.
+WaveVortexModel's modes are solutions to linearized geophysical equations rather than the simple harmonic example. `WVPrimaryFlowComponent` subclasses classify the geostrophic, internal-wave, inertial, and mean-density-anomaly solutions and provide the same primary/conjugate validation methods for their own mode sets.

--- a/README.md
+++ b/README.md
@@ -1,187 +1,52 @@
-WaveVortexModel
-==============
+# WaveVortexModel
 
-The WaveVortexModel decomposes a Boussinesq fluid with arbitrary stratification into geostrophic motions and interia-gravity waves. This model is complete, and therefore also can be time-stepped forward
+WaveVortexModel represents rotating, stratified Boussinesq flow on an energetically orthogonal basis of internal waves, inertial oscillations, geostrophic motions, and mean-density anomalies. It can decompose a fluid state into wave–vortex coefficients, reconstruct physical fields, diagnose the resulting flow, and integrate linear or nonlinear dynamics.
 
-This model has several significant features.
+**Complete documentation:** [wavevortexmodel.org](https://wavevortexmodel.org)
 
-1. The internal waves can be initialized with Garrett-Munk spectrum, consistent for bounded domains and arbitrary stratification.
-2. The model can be initialized from variables (u,v,rho), and thus performs a wave-vortex decomposition following the methodology in [Early, Lelong and Sundermeyer, 2021 JFM](https://arxiv.org/abs/2002.06267).
+## Installation
 
-If you use these classes, please cite the JFM paper.
-
-### Table of contents
-1. [Quick Start](#quick-start)
-2. [Introduction](#introduction)
-3. [Gridded wave modes](#gridded-wave-modes)
-4. [Dynamical variables](#dynamical-variables)
-    1. [Eulerian](#eulerian)
-    2. [Lagrangian](#lagrangian)
-5. [Initialization](#initialization)
-
-------------------------
-
-Quick start
-------------
-
-To initialize the linear internal wave model, you first have to set the problem dimensions,
-```matlab
-aspectRatio = 8;
-
-Lx = 100e3;
-Ly = aspectRatio*100e3;
-Lz = 5000;
-
-Nx = 64;
-Ny = aspectRatio*64;
-Nz = 65; % 2^n + 1 grid points, to match the Winters model, but 2^n ok too.
-
-latitude = 31;
-```
-and then initialization either the constant stratification model with some buoyancy frequency,
-```matlab
-N0 = 5.2e-3;
-wavemodel = InternalWaveModelConstantStratification([Lx, Ly, Lz], [Nx, Ny, Nz], latitude, N0);
-```
-or initialize the arbitrary stratification model with some density profile,
-```matlab
-[rho, ~, zIn] = InternalModes.StratificationProfileWithName('exponential');
-z = linspace(min(zIn),max(zIn),100)';
-maxModes = 32;
-wavemodel = InternalWaveModelArbitraryStratification([Lx, Ly, Lz], [Nx, Ny, Nz], rho, z, maxModes, latitude);
-```
-The constant stratification model *must* model the entire ocean depth, because it uses the fast cosine transform to sum the vertical modes. The arbitrary stratification model, however, can be given `z` that only includes part of the domain, because it uses the slow (matrix multiplication) transform to sum the vertical modes. The argument `maxModes` sets how many vertical modes are used. The stratification profile in the example came from the [`InternalModes` class](../InternalModes/).
-
-Once the model has been created, you can initialize the model with either a single plane wave,
-```matlab
-k0 = 4; % k=0..Nx/2
-l0 = 0; % l=0..Ny/2
-j0 = 20; % j=1..nModes, where 1 indicates the 1st baroclinic mode
-U = 0.01; % m/s
-sign = 1;
-
-period = wavemodel.setWaveModes(k0,l0,j0,U,sign);
-```
-or a full spectrum of waves,
-```matlab
-wavemodel.initWithGMSpectrum(1.0);
-```
-
-To access the velocity field or density field, you can simply request their value at any time,
-```matlab
-t = 0.0;
-[u,v,w] = wavemodel.VelocityFieldAtTime(t);
-rho = wavemodel.DensityFieldAtTime(t);
-zeta = wavemodel.IsopycnalDisplacementFieldAtTime(t);
-```
-
-The model also includes functions for advecting particles.
-
-Introduction
-------------
-
-The linear internal wave model adds together an arbitrary number single-mode plane-wave solutions to the linearized equations of motion on the f-plane. The model is entirely analytical---there is no numerical time-stepping routine---and the solutions are simply evaluated at the requested time.
-
-The `InternalWaveModel` class is divided into two subclasses, depending on the stratification. The constant stratification model `InternalWaveModelConstantStratification` takes advantage of the fact that the vertical modes in constant stratification are simply sines and cosines, and uses the fast fourier transform to sum the vertical modes. For more general stratification profiles, the class `InternalWaveModelArbitraryStratification` computes the vertical modes using the [`InternalModes` class](../InternalModes/) and then sums them with a (slow) matrix multiplication. This technique will often be *slower* than simplying time-stepping the linearized equations of motion using a Runge-Kutta time stepping routine, but comes with the advantage that the vertical extent of the model can be arbitrarily defined. This allows a model to be constructed with high resolution in regions of interested.
-
-Initializing the model creates a user-specified standard evenly-spaced, periodic grid. This grid is useful because it allows wave modes to be computed with the Fast Fourier Transform (FFT) algorithm and both the constant and arbitrary stratification classes use this grid to quickly compute the horizontal component of the solution.
-
-Gridded wave modes
-------------
-
-The gridded wave modes by individually added or set by specifying the mode number and amplitude,
-```matlab
-[omega,k,l] = wavemodel.addWaveModes(kMode, lMode, jMode, phi, Amp, signs);
-[omega,k,l] = wavemodel.setWaveModes(kMode, lMode, jMode, phi, Amp, signs);
-```
-where  `-Nx/2 < kMode < Nx/2` and `-Ny/2 < lMode < Ny/2` are integers specifying which modes you want to initialize. The `Set` method will remove all gridded modes and then add the list you give it, and the `Add` method will append these modes to the existing list.
-
-Equivalently, you can call
-```matlab
-period = wavemodel.setWaveModes(k0,l0,j0,U,sign);
-```
-which just calls `setWaveModes` with a phase of 0.
-
-The clear the gridded wave modes, call
-```matlab
-wavemodel.removeAllWaves();
-```
-and they will be set to 0 amplitude.
-
-
-Dynamical variables
-------------
-Once the `InternalWaveModel` object is initialized there are a few useful accessor methods for access the velocity and density at different times and positions. The API uses the following terminology:
-
-- *Eulerian* methods return values on the built-in grid. They will contain the word `Field` in the name, such as `VelocityFieldAtTime` and will always return variables in arrays that match the grid dimensions.
-- *Lagrangian* methods return values at arbitrary, user-specified positions. They will contain the phrase `Position` in the name, such as `VelocityAtTimePosition`.
-
-The density is decomposed into two parts such that density = mean + perturbation. The mean is strictly a function of z and does not vary in time.
-
-### Eulerian
-
-The following methods return values on the grid points.
+WaveVortexModel requires MATLAB R2024b or newer. The recommended installation uses [OceanKit](https://github.com/JeffreyEarly/OceanKit) as an MPM repository:
 
 ```matlab
-t = 0.0;
-[u,v,w] = wavemodel.VelocityFieldAtTime(t);
-rho = wavemodel.DensityFieldAtTime(t);
-zeta = wavemodel.IsopycnalDisplacementFieldAtTime(t);
+mpmAddRepository("OceanKit","local/path/to/OceanKit")
+mpminstall("WaveVortexModel")
 ```
 
-The density field is defined such that each part can be accessed separately,
-```matlab
-rho_bar = wavemodel.DensityMeanField;
-rho_prime = wavemodel.DensityPerturbationFieldAtTime(t);
-```
+See the [installation guide](https://wavevortexmodel.org/installation) for complete runtime and authoring instructions.
 
-Fundamentally these routines are just calling `VariableFieldsAtTime`, which lets you request any of the dynamical variables you want at a given time. If you are going for speed, it is best to call this function once for a given time point. You could request all variables like this,
+## Quick start
+
+Create a small constant-stratification transform, initialize one internal wave, inspect its velocity field, and advance the state with analytical linear dynamics:
 
 ```matlab
-[u,v,w,rho_prime,zeta] = wavemodel.VariablesFieldsAtTime(t,'u','v','w','rho_prime','zeta');
+wvt = WVTransformConstantStratification( ...
+    [40e3 40e3 1000], [16 16 9], N0=5.2e-3, latitude=45);
+
+[omega,k,l] = wvt.initWithWaveModes( ...
+    kMode=1, lMode=0, j=1, phi=0, u=0.05, sign=1);
+[u,v,w] = wvt.variableWithName('u','v','w');
+
+model = WVModel(wvt,shouldUseLinearDynamics=true);
+model.integrateToTime(600,shouldShowIntegrationDiagnostics=false);
 ```
 
-### Lagrangian
+The transform stores the decomposed state in the wave–vortex coefficients `Ap`, `Am`, and `A0`. Physical variables such as `u`, `v`, `w`, density, pressure, energy, and potential vorticity are reconstructed from those coefficients when requested.
 
-These methods will return values at any point in space and time. The argument `interpolationMethod` specifies whether periodic off-grid values use `'linear'` or cubic `'spline'` interpolation.
+## Documentation
 
-As an example, lets create some floats at various depths in the water column.
-```matlab
-dx = wavemodel.x(2)-wavemodel.x(1);
-dy = wavemodel.y(2)-wavemodel.y(1);
-nLevels = 5;
-N = floor(wavemodel.Nx/3);
-x = (0:N-1)*dx;
-y = (0:N-1)*dy;
-z = (0:nLevels-1)*(-wavemodel.Lz/(2*(nLevels-1)));
-```
-Now we can call the various Lagrangian methods to return the dynamical fields at those positions. Cubic `'spline'` interpolation offers a good accuracy-speed tradeoff, while `'linear'` interpolation is useful when speed is more important. The following code returns the values of the dynamical variables at the positions we requested,
+- [User guide](https://wavevortexmodel.org/users-guide/)
+- [Capabilities and limitations](https://wavevortexmodel.org/users-guide/supported-features.html)
+- [Transform API](https://wavevortexmodel.org/classes/transforms/)
+- [WVModel API](https://wavevortexmodel.org/classes/wvmodel/)
+- [Mathematical introduction](https://wavevortexmodel.org/mathematical-introduction/)
 
-```matlab
-interpolationMethod = 'spline';
-[u,v,w] = wavemodel.VelocityAtTimePosition(t,x,y,z,interpolationMethod);
-rho = wavemodel.DensityAtTimePosition(t,x,y,z,interpolationMethod);
-zeta = wavemodel.IsopycnalDisplacementAtTimePosition(t,x,y,z,interpolationMethod);
-```
-As with the Eulerian accessor methods, you can request all the dynamical variables at the same time, e.g.
-```matlab
-[u,v,w,rho_prime,zeta] = wavemodel.VariablesAtTimePosition(t,x,y,z,interpolationMethod,'u','v','w','rho_prime','zeta');
-```
-which provides the optimal speed advantage.
+## Citation
 
-Initialization
-------------
+If WaveVortexModel contributes to your work, cite the software and the scientific formulation relevant to your application:
 
-  The model can be initialized with a Garrett-Munk spectrum by calling,
-  ```matlab
-  wavemodel.initWithGMSpectrum(1.0);
-  ```
-where the only required argument indicates the GM reference level. This function also takes the following name/value pairs.
+- Early, J. J., Fabre-Lima, L., Remy, B. J., Wortham, C., & Sundermeyer, M. A. (2025). [WaveVortexModel](https://doi.org/10.5281/zenodo.4037401). Zenodo.
+- Early, J. J., Lelong, M.-P., & Sundermeyer, M. A. (2021). [A generalized wave-vortex decomposition for rotating Boussinesq flows with arbitrary stratification](https://doi.org/10.1017/jfm.2020.995). *Journal of Fluid Mechanics, 912*, A32.
+- Early, J. J., Hernández-Dueñas, G., Smith, L. M., & Lelong, M.-P. (2024). [Available potential vorticity and the wave-vortex decomposition for arbitrary stratification](https://doi.org/10.48550/arXiv.2403.20269). arXiv.
 
-- `'j_star'` takes any integer value, default is 3.
-- `'shouldRandomizeAmplitude'` takes a 0 or 1 to indicate whether or not the amplitude should be randomized with a Gaussian random variable with expectation matching the GM value. The default is 0.
-- `'maxDeltaOmega'` is the maximum width in frequency that will be integrated over for assigned energy. By default it is self.Nmax-self.f.
-- `'energyWarningThreshold'` will provide a warning if the energy of a single mode exceeds a certain value of the total energy in that modal band. Values between 0 and 1. Default is 0.5 (e.g., you get a warning if the energy in a single mode exceeds 50% of the total energy).
-- `'excludeNyquist'` takes a 0 or 1 to indicate whether or not to include the Nyquist wavenumbers in initialization. Default 1.
-- `'maxK'` and `'minK'` can be set to limit the wavenumbers that will be initialized. By default all resolved wavenumbers are initialized (other than the Nyquist, as above).
-- `'minMode'` and `'maxMode'` can be set to limit the vertical modes that will be initialized. By default all resolved vertical modes are initialized.
+Additional acknowledgements and BibTeX downloads are available at [wavevortexmodel.org/acknowledgements](https://wavevortexmodel.org/acknowledgements).

--- a/UnitTests/TestUserDocumentation.m
+++ b/UnitTests/TestUserDocumentation.m
@@ -1,0 +1,157 @@
+classdef TestUserDocumentation < matlab.unittest.TestCase
+    properties
+        repositoryRoot (1,1) string
+        canonicalRoot (1,1) string
+    end
+
+    methods (TestMethodSetup)
+        function locateRepository(testCase)
+            testCase.repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            testCase.canonicalRoot = fullfile(testCase.repositoryRoot,"Documentation","WebsiteDocumentation");
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function readmeAndHomepageShareExecutableQuickStart(testCase)
+            readmeBlock = testCase.quickStartBlock(fullfile(testCase.repositoryRoot,"README.md"));
+            homepageBlock = testCase.quickStartBlock(fullfile(testCase.canonicalRoot,"index.md"));
+            testCase.verifyEqual(readmeBlock,homepageBlock);
+
+            eval(char(readmeBlock));
+            testCase.verifyClass(wvt,"WVTransformConstantStratification");
+            testCase.verifyClass(model,"WVModel");
+            testCase.verifyTrue(model.isDynamicsLinear);
+            testCase.verifyEqual(model.t,600);
+            testCase.verifyTrue(any(abs(u)>0,"all"));
+            testCase.verifySize(v,wvt.spatialMatrixSize);
+            testCase.verifySize(w,wvt.spatialMatrixSize);
+            testCase.verifyTrue(all(isfinite([omega k l])));
+        end
+
+        function readmePointsToHostedDocumentation(testCase)
+            readme = testCase.readFile(fullfile(testCase.repositoryRoot,"README.md"));
+            linkLocations = strfind(readme,"https://wavevortexmodel.org");
+            testCase.verifyLessThan(linkLocations(1),500, ...
+                "The canonical documentation link must be prominent.");
+            requiredRoutes = [
+                "https://wavevortexmodel.org/installation"
+                "https://wavevortexmodel.org/users-guide/"
+                "https://wavevortexmodel.org/users-guide/supported-features.html"
+                "https://wavevortexmodel.org/classes/transforms/"
+                "https://wavevortexmodel.org/classes/wvmodel/"
+                "https://wavevortexmodel.org/mathematical-introduction/"
+                ];
+            for route = requiredRoutes'
+                testCase.verifySubstring(readme,route);
+            end
+            for citation = ["10.5281/zenodo.4037401" "10.1017/jfm.2020.995" "10.48550/arXiv.2403.20269"]
+                testCase.verifySubstring(readme,citation);
+            end
+        end
+
+        function onboardingUsesCurrentInterfaces(testCase)
+            homepage = testCase.readCanonical("index.md");
+            introduction = testCase.readCanonical(fullfile("users-guide","introduction.md"));
+            transformGuide = testCase.readCanonical(fullfile("users-guide","using-the-wvtransform.md"));
+            persistenceGuide = testCase.readCanonical(fullfile("users-guide","reading-and-writing-to-file.md"));
+            combined = homepage + introduction + transformGuide + persistenceGuide;
+
+            for className = [
+                    "WVTransformConstantStratification"
+                    "WVTransformHydrostatic"
+                    "WVTransformBoussinesq"
+                    "WVTransformStratifiedQG"
+                    "WVTransformBarotropicQG"
+                    "WVModel"
+                    ]'
+                testCase.verifySubstring(combined,className);
+            end
+            for entryPoint = [
+                    "initWithWaveModes"
+                    "initWithUVEta"
+                    "variableWithName"
+                    "variableAtPositionWithName"
+                    "waveVortexTransformFromFile"
+                    "modelFromFile"
+                    ]'
+                testCase.verifySubstring(combined,entryPoint);
+            end
+            testCase.verifySubstring(transformGuide,"`linear` or `spline`");
+            testCase.verifySubstring(transformGuide,"isHydrostatic=true");
+        end
+
+        function canonicalGuidanceAvoidsObsoleteProse(testCase)
+            markdownFiles = dir(fullfile(testCase.canonicalRoot,"**","*.md"));
+            contents = strings(numel(markdownFiles)+1,1);
+            contents(1) = testCase.readFile(fullfile(testCase.repositoryRoot,"README.md"));
+            for iFile = 1:numel(markdownFiles)
+                contents(iFile+1) = testCase.readFile(fullfile(markdownFiles(iFile).folder,markdownFiles(iFile).name));
+            end
+            allGuidance = join(contents,newline);
+            forbidden = [
+                "InternalWaveModel"
+                "exact interpolation"
+                "external-wave interpolation"
+                "| Status |"
+                "Status definitions"
+                "Stable"
+                "Experimental"
+                "Deprecated"
+                "v4.2.1"
+                ];
+            for phrase = forbidden'
+                testCase.verifyFalse(contains(allGuidance,phrase), ...
+                    "Obsolete or project-oriented phrase remains: " + phrase);
+            end
+        end
+
+        function netCDFConventionsAreSubstantive(testCase)
+            page = testCase.readCanonical(fullfile("users-guide","netcdf-output.md"));
+            for heading = ["## Scientific variables" "## CF conventions" "## Discovery metadata" "## Related guidance"]
+                testCase.verifySubstring(page,heading);
+            end
+            testCase.verifySubstring(page,"WVVariableAnnotation");
+            testCase.verifySubstring(page,"does not claim");
+            testCase.verifySubstring(page,"responsibility of the file producer");
+            testCase.verifyFalse(contains(page,"## Global attributes"+newline+newline+"## Dimensions"));
+        end
+
+        function websiteUsesModernTypographyAndSearch(testCase)
+            expectedFont = 'font-family: "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Arial, sans-serif;';
+            for root = [testCase.canonicalRoot fullfile(testCase.repositoryRoot,"docs")]
+                stylesheet = testCase.readFile(fullfile(root,"_sass","custom","custom.scss"));
+                config = testCase.readFile(fullfile(root,"_config.yml"));
+                testCase.verifySubstring(stylesheet,expectedFont);
+                testCase.verifySubstring(stylesheet,"line-height: 1.65;");
+                testCase.verifySubstring(stylesheet,"letter-spacing: -0.015em;");
+                testCase.verifySubstring(stylesheet,".search-input");
+                testCase.verifyMatches(config,"(?m)^search_enabled: true$");
+            end
+        end
+
+        function canonicalDomainIsPreserved(testCase)
+            canonicalCNAME = strtrim(testCase.readFile(fullfile(testCase.canonicalRoot,"CNAME")));
+            generatedCNAME = strtrim(testCase.readFile(fullfile(testCase.repositoryRoot,"docs","CNAME")));
+            testCase.verifyEqual(canonicalCNAME,"wavevortexmodel.org");
+            testCase.verifyEqual(generatedCNAME,canonicalCNAME);
+        end
+    end
+
+    methods (Access=private)
+        function block = quickStartBlock(testCase,path)
+            page = testCase.readFile(path);
+            section = extractAfter(page,"## Quick start");
+            block = extractBetween(section,"```matlab","```");
+            testCase.assertNotEmpty(block,"No MATLAB quick-start block found in " + path);
+            block = strtrim(block(1));
+        end
+
+        function contents = readCanonical(testCase,relativePath)
+            contents = testCase.readFile(fullfile(testCase.canonicalRoot,relativePath));
+        end
+
+        function contents = readFile(~,path)
+            contents = string(fileread(path));
+        end
+    end
+end

--- a/WVOperation.m
+++ b/WVOperation.m
@@ -10,7 +10,7 @@ classdef WVOperation < handle & matlab.mixin.Heterogeneous
 % For example,
 % 
 % ```matlab
-% outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s^2', 'vertical component of relative vorticity');
+% outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s', 'vertical component of relative vorticity');
 % f = @(wvt) wvt.diffX(wvt.v) - wvt.diffY(wvt.u);
 % wvt.addOperation(WVOperation('zeta_z',outputVar,f));
 % ```

--- a/WVOperation.md
+++ b/WVOperation.md
@@ -5,7 +5,7 @@ A WVOperation allows you to add new functionality to the WVTransform by defining
 If the operation is simple and can be computed in one line, you can directly instantiate the WVOperation class and pass a function handle. For example,
 
 ```matlab
-outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s^2', 'vertical component of relative vorticity');
+outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s', 'vertical component of relative vorticity');
 f = @(wvt) wvt.diffX(wvt.v) - wvt.diffY(wvt.u);
 wvt.addOperation(WVOperation('zeta_z',outputVar,f));
 ```

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,6 @@
 remote_theme: just-the-docs/just-the-docs
 title: WaveVortexModel
-description: Solve the stratified nonhydrostatic equations of motion and decompose into wave-vortex components
+description: Decompose and model rotating stratified flow with wave-vortex modes
+search_enabled: true
 compress_html:
   blanklines: true

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,4 +1,36 @@
 
 @import "./sidebar-upgrades";
 
+body,
+.site-title,
+.site-button,
+.nav-list .nav-list-link,
+.nav-list .nav-list-expander,
+.main-content,
+.search-input,
+.search-result-title,
+.search-result-rel-url,
+.label,
+button,
+input,
+select,
+textarea {
+  font-family: "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.main-content {
+  line-height: 1.65;
+}
+
+.main-content h1,
+.main-content h2,
+.main-content h3,
+.main-content h4,
+.main-content h5,
+.main-content h6,
+.site-title {
+  font-family: "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  letter-spacing: -0.015em;
+}
+
 @import "./matlab-live-script";

--- a/docs/classes/model-output/index.md
+++ b/docs/classes/model-output/index.md
@@ -9,5 +9,4 @@ permalink: /classes/model-output
 
 #  Model output
 
-These classes are part of the internal system of reading and writing to file and are considered an advanced topic. The simplest interface is described in the [reading and writing to file users guide](/users-guide/reading-and-writing-to-file.html)
-
+These classes coordinate NetCDF files, output schedules, and observing systems. Start with the [reading and writing files guide](/users-guide/reading-and-writing-to-file.html); use these classes directly when a model needs multiple files, schedules, or bounded output windows.

--- a/docs/classes/observing-systems/index.md
+++ b/docs/classes/observing-systems/index.md
@@ -9,5 +9,4 @@ permalink: /classes/observing-systems
 
 #  Observing systems
 
-These classes allows you to *observe* during integration. Specific subclasses include systems for Eulerian fields, Lagrangian particles, tracers, moorings, and even [along-track satellite observations](https://satmapkit.github.io/AlongTrackSimulator/)
-
+These classes let you observe a state during integration. Specific subclasses provide Eulerian fields, Lagrangian particles, tracers, moorings, and [along-track satellite observations](https://satmapkit.github.io/AlongTrackSimulator/).

--- a/docs/classes/operations-and-annotations/wvoperation/index.md
+++ b/docs/classes/operations-and-annotations/wvoperation/index.md
@@ -31,7 +31,7 @@ directly instantiate the WVOperation class and pass a function handle.
 For example,
 
 ```matlab
-outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s^2', 'vertical component of relative vorticity');
+outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s', 'vertical component of relative vorticity');
 f = @(wvt) wvt.diffX(wvt.v) - wvt.diffY(wvt.u);
 wvt.addOperation(WVOperation('zeta_z',outputVar,f));
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,15 +2,46 @@
 layout: default
 title: Home
 nav_order: 1
-description: "The WaveVortexModel decomposes a rotating stratified fluid into internal waves and geostrophic vortices"
+description: "Decompose and model rotating stratified flow with wave-vortex modes"
 permalink: /
 ---
 
-WaveVortexModel
-==============
+# WaveVortexModel
 
-The WaveVortexModel decomposes a Boussinesq fluid with arbitrary stratification into geostrophic motions and interia-gravity waves. This model is complete, and therefore also can be time-stepped forward
+WaveVortexModel represents rotating, stratified Boussinesq flow on an energetically orthogonal basis of internal waves, inertial oscillations, geostrophic motions, and mean-density anomalies.
 
-The model is based on the [decomposition described in Early, Lelong and Sundermeyer, 2021](https://doi.org/10.1017/jfm.2020.995);
+Use a [`WVTransform`](/classes/transforms/wvtransform/) to decompose a fluid state, reconstruct physical fields, and calculate diagnostics. Use [`WVModel`](/classes/wvmodel/) to integrate the state while advecting particles and tracers, sampling observing systems, and writing restartable NetCDF output.
 
+## Quick start
 
+Create a small constant-stratification transform, initialize one internal wave, inspect its velocity field, and advance the state with analytical linear dynamics:
+
+```matlab
+wvt = WVTransformConstantStratification( ...
+    [40e3 40e3 1000], [16 16 9], N0=5.2e-3, latitude=45);
+
+[omega,k,l] = wvt.initWithWaveModes( ...
+    kMode=1, lMode=0, j=1, phi=0, u=0.05, sign=1);
+[u,v,w] = wvt.variableWithName('u','v','w');
+
+model = WVModel(wvt,shouldUseLinearDynamics=true);
+model.integrateToTime(600,shouldShowIntegrationDiagnostics=false);
+```
+
+The transform stores the decomposed state in `Ap`, `Am`, and `A0`. Variables such as velocity, density, pressure, energy, and potential vorticity are reconstructed from those coefficients when requested.
+
+## Start here
+
+| Goal | Documentation |
+| --- | --- |
+| Install the package | [Installation](/installation) |
+| Choose and construct a transform | [Using `WVTransform`](/users-guide/using-the-wvtransform.html) |
+| Understand the main objects | [Introduction](/users-guide/introduction.html) |
+| Add forcing and closures | [Adding forcing](/users-guide/adding-forcing.html) |
+| Write output and restart a model | [Reading and writing files](/users-guide/reading-and-writing-to-file.html) |
+| Check a capability or limitation | [Capabilities and limitations](/users-guide/supported-features.html) |
+| Browse classes and methods | [API reference](/classes/) |
+
+## Scientific basis
+
+The generalized decomposition is described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The available-potential-vorticity formulation is described by [Early et al. (2024)](https://doi.org/10.48550/arXiv.2403.20269). See [Acknowledgements and citations](/acknowledgements) for software citation information and BibTeX downloads.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,40 +2,48 @@
 layout: default
 title: Installation
 nav_order: 2
-description: Installation instructions"
+description: Install WaveVortexModel and its dependencies
 permalink: /installation
 ---
 
-## Installation
+# Installation
 
-The recommended way to install the model is with [OceanKit](https://github.com/JeffreyEarly/OceanKit).
+WaveVortexModel requires MATLAB R2024b or newer. The package depends on other OceanKit packages and on Chebfun; MPM installs the declared dependencies automatically.
 
-Clone the OceanKit repository
-```
-git clone https://github.com/JeffreyEarly/OceanKit.git
-```
-from the command-line (or download [the zip](https://github.com/JeffreyEarly/OceanKit/archive/refs/heads/main.zip)). Within Matlab, add this folder as an MPM repository,
+## Install from OceanKit
+
+Clone or download the [OceanKit repository](https://github.com/JeffreyEarly/OceanKit), then register its local folder with MPM:
+
 ```matlab
-mpmAddRepository("OceanKit","path/to/folder/OceanKit")
+mpmAddRepository("OceanKit","local/path/to/OceanKit")
 ```
-and then
+
+Install WaveVortexModel and its dependencies:
+
 ```matlab
 mpminstall("WaveVortexModel")
 ```
-will install the [WaveVortexModel](https://wavevortexmodel.org) and its dependencies.
 
-## Advanced
+The installed package can be inspected with:
 
-The WaveVortexModel is highly extensible and rarely needs to be modified directly. However, if you do need to make change to the code you will need to install the model with *Authoring* enabled.
-
-You should still download OceanKit and add the mpm repo as above. However, instead of installing model from the OceanKit, you will install it directly from its github repo.
-
-Clone the WaveVortexModel repository
+```matlab
+mpmlist("WaveVortexModel")
 ```
+
+See [OceanKit installation](https://jeffreyearly.github.io/OceanKit/installation/) for repository management, updates, and removal.
+
+## Install an authoring checkout
+
+Ordinary users should install the released OceanKit package. Clone the authoring repository only when developing WaveVortexModel or rebuilding its documentation:
+
+```text
 git clone https://github.com/JeffreyEarly/wave-vortex-model.git
 ```
-and install with
+
+Install that checkout with authoring files enabled:
+
 ```matlab
-mpminstall("path/to/folder/wave-vortex-model", Authoring=true); 
+mpminstall("local/path/to/wave-vortex-model",Authoring=true)
 ```
-This will still install the dependencies from the mpm repo (and those will not be editable).
+
+Runtime dependencies still come from the registered OceanKit repository. Documentation generation additionally requires the authoring-only package `ClassDocumentation@1.3.0`; it is not a WaveVortexModel runtime dependency.

--- a/docs/mathematical-introduction/transformations.md
+++ b/docs/mathematical-introduction/transformations.md
@@ -161,7 +161,7 @@ $$
 
 ## Phase winding
 
-The final step of the transformation is to wind the phases to reference time $$t_0$$. This is done using the the phase winding operator $$T_\omega$$
+The final step of the transformation is to wind the phases to reference time $$t_0$$. This is done using the phase winding operator $$T_\omega$$
 
 $$
     T_\omega = 

--- a/docs/users-guide/adding-forcing.md
+++ b/docs/users-guide/adding-forcing.md
@@ -1,18 +1,18 @@
 ---
 layout: default
 title: Adding forcing
-parent: Users guide
+parent: User guide
 nav_order: 4
 mathjax: true
 ---
 
-#  Adding forcing
+# Adding forcing
 
-The `WVTransform` is the linear part of the equations of motion and thus forcing is required for more interesting dynamics.
+A `WVTransform` provides analytical linear evolution of its modes. Nonlinear advection, external tendencies, and closures enter through `WVForcing` objects.
 
 ## Quick start
 
-By default, a `WVTransform` is initialized with exactly one forcing term: nonlinear advection. To see this, initialize a new transform, then `summarizeForcing` to list all right-hand-side terms,
+By default, a `WVTransform` is initialized with exactly one forcing term: nonlinear advection. Initialize a transform, then call `summarizeForcing` to list its right-hand-side terms:
 ```matlab
 wvt = WVTransformHydrostatic([800e3, 800e3, 4000],[64, 64, 65], N2=@(z) (3*2*pi/3600)^2*exp(2*z/1300),latitude=30);
 wvt.summarizeForcing
@@ -25,7 +25,7 @@ wvt.summarizeForcing
     "nonlinear advection"     "false"
  ```
 
-This indicates that the only forcing term is the nonlinear advection. If the goal is to time-step a model, we also require a closure scheme to remove small scale features. For a first pass, we recommend using the `WVAdaptiveDamping`. You add a right-hand-side forcing term with `addForcing`,
+Nonlinear integration also needs a closure to control unresolved small scales. `WVAdaptiveDamping` is a useful first choice. Register it with `addForcing`:
 
 ```matlab
 wvt.addForcing(WVAdaptiveDamping(wvt));
@@ -40,7 +40,7 @@ wvt.summarizeForcing
     "adaptive damping"        "true"
  ```
 
-With this, you could now time-step the `WVTransform` forwards in time with the model,
+The model now includes nonlinear advection and adaptive damping when it advances the transform:
 ```matlab
 model = WVModel(wvt);
 model.integrateToTime(wvt.inertialPeriod);
@@ -82,7 +82,7 @@ $$
 \end{bmatrix}
 $$
 
-is the nonlinear advection. For the hydrostatic model, `WVTransformHydrostatic`, the the vertical momentum equation effectively vanishes, as $$w$$ is determined diagnostically.
+is the nonlinear advection. For hydrostatic dynamics, the vertical momentum equation effectively vanishes because $$w$$ is determined diagnostically.
 
 For the quasigeostrophic transforms, `WVTransformStratifiedQG` and `WVTransformBarotropicQG`, the equation of motion is the evolution of quasigeostrophic potential vorticity (QGPV),
 
@@ -100,7 +100,7 @@ This is also commonly written as a streamfunction, using $\psi = \frac{1}{\rho_0
 
 Adding forcing to a transform with `wvt.addForcing()` adds an additional right-hand-side term, $$\mathcal{S}$$.
 
-The total forcing (at the current time) in the spectral is found by calling `wvt.nonlinearFlux`,
+The total coefficient tendency at the current time is returned by `wvt.nonlinearFlux`:
 ```matlab
 [Fp,Fm,F0] = wvt.nonlinearFlux();
 ```
@@ -127,9 +127,15 @@ By default, the generated tendency is projected outside the exact support of any
 
 ## Creating your own forcing
 
-The model has a number of very useful forcings already built-in; however, it is also very straightforward to add your own forcing.
+Custom forcing subclasses derive from `WVForcing`, declare one or more `WVForcingType` stages, and override the method corresponding to each declared stage. Physical-space forcing modifies velocity and displacement tendencies before projection. Spectral forcing modifies $$(F_+,F_-,F_0)$$ after projection. Spectral-amplitude forcing updates `Ap`, `Am`, and `A0` directly.
+
+For example, horizontal and vertical spectral damping can be expressed as
 
 $$
+
+and implemented by overriding `addSpectralForcing`. Hydrostatic and nonhydrostatic physical forcing instead override `addHydrostaticSpatialForcing` or `addNonhydrostaticSpatialForcing`. QG forcing uses the potential-vorticity variants of the spatial, spectral, or amplitude interfaces.
+
+The transform validates that a forcing stage is compatible with its dynamics, applies stages in physical–spectral–amplitude order, and uses `priority` to order forcing objects within one stage. See [`WVForcing`](/classes/forcing/wvforcing/) and [`WVForcingType`](/classes/forcing/wvforcing/) before implementing a subclass.
     \begin{align}
         \partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
         \partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}

--- a/docs/users-guide/creating-new-state-variables.md
+++ b/docs/users-guide/creating-new-state-variables.md
@@ -1,61 +1,62 @@
 ---
 layout: default
 title: Creating new state variables
-parent: Users guide
+parent: User guide
 mathjax: true
 nav_order: 14
 ---
 
-#  Creating new state variables
+# Creating new state variables
 
-The WaveVortexModel allows you to quickly and easily create custom operations to define new variables describing the state of the ocean. These new variables can saved to file and their values can be tracked along particle trajectories using the model.
+Custom `WVOperation` objects add derived variables to a transform. Once registered, those variables participate in ordinary field access, caching, NetCDF output, and particle tracking.
 
-## WVOperation
+## Define and register an operation
 
-The simplest way to add new functionality to the WaveVortexModel is to create a new `WVOperation`. A `WVOperation` instance has two jobs: 1) describe the variable (or variables) that it is capable of producing and 2) implement an operation for computing those variables.
+A `WVVariableAnnotation` describes the output's name, dimensions, units, and meaning. A `WVOperation` associates one or more annotations with the calculation that produces them.
 
-### Creating a new operation
-
-As an example, lets add a new operation to compute relative vorticity. Assuming that `wvt` is a WVTransform instance,
+For example, register the vertical component of relative vorticity:
 
 ```matlab
-outputVar = WVVariableAnnotation('zeta_z',{'x','y','z'},'1/s^2', 'vertical component of relative vorticity');
-f = @(wvt) wvt.diffX(wvt.v) - wvt.diffY(wvt.u);
-wvt.addOperation(WVOperation('zeta_z',outputVar,f));
+annotation = WVVariableAnnotation( ...
+    'zeta_z',{'x','y','z'},'1/s','vertical component of relative vorticity');
+computeVorticity = @(wvt) wvt.diffX(wvt.v) - wvt.diffY(wvt.u);
+wvt.addOperation(WVOperation('zeta_z',annotation,computeVorticity));
 ```
 
-That's it! The `WVVariableAnnotation` class is used to describe the structure of the the output variable, and the function handle `f` performs the actual computation. The computation is not actually performed until it is needed.
-
-Now that the WVTransform has a recipe for computing `zeta_z`, you can simply call `wvt.zeta_z` at any time. In fact, these operations compose---so you can create a new operation itself calls `wvt.zeta_z` as part of its computation.
-
-### Saving to file
-
-The new variable can be immediately saved to file because it already has a name, dimensions, and units.
-
-Using the variable `zeta_z` from the example above, the transform can be written to file
+The calculation is lazy: registration records how to compute `zeta_z`, but the operation does not run until the value is requested.
 
 ```matlab
-wvt.writeToFile('path/to/file.nc','zeta_z');
+zeta_z = wvt.zeta_z;
 ```
 
-When doing a model simulation, this variable is also available to write to file as part of the time series see, e.g., `setNetCDFOutputVariables`.
+Operations compose, so another operation may use `wvt.zeta_z` as an input. More involved calculations can subclass `WVOperation` and override `compute`.
 
-### Tracking along particle trajectories
+## Control caching
 
-If the output variable has spatial dimension $$(x,y)$$ or $$(x,y,z)$$, then the WVModel can track its value along advected particle trajectories. See the documentation for `addParticles`, `setFloatPositions`, or `setDrifterPositions`. 
+Computed variables are cached. Set the operation's dependency metadata before registration so the transform knows when to invalidate its outputs:
 
-## Notes
+- `isVariableWithLinearTimeStep=true` invalidates the output when transform time changes.
+- `isDependentOnApAmA0=true` invalidates the output when `Ap`, `Am`, or `A0` changes.
 
-In the example above a function handle was used to compute the relative vorticity because it only required a single line of code. However, it is often the case that computations will be more involved. In that case, you should subclass the `WVOperation`.
+Outputs without the relevant dependency remain cached. A multiple-output operation computes and caches its annotations together in annotation order.
 
-Operation names and output-variable names must be unique. By default, `addOperation` rejects a new operation that conflicts with an existing operation and leaves the registry unchanged. To intentionally replace an operation, opt in explicitly:
+Operation names and output-variable names must be unique. Registration rejects conflicts by default. Pass `shouldOverwriteExisting=true` to replace the complete conflicting operation intentionally.
+
+## Write and track the variable
+
+The annotation supplies the metadata needed to write the variable with a transform:
 
 ```matlab
-wvt.addOperation(replacementOperation,shouldOverwriteExisting=true);
+ncfile = wvt.writeToFile('state.nc','zeta_z');
+ncfile.close();
 ```
 
-An operation is registered and removed as a unit. If the replacement conflicts with one output from a multiple-output operation, every output from the displaced operation is removed. When registering an array of operations with replacement enabled, conflicts are resolved in caller order and the last conflicting operation wins.
+For model output, add the variable to the Eulerian field selection:
 
-A `WVOperation` can return multiple variables. Its outputs are returned in annotation order and computed together when any uncached output is requested.
+```matlab
+model.addNetCDFOutputVariables('zeta_z');
+```
 
-All computed variables are cached to avoid unnecessary calculations. Set an operation's dependency metadata before registration: `isVariableWithLinearTimeStep=true` invalidates its outputs when transform time changes, while `isDependentOnApAmA0=true` invalidates them when `Ap`, `Am`, or `A0` changes. Outputs without the relevant dependency remain cached.
+Variables with spatial dimensions $$(x,y)$$ or $$(x,y,z)$$ can also be sampled along particle trajectories. Pass their names to `addParticles`, `setFloatPositions`, or `setDrifterPositions`.
+
+For details about annotations, multiple outputs, replacement, and cache invalidation, see [`WVOperation`](/classes/operations-and-annotations/wvoperation/) and [`WVVariableAnnotation`](/classes/operations-and-annotations/wvvariableannotation/).

--- a/docs/users-guide/index.md
+++ b/docs/users-guide/index.md
@@ -1,9 +1,17 @@
 ---
 layout: default
-title: Users guide
+title: User guide
 nav_order: 3
 has_children: true
 permalink: /users-guide
 ---
 
-This document is a users guide to the Matlab implementation of the WaveVortexModel.
+# User guide
+
+The user guide introduces the main WaveVortexModel workflows and connects them to the complete API reference.
+
+- Start with the [Introduction](/users-guide/introduction.html) to understand `WVTransform` and `WVModel`.
+- Use [Using `WVTransform`](/users-guide/using-the-wvtransform.html) to choose a transform, initialize a state, and evaluate physical fields.
+- Consult [Capabilities and limitations](/users-guide/supported-features.html) when choosing interpolation, integration, forcing, output, or extension features.
+- Read [Adding forcing](/users-guide/adding-forcing.html) before integrating nonlinear dynamics.
+- Use [Reading and writing files](/users-guide/reading-and-writing-to-file.html) for transform persistence, model output, and restart.

--- a/docs/users-guide/introduction.md
+++ b/docs/users-guide/introduction.md
@@ -1,21 +1,33 @@
 ---
 layout: default
 title: Introduction
-parent: Users guide
+parent: User guide
 mathjax: true
 nav_order: 1
 ---
 
-#  Introduction
+# Introduction
 
-There are two high-level components to the wave-vortex model, the `WVTransform` and the `WVModel`. The `WV` prefix is short for wave-vortex and establishes a namespace for all classes in the model.
+WaveVortexModel separates the representation of a fluid state from its time evolution. The `WV` prefix means wave–vortex and provides a common namespace for the package's classes.
 
-## WVTransform
+## `WVTransform`: represent and diagnose a state
 
-The `WVTransform` subclasses encapsulate data representing the *state* of the ocean at a given instant in time (e.g., $$u$$, $$v$$, $$w$$, and $$\rho$$). The `WVTransform` can be customized to tell you anything you want about the state of the ocean at a point in time.
+A [`WVTransform`](/classes/transforms/wvtransform/) represents the state of a rotating fluid at a reference time. Wave-bearing transforms store that state in the wave–vortex coefficients `Ap`, `Am`, and `A0`; quasigeostrophic transforms use `A0`. The transform reconstructs physical variables such as velocity, density, pressure, and potential vorticity when they are requested.
 
-## WVModel
+Transforms also provide the forward projection from physical fields to coefficients, spectral differentiation and integration, interpolation at periodic off-grid positions, energetics, spectra, and flow-component diagnostics. Choose the transform family to match the desired stratification and dynamical approximation.
 
-A `WVModel` instance uses a `WVTransform` instance to integrate (time-step) the non-linear equations of motion forwad in time. The `WVModel` class adds support for features like particle advection and tracer advection.
+## `WVModel`: evolve and observe a state
 
+A [`WVModel`](/classes/wvmodel/) advances a `WVTransform` in time. Analytical linear evolution is useful for evaluating a prescribed superposition of modes. Fixed-step and adaptive integration evolve active coefficient and observing-system dynamics.
 
+The model coordinates forcing and closures, Lagrangian particles, tracers, moorings, Eulerian fields, and wave–vortex coefficients. Output files and output groups allow these observing systems to be sampled on different schedules and restored for a later restart.
+
+## A typical workflow
+
+1. Construct the appropriate `WVTransform`.
+2. Initialize it from physical fields, individual modes, a spectrum, or a saved file.
+3. Inspect reconstructed fields and diagnostics.
+4. If integrating nonlinear dynamics, configure forcing and a closure.
+5. Construct a `WVModel`, add observing systems or output, and integrate.
+
+Continue with [Using `WVTransform`](/users-guide/using-the-wvtransform.html) for concrete construction and initialization examples.

--- a/docs/users-guide/netcdf-output.md
+++ b/docs/users-guide/netcdf-output.md
@@ -1,25 +1,35 @@
 ---
 layout: default
-title: WaveVortexModel NetCDF output
-parent: Users guide
+title: NetCDF conventions
+parent: User guide
 nav_order: 18
 mathjax: true
 ---
 
-#  WaveVortexModel NetCDF output
+# NetCDF conventions
 
-WaveVortexModel NetCDF output follows the [CF metadata conventions](https://cfconventions.org) to "promote the processing and sharing of files created with the NetCDF API". These conventions are (mostly) automatically followed by the code.
+WaveVortexModel writes named dimensions, variables, units, descriptive attributes, transform metadata, and history information through its annotated persistence system. This metadata makes model files self-describing and provides the information required to reconstruct supported transforms, forcing, observing systems, and restart state.
 
-For data that is intended to be distributed, it is also useful to follow the [attribute convention for data discovery](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3). These additional attributes are not added automatically by the WaveVortexModel, but a tool is provided for making this easy.
+## Scientific variables
 
-## Global attributes
+Each registered variable has a `WVVariableAnnotation` that defines its name, dimensions, units, and description. The output system uses those annotations when creating NetCDF dimensions and variables. Eulerian fields, coefficients, particles, tracers, and moorings add the dimensions and metadata needed for their own stored state.
 
-## Dimensions
+The package uses established names and units where they are defined, but the metadata should still be reviewed before a file is distributed or deposited in an archive.
 
-## Variables
+## CF conventions
 
-- `name' name of the variable used by the WVOperation
-- `standard_name' the standard name must come
-- `long_name'
+The [Climate and Forecast metadata conventions](https://cfconventions.org) provide standard names, coordinate rules, and structural guidance for interoperable geoscience data. WaveVortexModel supplies useful CF-oriented metadata, but it does not claim that every possible output configuration is automatically a complete CF-compliant data product.
 
+Users preparing a distributed dataset should verify coordinate attributes, standard names, units, missing-value treatment, and any project-specific requirements with an appropriate CF checker.
 
+## Discovery metadata
+
+The [Attribute Convention for Data Discovery](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3) describes global attributes used by repositories and search systems. Dataset title, summary, creator, institution, spatial and temporal coverage, license, and persistent identifiers depend on the scientific project and are therefore the responsibility of the file producer.
+
+Add project-specific global attributes as part of the output workflow and validate the finished file before publication. WaveVortexModel's automatically recorded class, package version, creation date, references, and history complement this dataset-level metadata but do not replace it.
+
+## Related guidance
+
+- [Reading and writing files](/users-guide/reading-and-writing-to-file.html) covers transform persistence, ordinary model output, and restart.
+- [Reading and writing files: advanced topics](/users-guide/reading-and-writing-to-file-advanced.html) covers multiple files, schedules, observing systems, restoration, and failure behavior.
+- [Creating new state variables](/users-guide/creating-new-state-variables.html) explains how annotations supply names, dimensions, units, and descriptions for custom output variables.

--- a/docs/users-guide/reading-and-writing-to-file-advanced.md
+++ b/docs/users-guide/reading-and-writing-to-file-advanced.md
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: Reading and writing to file, advanced topics
-parent: Users guide
+title: Reading and writing files: advanced topics
+parent: User guide
 mathjax: true
 nav_order: 12
 has_toc: true
 ---
 
-#  Reading and writing to file, advanced topics
+# Reading and writing files: advanced topics
 
 The `WVModel` supports multiple output files, groups with different output intervals, and groups that start and stop at different model times.
 
-With these features, it is possible to setup up numerical simulations that "observe" the ocean in different ways, at different intervals. For example, you might place moorings in your simulation that sample the velocity field at a high frequency. You might setup a series of drifter experiments, that deploy and retrieve drifters every five days.
+These features let one simulation observe the fluid in several ways and at several intervals. For example, moorings may sample velocity frequently while a sequence of drifter experiments deploys and retrieves particles in bounded five-day windows.
 
 There are three classes that work together to write to file:
 
@@ -24,13 +24,24 @@ Any `WVObservingSystem` that requires integration is also held by the model. The
 
 ## WVObservingSystem
 
-Observing systems include, e.g., the wave-vortex coefficients, Eulerian fields, Lagrangian particles, tracers, mooring, and satellite along-track data.
+Observing systems include wave–vortex coefficients, Eulerian fields, Lagrangian particles, tracers, moorings, and satellite along-track data.
 
 Subclasses of `WVObservingSystem` describe whether the observing system needs to be integrated in time and how it writes to a `WVModelOutputGroup`. `WVCoefficients` participates in model integration while coefficient storage is provided by the Eulerian field observer. `WVMooring` writes sampled fields without adding integrated state. `WVLagrangianParticles` and `WVTracer` both add integrated state and write their latest state to output.
 
 ## WVModelOutputFile
 
 After creating a `WVModel`, you may add one or more `WVModelOutputFile` instances. The model combines their requested output times so coincident times are integrated once and delivered to every file and group that requested them.
+
+The convenience method `createNetCDFFileForModelOutput` creates one file and one evenly spaced group containing the model's ordinary observing systems. For explicit control, construct the layers separately:
+
+```matlab
+outputFile = model.addNewOutputFile('experiment.nc');
+hourly = outputFile.addNewEvenlySpacedOutputGroup( ...
+    'hourly',initialTime=model.t,finalTime=model.t+86400,outputInterval=3600);
+hourly.addObservingSystem(model.eulerianObservingSystem);
+```
+
+The file remains an in-memory configuration until its first output initialization. This makes it possible to assemble groups and observing systems before any partial file exists on disk.
 
 Each file is an independent restart boundary. `WVModel.modelFromFile(path)` restores the supplied file and all of its groups; it does not reconstruct other files that the original model may also have written. A restart-capable file must contain exactly one group with the complete coefficient stream (`Ap`, `Am`, and `A0` for wave-bearing transforms, or `A0` for QG transforms). Other groups may store fields and observing systems without duplicating that complete coefficient stream.
 

--- a/docs/users-guide/reading-and-writing-to-file.md
+++ b/docs/users-guide/reading-and-writing-to-file.md
@@ -1,74 +1,86 @@
 ---
 layout: default
-title: Reading and writing to file
-parent: Users guide
+title: Reading and writing files
+parent: User guide
 mathjax: true
 nav_order: 10
 has_toc: true
 ---
 
-#  Reading and writing to file
+# Reading and writing files
 
-The `WVTransform` and the `WVModel` both read and write to NetCDF files.
+WaveVortexModel uses NetCDF files for transform persistence, model output, and restart. A transform file stores the geometry and wave–vortex state needed to reconstruct a `WVTransform`. A restart-capable model file additionally stores forcing, observing systems, output groups, and the latest integrated state.
 
-## WVTransform
+## Save and restore a transform
 
-After you create a `WVTransform` instance
+Write a transform and close the returned file handle:
+
 ```matlab
-wvt = WVTransformConstantStratification([50e3 50e3 1300], [64 64 32]);
+wvt = WVTransformConstantStratification( ...
+    [50e3 50e3 1300],[32 32 17],N0=5.2e-3,latitude=45);
+wvt.initWithRandomFlow();
+
+ncfile = wvt.writeToFile('transform.nc');
+ncfile.close();
 ```
-you call `writeToFile`
+
+Restore the transform through the static factory. The one-output form closes its read handle before returning:
+
 ```matlab
-wvt.writeToFile('test.nc');
+wvtRestored = WVTransform.waveVortexTransformFromFile('transform.nc');
 ```
-and all the information needed to exactly re-create the `wvt` instance will be written to file.
 
-To create a new `WVTransform` instance from file, call the static method [`waveVortexTransformFromFile`](/classes/transforms/wvtransform/wavevortextransformfromfile.html)
+Pass additional registered variable names to `writeToFile` when physical fields or diagnostics should be stored alongside the reconstructable state:
+
 ```matlab
-wvt2 = WVTransform.waveVortexTransformFromFile('test.nc');
+ncfile = wvt.writeToFile('transform-with-fields.nc','u','v','rho');
+ncfile.close();
 ```
-The two instances `wvt` and `wvt2` are now equivalent. This one-output form closes the NetCDF file before returning.
 
-### Adding variables
+## Read a transform time series
 
-Any variable that the `WVTransform` instance knows about (including [custom variables](/developers-guide/operations-and-variables.html)) can also be written to file, but including its name in the variable argument list. For example, if you want to add the variables $$u$$, $$v$$, and $$\zeta_z$$ then call,
+Model output may contain many time records. Creating the transform once and updating its coefficients is less expensive than reconstructing its geometry for every record.
+
+Request the second output to retain a caller-owned, read-only `NetCDFFile`, and close it explicitly:
+
 ```matlab
-wvt.writeToFile('test.nc','u','v','zeta_z');
-```
-and the data will be written, accessible from anything that reads NetCDF files.
-
-### Reading model output
-
-Model output contains multiple time points from which the a `WVTransform` instance can be initialized. To initialize a `WVTransform` instance from a specific point in the model output, call
-```matlab
-wvt = WVTransform.waveVortexTransformFromFile('test.nc',iTime=100);
-``` 
-where `iTime=100` indicates the index along the time dimension.
-
-It is often the case that for analysis of model output, you want to read the model output at multiple time points. You *could* intialize a new `WVTransform` instance at each time index, but this involves unnecessary computation. Instead, you should update the existing `WVTransform` instance `wvt` with the data from that time point.
-
-First load the NetCDF file, then initialize the existing instance from a specific time point in that file with [`initFromNetCDFFile`](/classes/transforms/wvtransform/initfromnetcdffile.html). For example, a for-loop over all time points written to file, would look like
-```matlab
-[wvt, ncfile] = WVTransform.waveVortexTransformFromFile('test.nc');
+[wvt,ncfile] = WVTransform.waveVortexTransformFromFile('model-output.nc');
 cleanup = onCleanup(@()ncfile.close());
 t = ncfile.readVariables("wave-vortex/t");
 
-for iTime=1:length(t)
+for iTime = 1:numel(t)
     wvt.initFromNetCDFFile(ncfile,iTime=iTime);
-    % do some analysis
+    energy(iTime) = wvt.totalEnergy;
 end
 ```
 
-The returned `ncfile` is read-only by default and must be closed by the caller. Pass `shouldReadOnly=false` explicitly only when writable access is required.
+Use `shouldReadOnly=false` only when the returned file genuinely needs writable access.
 
-## WVModel
+## Write model output
 
-Time series model output is created with
+For a model with one ordinary output schedule, create the file through the convenience method and integrate:
 
 ```matlab
-model = WVModel(wvt);
-model.createNetCDFFileForModelOutput('test.nc',outputInterval=wvt.inertialPeriod);
-model.integrateToTime(10*wvt.inertialPeriod);
+model = WVModel(wvt,shouldUseLinearDynamics=true);
+outputFile = model.createNetCDFFileForModelOutput( ...
+    'model-output.nc',outputInterval=600);
+model.integrateToTime(3600);
+outputFile.closeNetCDFFile();
 ```
 
-which can then be read in using the above commands.
+The physical file is created lazily when output is first initialized. Before integration you may add Eulerian variables, particles, tracers, or other observing systems to the model's output configuration.
+
+## Restore and continue a model
+
+Restore a model from one restart-capable file:
+
+```matlab
+model = WVModel.modelFromFile('model-output.nc');
+model.setupIntegrator();
+model.integrateToTime(model.t + 3600);
+model.outputFiles(1).closeNetCDFFile();
+```
+
+Runtime integrator objects are not persisted, so configure the desired fixed or adaptive settings after restoration. `modelFromFile` restores only the supplied file's output graph; other files written by the original run are independent restart boundaries.
+
+For multiple schedules, bounded output windows, shared observing systems, and handle ownership, continue with [Reading and writing files: advanced topics](/users-guide/reading-and-writing-to-file-advanced.html). For metadata conventions, see [NetCDF conventions](/users-guide/netcdf-output.html).

--- a/docs/users-guide/supported-features.md
+++ b/docs/users-guide/supported-features.md
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: Capabilities and limitations
-parent: Users guide
+parent: User guide
 nav_order: 3
 has_toc: true
 ---
 
 # Capabilities and limitations
 
-WaveVortexModel provides five transform families together with model integration, forcing, observing systems, and NetCDF output. This page summarizes the public behavior covered by the package documentation and release tests. Public MATLAB visibility alone does not make an implementation helper a recommended entry point.
+WaveVortexModel provides five transform families together with model integration, forcing, observing systems, and NetCDF output. This page summarizes the documented public behavior and important limitations. Public MATLAB visibility alone does not make an implementation helper a recommended entry point.
 
 ## Transforms
 
@@ -38,7 +38,7 @@ For three-dimensional transforms, `diffZF` and `diffZG` accept derivative orders
 
 `WVModel` provides adaptive and fixed-step integration, tolerance and time-step configuration, segmented integration, model output, and restart. Call `setupIntegrator` to change time-stepping settings.
 
-The `adaptive-cell` option remains available for development but is not exercised by the v4.2.1 release tests. Low-level integrator mixins and `ode45_cell` are implementation machinery rather than model entry points.
+The `adaptive-cell` option is under development and does not have the validation coverage of fixed-step and adaptive integration. Low-level integrator mixins and `ode45_cell` are implementation machinery rather than model entry points.
 
 ## Forcing and closures
 
@@ -56,7 +56,7 @@ The supplied forcing and closure classes are:
 - `WVBetaPlanePVAdvection`
 - `WVPseudoTopographicWaveGeneration`
 
-`WVThermalDamping` remains available for development but does not yet have the same release-test coverage as the classes above. Custom forcing may be implemented through the documented `WVForcing` extension interface.
+`WVThermalDamping` is under development and has more limited validation than the classes above. Custom forcing may be implemented through the documented `WVForcing` extension interface.
 
 ## Observing systems, output, and restart
 
@@ -70,6 +70,4 @@ Custom operations and annotated variables use `WVOperation` and `WVVariableAnnot
 
 Optimization Toolbox is optional. `WVNoMotionProfileOperation` uses `lsqnonlin` when it is available and otherwise uses `fminsearch` with an advisory warning.
 
-FFTW selection and the low-level barotropic FINUFFT path remain active development machinery. They are not selected through the documented transform constructors or public interpolation options, and FINUFFT is not a required package dependency.
-
-New scientific capabilities, new transform families, and broad numerical redesign are outside the v4.2.1 maintenance release.
+FFTW selection and the low-level barotropic FINUFFT path remain development machinery. They are not selected through the documented transform constructors or public interpolation options, and FINUFFT is not a required package dependency.

--- a/docs/users-guide/using-the-wvtransform.md
+++ b/docs/users-guide/using-the-wvtransform.md
@@ -1,121 +1,145 @@
 ---
 layout: default
-title: Using the WVTransform
-parent: Users guide
+title: Using WVTransform
+parent: User guide
 mathjax: true
 nav_order: 2
 has_toc: true
 ---
 
-#  Using the WVTransform
+# Using `WVTransform`
 
-At the time of this writing there are five `WVTransform` subclasses with different capabilities,
-- `WVTransformBoussinesq` Non-hydrostatic, variable stratification
-- `WVTransformHydrostatic` Hydrostatic, variable stratification
-- `WVTransformConstantStratification` Non-hydrostatic, constant stratification
-- `WVTransformStratifiedQG` Quasigeostrophic dynamics, variable stratification
-- `WVTransformBarotropicQG` Quasigeostrophic dynamics, equivalent barotropic
+A `WVTransform` represents a fluid state in physical and wave–vortex coordinates. The transform family determines the dynamical approximation, vertical structure, and flow components available to the state.
 
-These `WVTransform` subclasses are used in the same way, but may have different capabilities and requirements for initialization.
+## Choose a transform
 
-## Initialization
+| Transform | Use it for |
+| --- | --- |
+| [`WVTransformConstantStratification`](/classes/transforms/wvtransformconstantstratification/) | Hydrostatic or nonhydrostatic flow with constant buoyancy frequency. |
+| [`WVTransformHydrostatic`](/classes/transforms/wvtransformhydrostatic/) | Hydrostatic flow with variable stratification. |
+| [`WVTransformBoussinesq`](/classes/transforms/wvtransformboussinesq/) | Nonhydrostatic flow with variable stratification. |
+| [`WVTransformStratifiedQG`](/classes/transforms/wvtransformstratifiedqg/) | Three-dimensional stratified quasigeostrophic flow. |
+| [`WVTransformBarotropicQG`](/classes/transforms/wvtransformbarotropicqg/) | Two-dimensional equivalent-barotropic quasigeostrophic flow. |
 
-All transforms require you specify the domain size, number of grid points and latitude.
+All rotating transforms accept latitude in either hemisphere for $$5 \leq |\mathrm{latitude}| \leq 85$$ degrees.
 
-The Boussinesq, hydrostatic and stratified QG transformations require you pass a function handle describing the stratification, e.g.,
+## Construct a transform
+
+Every transform takes the domain size and grid size as its first two arguments. Wave-bearing three-dimensional transforms store `Ap`, `Am`, and `A0`; the QG transforms store their geostrophic state in `A0`.
+
+### Constant stratification
+
+Supply the constant buoyancy frequency `N0`. The default is nonhydrostatic; set `isHydrostatic=true` to use the hydrostatic approximation.
+
 ```matlab
-wvt = WVTransformHydrostatic([Lx, Ly, Lz], [Nx, Ny, Nz], N2=@(z) N0*N0*exp(2*z/L_gm),latitude=33);
-```
-whereas constant stratification transform requies the buoyancy frequency $$N_0$$
-```matlab
-wvt = WVTransformConstantStratification([Lx, Ly, Lz], [Nx, Ny, Nz], N0=5.2e-3,latitude=33);
-```
-The equivalent barotropic transform requires that you specify an equivent depth $$h$$,
-```matlab
-wvt = WVTransformBarotropicQG([Lx, Ly], [Nx, Ny], h=0.80,latitude=33);
-```
-where a typical oceanic value for the first barolinic mode would be around 80 cm.
+Lxyz = [100e3 100e3 4000];
+Nxyz = [64 64 65];
+N0 = 3*2*pi/3600;
 
-## Grids
-
-Note that you do not specify the grids, only the domain size---the grids are determined by the transforms.
-
-The dimensions that result can be accessed with, e.g., `wvt.x` or `wvt.z`. This will be array of size `[Nx 1]` and `[Nz 1]`, respectively. More useful perhaps are the grids, e.g., `wvt.X` or `wvt.Z` which are of size `[Nx Ny Nz]`.
-
-For the current set of transforms $$x$$ and $$y$$ grids will always be evenly spaced grids appropriate for Fourier transforms, while the $$z$$ grid will be evenly spaced for constant stratification (sine and cosine transforms), but will have variable spacing when using variable stratification. **Never create your own grids---always use the built-in functions.**
-
-
-## Initial conditions
-
-Once a tranform is instantiated, it is often the case that one would like to add initial conditions. The [WVTransform](/classes/transforms/wvtransform/) class has numerous methods for adding initial conditions---including very general initialization from any fluid state, as well as initialization specific to waves, inertial oscillations, and geostrophic motions.
-
-### Initializing from $$(u,v,\eta)$$
-
-The most direct methods for initializing the model are [`initWithUVEta`](/classes/transforms/wvtransform/initwithuveta.html) and [`initWithUVRho`](/classes/transforms/wvtransform/initwithuvrho.html) which take either $$(u,v,\eta)$$ or $$(u,v,\rho)$$. As a simple example, let's intialize with an inertial oscillation initial condition, $$(u_0 \exp(z/100),0,0)$$. In code, this is
-```matlab
-wvt.initWithUVEta( 0.2*exp(wvt.Z/100), 0*wvt.X, 0*wvt.X );
+wvt = WVTransformConstantStratification( ...
+    Lxyz,Nxyz,N0=N0,latitude=30);
+wvtHydrostatic = WVTransformConstantStratification( ...
+    Lxyz,Nxyz,N0=N0,latitude=30,isHydrostatic=true);
 ```
 
-These methods can be used to initialize from *any* flow fields that use the same stratification and boundary conditions as the `WVTransform` that is being used. For example, you might use output from another model and use [`initWithUVRho`](/classes/transforms/wvtransform/initwithuvrho.html) to initialize the WaveVortexMode with that output.
+### Variable stratification
 
-### Initializing waves, inertial oscillations, and geostrophic motions
+Supply either `N2Function`, returning the squared buoyancy frequency, or `rhoFunction`, returning the mean density profile on $$[-L_z,0]$$.
 
-The wave-vortex model provides methods for initializing the fluid with specific dynamical solutions, including inertial oscillations, internal gravity waves, and geostrophic (vortex) flows. 
-
-To initialize individual waves, use `initWithWaveModes` and the related methods, e.g.,
 ```matlab
-[omega, k, l] = wvt.initWithWaveModes(kMode=10,lMode=0,j=1,phi=0,u=0.2,sign=1);
+N0 = 3*2*pi/3600;
+Lgm = 1300;
+N2 = @(z) N0*N0*exp(2*z/Lgm);
+
+wvtHydrostatic = WVTransformHydrostatic( ...
+    Lxyz,Nxyz,N2Function=N2,latitude=30);
+wvtBoussinesq = WVTransformBoussinesq( ...
+    Lxyz,Nxyz,N2Function=N2,latitude=30);
+wvtQG = WVTransformStratifiedQG( ...
+    Lxyz,Nxyz,N2Function=N2,latitude=30);
+```
+
+### Equivalent-barotropic QG
+
+The two-dimensional transform takes horizontal dimensions and an equivalent depth `h`:
+
+```matlab
+wvtBarotropic = WVTransformBarotropicQG( ...
+    [100e3 100e3],[64 64],h=0.8,latitude=30);
+```
+
+## Use the transform grids
+
+The transform chooses grids compatible with its spectral representation. Access coordinate vectors through `wvt.x`, `wvt.y`, and, for three-dimensional transforms, `wvt.z`. The arrays `wvt.X`, `wvt.Y`, and `wvt.Z` have the transform's spatial matrix shape.
+
+Horizontal grids are evenly spaced and periodic. Constant-stratification transforms use the sine/cosine vertical grid, while variable-stratification transforms use quadrature points determined by the vertical modes. Use the grids supplied by the transform rather than constructing replacements.
+
+## Initialize a fluid state
+
+Initialization methods follow a common naming convention:
+
+- `initWith...` clears `Ap`, `Am`, and `A0` before initializing the requested state.
+- `set...` replaces one flow component while preserving the others.
+- `add...` superimposes a flow component on the existing state.
+- `removeAll...` removes the named component.
+
+### Project physical fields
+
+For wave-bearing transforms, `initWithUVEta` and `initWithUVRho` project gridded velocity and displacement or density-anomaly fields onto the wave–vortex basis. Inputs must use the transform's spatial grid and boundary conditions.
+
+```matlab
+U = 0.2*exp(wvt.Z/100);
+V = zeros(wvt.spatialMatrixSize);
+eta = zeros(wvt.spatialMatrixSize);
+wvt.initWithUVEta(U,V,eta);
+```
+
+This projection can also decompose output from another numerical model when its fields have been placed on compatible grids with compatible stratification and boundary conditions.
+
+### Initialize analytical components
+
+The component-specific methods initialize internal waves, inertial oscillations, geostrophic motions, and mean-density anomalies. For example, initialize one internal wave by integer horizontal and vertical mode numbers:
+
+```matlab
+[omega,k,l] = wvt.initWithWaveModes( ...
+    kMode=10,lMode=0,j=1,phi=0,u=0.2,sign=1);
 period = 2*pi/omega;
 ```
-will initialize a first baroclinic mode wave with a wavenumber of $$k = 10(2\pi)/L_x$$.
 
-To initialize with a geostrophic stream function, use `initWithGeostrophicStreamfunction` and the related methods, e.g.,
-```matlab
-Le = 35e3;
-z0 = -wvt.Lz/4;
-He = wvt.Lz/10;
-U = 0.25; % m/s
-psi = @(x,y,z) U*(Le/sqrt(2))*exp(1/2)*exp(-((x-x0)/Le).^2 -((y-y0)/Le).^2) .* (erf((z-z0)/He)+1)/2;
+Use `initWithRandomFlow` for a deterministic or random collection of supported components, and use the component-specific API pages for spectral initialization options.
 
-wvt.setGeostrophicStreamfunction(psi);
-```
-creates a deep eddy.
+## Evaluate physical fields
 
-The initialization methods for the [WVTransform](/classes/transforms/wvtransform/) all use the same nomenclature,
+Registered state variables can be accessed through dot syntax:
 
-- `init`---clears ALL variables `Ap`, `Am`, `A0`, then sets/adds
-- `set`---clears only the component requested, and sets with new value.
-- `add`---adds to existing component
-- `removeAll`---remove all features of given type  
-
-### Other initialization methods
-
-It can also be useful to [`initWithRandomFlow`](/classes/transforms/wvtransform/initwithrandomflow.html). Also check out the section on [reading and writing to file](/users-guide/reading-and-writing-to-file.html) for how to use [`initFromNetCDFFile`](/classes/transforms/wvtransform/initfromnetcdffile.html) to quickly read in the ocean state from a saved file.
-
-## Examining the fluid state
-
-Once you have a `WVTransform` instance, you can now query it to return different state variables. The term "state" is used because these variables tell you something about the state of the fluid at the time in question.
-
-Standard variables that are available are documented with the [WVTransform](/classes/transforms/wvtransform/) and include $$(u,v,w,\rho,p)$$, the sea-surface height and velocities, the quasi-geostrophic potential vorticity (qgpv), the nonlinear fluxes $$(F_p, F_m, F_0)$$ and others. The transform has numerous built-in state variables
-```matlab
-wvt.summarizeVariables
-```
-will enumerate all current variables.
-
-There are two ways to access state variables. In the first way, you can query the transform using Matlab's dot syntax, e.g.,
 ```matlab
 u = wvt.u;
+rho = wvt.rho;
 ```
-will return a matrix of the $$u$$ velocity component. This can then be plotted in the usual way, e.g.,
+
+Requesting related variables together avoids repeating shared calculations:
+
 ```matlab
-figure
-pcolor(wvt.y,wvt.z,squeeze(wvt.u(1,:,:)).'), shading interp
+[u,v,w,rho] = wvt.variableWithName('u','v','w','rho');
 ```
-where the properties of the WVTransform `wvt.y` and `wvt.z` refer to those dimensions.
 
-The other way to access variables is to query them in a list using the [`variableWithName`](/classes/transforms/wvtransform/variablewithname.html) method,
- ```matlab
-[u,v,w] = wvt.variableWithName('u','v','w');
+Use `wvt.summarizeVariables` to list the registered variables, their dimensions, and units. Depending on the transform, variables include velocity, density, pressure, sea-surface fields, quasigeostrophic potential vorticity, energy diagnostics, and nonlinear fluxes.
+
+For periodic off-grid queries, use `variableAtPositionWithName` with `linear` or `spline` interpolation:
+
+```matlab
+xq = [0 10e3 20e3];
+yq = [0 15e3 30e3];
+zq = [-100 -300 -500];
+[uq,vq] = wvt.variableAtPositionWithName( ...
+    xq,yq,zq,'u','v',interpolationMethod='spline');
 ```
-this returns all the variables requested at the grid points. However, you can also use the [`variableAtPositionWithName`](/classes/transforms/wvtransform/variableatpositionwithname.html) method to return the value of any variable at *any* set of points in the domain. This method is used to do particle advection by the `WVModel`.
 
+Horizontal query coordinates wrap periodically. The returned arrays retain the query shape.
+
+## Continue from here
+
+- [Wavenumbers, modes, and indices](/users-guide/wavenumber-modes-and-indices.html) explains primary and conjugate mode conventions.
+- [Adding forcing](/users-guide/adding-forcing.html) prepares a transform for nonlinear integration.
+- [Reading and writing files](/users-guide/reading-and-writing-to-file.html) covers transform persistence and model restart.
+- [`WVTransform` API](/classes/transforms/wvtransform/) lists all state variables, diagnostics, and initialization methods.

--- a/docs/users-guide/wavenumber-modes-and-indices.md
+++ b/docs/users-guide/wavenumber-modes-and-indices.md
@@ -1,39 +1,39 @@
 ---
 layout: default
 title: Wavenumbers, modes, and indices
-parent: Users guide
+parent: User guide
 mathjax: true
 nav_order: 16
 ---
 
-#  Wavenumbers, modes, and indices
+# Wavenumbers, modes, and indices
 
-Working with the WaveVortexModel requires working with wavenumbers (such as $$k$$ and $$l$$), modes (such as geostrophic modes, or mode number $$j$$), and indices into matrices. There are many best practices and tools for working with wavenumbers, mode, and indices.
+WaveVortexModel distinguishes physical wavenumbers, integer mode numbers, and array indices. Keeping those concepts separate is important when initializing modes or mapping between physical, DFT, and wave–vortex representations.
 
 ## Definitions
 
-A **wavenumber** is a [spatial frequency](https://en.wikipedia.org/wiki/Wavenumber) with units of radians per meter. All WVTransform classes have horizontal wavenumbers $$k$$ and $$l$$, and the constant stratification class also has a vertical wavenumber $$m$$.
+A **wavenumber** is a [spatial frequency](https://en.wikipedia.org/wiki/Wavenumber) with units of radians per meter. Every `WVTransform` has horizontal wavenumbers $$k$$ and $$l$$, and the constant-stratification transform also has vertical wavenumber $$m$$.
 
-A **mode** is a unitless integer quantity. The model refers to `kMode` and `lMode`, and `j` all as unitless modes. Additionally, a geostrophic solution is also a mode (as are the other linear solutions).
+A **mode number** is a dimensionless integer label. `kMode`, `lMode`, and `j` identify a spectral solution independently of its storage location. The word *mode* may also refer to the corresponding geostrophic, wave, inertial, or mean-density-anomaly solution.
 
-An **index** is a location in memory of a particular variable. Matlab uses [subscript indices, linear indices, and logical indexing](https://www.mathworks.com/company/technical-articles/matrix-indexing-in-matlab.html) for different ways of accessing memory. The prefered method of indexing is local indexing.
+An **index** is a storage location in a MATLAB array. MATLAB provides [subscript, linear, and logical indexing](https://www.mathworks.com/company/technical-articles/matrix-indexing-in-matlab.html). Use the transform and flow-component mapping methods instead of assuming a particular internal ordering.
 
 ## More about modes
 
-Each degree-of-freedom in the wave-vortex model is a mode, which, in this case, is specifically a linear solution to the equations of motion. Each degree-of-freedom is identified with a unique set of mode numbers, either `(kMode,lMode)` or `(kMode,lMode,jMode)`, depending on whether the flow is two-dimensional or three-dimensional. There are two aspects of this identification which are important to call out:
+Each degree of freedom in the wave–vortex representation corresponds to a linear solution of the governing equations. A unique set of mode numbers, either `(kMode,lMode)` or `(kMode,lMode,j)`, identifies that solution. Two aspects of this identification are important:
 1. each set of mode numbers identifies a unique solution, and
 2. the choice of mode number for each solution is a matter of convention.
 
-As a consequence of these two aspects, you, the user, cannot know *a priori* what a valid set of mode numbers is unless the notation is established. The terminology used here is that these mode numbers are *primary* mode numbers. Furthermore, there may be other reasonable choices of mode number which are standard and perfectly valid. The terminology used here is that these are *conjugate* mode numbers. If a conjugate mode number exists, then this implies that there is some mapping from the conjugate mode to the primary solution. For these reasons, the all `WVTransform` subclass respond to the follow APIs,
+The unique labels stored by the transform are *primary* mode numbers. A physically equivalent Fourier representation may use a *conjugate* mode number, which maps back to the primary solution with the appropriate conjugation. The transform geometries provide:
 
 - `bool = isValidPrimaryModeNumber(self,kMode,lMode,jMode)`
 - `bool = isValidConjugateModeNumber(self,kMode,lMode,jMode)`
 - `bool = isValidModeNumber(self,kMode,lMode,jMode)`
 
-The function `isValidPrimaryModeNumber` will tell you whether or not that particular set of mode numbers is a valid, unique solution that is part of the basis set being used. The function `isValidConjugateModeNumber` will similarly tell you whether that mode number corresponds to a valid solution, but one which is not primary.
+`isValidPrimaryModeNumber` identifies a unique stored solution. `isValidConjugateModeNumber` identifies a valid equivalent label that is not primary. `isValidModeNumber` accepts either form.
 
-As a concrete example, consider the the modal solution to the periodic harmonic equation, $$u = A \sin\left( n \frac{\pi x}{L} \right)$$. A resonable convention would be to establish that $$n$$ must be an integer such that $$ 1 \leq n \leq 7$$ as the 7 primary mode numbers. Alternatively, it would be perfectly reasonable to choose $$-7 \leq n \leq -1$$ as the mode numbers and thus as a matter of convention we could identify these as conjugate mode numbers. Both are valid sets of mode numbers, and the mapping that exists between these different set of mode numbers requires we change the sign on the amplitude of the solution.
+As a simple analogy, consider the periodic harmonic solution $$u = A \sin(n\pi x/L)$$. One convention could label $$1 \leq n \leq 7$$ as primary, while the equivalent negative labels $$-7 \leq n \leq -1$$ are conjugate. Both label the same physical solution set, but their amplitudes must be mapped consistently.
 
-The situation gets more complicated as the solutions get more complicated. For doubly periodic geometry we now make a choice as to which set of wavenumber in which dimension gets designated as conjugate, and thus `WVGeometryDoublyPeriodic` has a `conjugateDimension` property which gets set upon initialization. Use of the above APIs let this choice be invisible to the user, even though it strongly affects the numerics.
+For doubly periodic geometry, the primary half-plane depends on the geometry's conjugate dimension. The mapping APIs hide that storage convention from ordinary initialization and analysis code.
 
-The modes of the `WVTransform` classes are not solutions to the harmonic equation, but are instead solutions to various linearized equations of motion of geophysical flows. These solutions include the usual geostrophic and internal gravity solutions. The wave-vortex model identifies these solution types using the `WVFlowComponent` subclass `WVPrimaryFlowComponent`. The flow components also respond to the same three APIs listed above.
+WaveVortexModel's modes are solutions to linearized geophysical equations rather than the simple harmonic example. `WVPrimaryFlowComponent` subclasses classify the geostrophic, internal-wave, inertial, and mean-density-anomaly solutions and provide the same primary/conjugate validation methods for their own mode sets.

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -8,6 +8,7 @@ nav_order: 100
 
 ## [Unreleased]
 
+- Rewrote the README, homepage, installation instructions, and user guidance around the current `WVTransform` and `WVModel` workflows; completed the NetCDF conventions guide; linked the canonical wavevortexmodel.org site prominently; and adopted the Avenir-first website typography while retaining search.
 - Reorganized the generated API reference around user tasks, moved implementation machinery into Developer Topics, replaced release-status jargon with direct descriptions of capabilities and limitations, and restored authored scientific context, coefficient-occupancy tables, and design rationale.
 - Corrected the `WVTransform` and `WVModel` API reference, promoted the stored and time-evaluated wave-vortex coefficients, and classified low-level projection and reconstruction arrays as Developer reference.
 - Made documentation generation clean, deterministic, transactional, and reviewable with an exact ClassDocumentation 1.3.0 authoring dependency, canonical build/check tasks, generated hierarchy validation, and case-sensitive internal-route checks.


### PR DESCRIPTION
## Summary

- replace the README and website onboarding with the current WaveVortexModel 4.2.x API
- make wavevortexmodel.org the prominent canonical documentation destination
- modernize installation, transform, forcing, persistence, and NetCDF guidance while preserving useful scientific rationale
- adopt the Avenir-first site typography while retaining search
- add executable onboarding and documentation regressions

## Verification

- documentation route validation: 3,507 routes, zero failures
- `buildtool docs:check` twice with zero differences
- focused documentation tests: 20 passed
- smoke: 127 passed
- full: 602 passed, twice
- exhaustive: 2,440 passed
- Code Analyzer: zero blocking findings
- whitespace, package-manifest, artifact, CNAME, and repository-scope checks passed

Closes #63