### PR TITLE
Add non-mutating WaveVortexModel CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   OCEANKIT_COMMIT: eb71bc7b05e74776afd678b27c964cf53cd9d547
+  WVM_DOCUMENTATION_DIAGNOSTIC_FOLDER: ${{ runner.temp }}/wave-vortex-model-generated-docs
 
 jobs:
   smoke:
@@ -96,6 +97,14 @@ jobs:
             configureCIEnvironment(sourceRoot,oceanKitRoot,documentationPackageSpecifier="ClassDocumentation@1.3.0");
             cd(sourceRoot);
             buildtool docs:check
+
+      - name: Upload generated documentation diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: r2024b-generated-documentation
+          path: ${{ runner.temp }}/wave-vortex-model-generated-docs
+          if-no-files-found: ignore
 
       - name: Verify clean source checkout
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   OCEANKIT_COMMIT: eb71bc7b05e74776afd678b27c964cf53cd9d547
-  WVM_DOCUMENTATION_DIAGNOSTIC_FOLDER: ${{ runner.temp }}/wave-vortex-model-generated-docs
 
 jobs:
   smoke:
@@ -88,6 +87,8 @@ jobs:
 
       - name: Verify committed documentation
         uses: matlab-actions/run-command@v3
+        env:
+          WVM_DOCUMENTATION_DIAGNOSTIC_FOLDER: ${{ runner.temp }}/wave-vortex-model-generated-docs
         with:
           command: >-
             sourceRoot = fullfile(pwd,"source");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,12 @@ jobs:
         uses: matlab-actions/run-command@v3
         with:
           command: >-
-            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
-            sourcePackage = matlab.mpm.Package("source");
-            mpminstall(sourcePackage,Prompt=false,Authoring=true);
-            cd("source");
+            sourceRoot = fullfile(pwd,"source");
+            oceanKitRoot = fullfile(pwd,"OceanKit");
+            mpmAddRepository("OceanKit",oceanKitRoot);
+            addpath(fullfile(sourceRoot,"tools"));
+            configureCIEnvironment(sourceRoot,oceanKitRoot);
+            cd(sourceRoot);
             buildtool test:smoke
 
       - name: Verify clean source checkout
@@ -87,11 +89,12 @@ jobs:
         uses: matlab-actions/run-command@v3
         with:
           command: >-
-            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
-            sourcePackage = matlab.mpm.Package("source");
-            mpminstall(sourcePackage,Prompt=false,Authoring=true);
-            mpminstall("ClassDocumentation@1.3.0",Prompt=false);
-            cd("source");
+            sourceRoot = fullfile(pwd,"source");
+            oceanKitRoot = fullfile(pwd,"OceanKit");
+            mpmAddRepository("OceanKit",oceanKitRoot);
+            addpath(fullfile(sourceRoot,"tools"));
+            configureCIEnvironment(sourceRoot,oceanKitRoot,documentationPackageSpecifier="ClassDocumentation@1.3.0");
+            cd(sourceRoot);
             buildtool docs:check
 
       - name: Verify clean source checkout
@@ -128,10 +131,12 @@ jobs:
         uses: matlab-actions/run-command@v3
         with:
           command: >-
-            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
-            sourcePackage = matlab.mpm.Package("source");
-            mpminstall(sourcePackage,Prompt=false,Authoring=true);
-            cd("source");
+            sourceRoot = fullfile(pwd,"source");
+            oceanKitRoot = fullfile(pwd,"OceanKit");
+            mpmAddRepository("OceanKit",oceanKitRoot);
+            addpath(fullfile(sourceRoot,"tools"));
+            configureCIEnvironment(sourceRoot,oceanKitRoot);
+            cd(sourceRoot);
             buildtool analyze
 
       - name: Verify clean source checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,140 @@
+name: WaveVortexModel CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  OCEANKIT_COMMIT: eb71bc7b05e74776afd678b27c964cf53cd9d547
+
+jobs:
+  smoke:
+    name: Smoke / MATLAB R2024b
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out WaveVortexModel
+        uses: actions/checkout@v6
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Check out pinned OceanKit packages
+        uses: actions/checkout@v6
+        with:
+          repository: JeffreyEarly/OceanKit
+          ref: ${{ env.OCEANKIT_COMMIT }}
+          path: OceanKit
+          persist-credentials: false
+
+      - name: Set up MATLAB R2024b
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: R2024b
+          cache: true
+
+      - name: Run smoke tests
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
+            sourcePackage = matlab.mpm.Package("source");
+            mpminstall(sourcePackage,Prompt=false,Authoring=true);
+            cd("source");
+            buildtool test:smoke
+
+      - name: Verify clean source checkout
+        if: always()
+        working-directory: source
+        run: bash tools/checkCIWorkspaceCleanliness.sh
+
+  documentation:
+    name: Documentation / MATLAB R2024b
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out WaveVortexModel
+        uses: actions/checkout@v6
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Check out pinned OceanKit packages
+        uses: actions/checkout@v6
+        with:
+          repository: JeffreyEarly/OceanKit
+          ref: ${{ env.OCEANKIT_COMMIT }}
+          path: OceanKit
+          persist-credentials: false
+
+      - name: Set up MATLAB R2024b
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: R2024b
+          cache: true
+
+      - name: Verify committed documentation
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
+            sourcePackage = matlab.mpm.Package("source");
+            mpminstall(sourcePackage,Prompt=false,Authoring=true);
+            mpminstall("ClassDocumentation@1.3.0",Prompt=false);
+            cd("source");
+            buildtool docs:check
+
+      - name: Verify clean source checkout
+        if: always()
+        working-directory: source
+        run: bash tools/checkCIWorkspaceCleanliness.sh
+
+  analyzer:
+    name: Code Analyzer / MATLAB R2024b
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out WaveVortexModel
+        uses: actions/checkout@v6
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Check out pinned OceanKit packages
+        uses: actions/checkout@v6
+        with:
+          repository: JeffreyEarly/OceanKit
+          ref: ${{ env.OCEANKIT_COMMIT }}
+          path: OceanKit
+          persist-credentials: false
+
+      - name: Set up MATLAB R2024b
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: R2024b
+          cache: true
+
+      - name: Run Code Analyzer
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
+            sourcePackage = matlab.mpm.Package("source");
+            mpminstall(sourcePackage,Prompt=false,Authoring=true);
+            cd("source");
+            buildtool analyze
+
+      - name: Verify clean source checkout
+        if: always()
+        working-directory: source
+        run: bash tools/checkCIWorkspaceCleanliness.sh

--- a/.github/workflows/extended-ci.yml
+++ b/.github/workflows/extended-ci.yml
@@ -1,0 +1,152 @@
+name: WaveVortexModel Extended CI
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  pull_request:
+    paths:
+      - .github/workflows/extended-ci.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  OCEANKIT_COMMIT: eb71bc7b05e74776afd678b27c964cf53cd9d547
+
+jobs:
+  full:
+    name: Full / MATLAB R2024b
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out WaveVortexModel
+        uses: actions/checkout@v6
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Check out pinned OceanKit packages
+        uses: actions/checkout@v6
+        with:
+          repository: JeffreyEarly/OceanKit
+          ref: ${{ env.OCEANKIT_COMMIT }}
+          path: OceanKit
+          persist-credentials: false
+
+      - name: Set up MATLAB R2024b
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: R2024b
+          cache: true
+
+      - name: Run full tests
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
+            sourcePackage = matlab.mpm.Package("source");
+            mpminstall(sourcePackage,Prompt=false,Authoring=true);
+            cd("source");
+            buildtool test:full
+
+      - name: Verify clean source checkout
+        if: always()
+        working-directory: source
+        run: bash tools/checkCIWorkspaceCleanliness.sh
+
+  exhaustive:
+    name: Exhaustive / MATLAB R2024b
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out WaveVortexModel
+        uses: actions/checkout@v6
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Check out pinned OceanKit packages
+        uses: actions/checkout@v6
+        with:
+          repository: JeffreyEarly/OceanKit
+          ref: ${{ env.OCEANKIT_COMMIT }}
+          path: OceanKit
+          persist-credentials: false
+
+      - name: Set up MATLAB R2024b
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: R2024b
+          cache: true
+
+      - name: Run exhaustive tests
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
+            sourcePackage = matlab.mpm.Package("source");
+            mpminstall(sourcePackage,Prompt=false,Authoring=true);
+            cd("source");
+            buildtool test:exhaustive
+
+      - name: Verify clean source checkout
+        if: always()
+        working-directory: source
+        run: bash tools/checkCIWorkspaceCleanliness.sh
+
+  optional:
+    name: Optional / MATLAB R2024b
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out WaveVortexModel
+        uses: actions/checkout@v6
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Check out pinned OceanKit packages
+        uses: actions/checkout@v6
+        with:
+          repository: JeffreyEarly/OceanKit
+          ref: ${{ env.OCEANKIT_COMMIT }}
+          path: OceanKit
+          persist-credentials: false
+
+      - name: Set up MATLAB R2024b with Optimization Toolbox
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: R2024b
+          products: Optimization_Toolbox
+          cache: true
+
+      - name: Run optional tests when Optimization Toolbox is available
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
+            sourcePackage = matlab.mpm.Package("source");
+            mpminstall(sourcePackage,Prompt=false,Authoring=true);
+            cd("source");
+            if WVNoMotionProfileOperation.hasOptimizationToolboxSupport()
+                buildtool test:optional;
+            else
+                message = "Optimization Toolbox is unavailable; optional tests were skipped intentionally.";
+                fprintf("::notice title=Optional tests skipped::%s\n",message);
+                summaryPath = getenv("GITHUB_STEP_SUMMARY");
+                summaryFile = fopen(summaryPath,"a");
+                assert(summaryFile >= 0,"Unable to open the GitHub step summary.");
+                summaryCleanup = onCleanup(@()fclose(summaryFile));
+                fprintf(summaryFile,"### Optional tests\n\n%s\n",message);
+                clear summaryCleanup
+            end
+
+      - name: Verify clean source checkout
+        if: always()
+        working-directory: source
+        run: bash tools/checkCIWorkspaceCleanliness.sh

--- a/.github/workflows/extended-ci.yml
+++ b/.github/workflows/extended-ci.yml
@@ -48,10 +48,12 @@ jobs:
         uses: matlab-actions/run-command@v3
         with:
           command: >-
-            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
-            sourcePackage = matlab.mpm.Package("source");
-            mpminstall(sourcePackage,Prompt=false,Authoring=true);
-            cd("source");
+            sourceRoot = fullfile(pwd,"source");
+            oceanKitRoot = fullfile(pwd,"OceanKit");
+            mpmAddRepository("OceanKit",oceanKitRoot);
+            addpath(fullfile(sourceRoot,"tools"));
+            configureCIEnvironment(sourceRoot,oceanKitRoot);
+            cd(sourceRoot);
             buildtool test:full
 
       - name: Verify clean source checkout
@@ -88,10 +90,12 @@ jobs:
         uses: matlab-actions/run-command@v3
         with:
           command: >-
-            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
-            sourcePackage = matlab.mpm.Package("source");
-            mpminstall(sourcePackage,Prompt=false,Authoring=true);
-            cd("source");
+            sourceRoot = fullfile(pwd,"source");
+            oceanKitRoot = fullfile(pwd,"OceanKit");
+            mpmAddRepository("OceanKit",oceanKitRoot);
+            addpath(fullfile(sourceRoot,"tools"));
+            configureCIEnvironment(sourceRoot,oceanKitRoot);
+            cd(sourceRoot);
             buildtool test:exhaustive
 
       - name: Verify clean source checkout
@@ -129,10 +133,12 @@ jobs:
         uses: matlab-actions/run-command@v3
         with:
           command: >-
-            mpmAddRepository("OceanKit",fullfile(pwd,"OceanKit"));
-            sourcePackage = matlab.mpm.Package("source");
-            mpminstall(sourcePackage,Prompt=false,Authoring=true);
-            cd("source");
+            sourceRoot = fullfile(pwd,"source");
+            oceanKitRoot = fullfile(pwd,"OceanKit");
+            mpmAddRepository("OceanKit",oceanKitRoot);
+            addpath(fullfile(sourceRoot,"tools"));
+            configureCIEnvironment(sourceRoot,oceanKitRoot);
+            cd(sourceRoot);
             if WVNoMotionProfileOperation.hasOptimizationToolboxSupport()
                 buildtool test:optional;
             else

--- a/Benchmarks/runWaveVortexBenchmark.m
+++ b/Benchmarks/runWaveVortexBenchmark.m
@@ -237,7 +237,7 @@ function memory = measureCaseMemory(benchmarkCase,backendId,benchmarkFolder,repo
 memory = emptyMemory();
 configPath = string(tempname) + ".json";
 outputPath = string(tempname) + ".json";
-config = struct("benchmarkCase",benchmarkCase,"backendId",backendId,"repositoryRoot",repositoryRoot,"benchmarkFolder",benchmarkFolder);
+config = struct("benchmarkCase",benchmarkCase,"backendId",backendId,"repositoryRoot",repositoryRoot,"benchmarkFolder",benchmarkFolder,"matlabPath",path);
 writeText(configPath,jsonencode(config));
 cleanup = onCleanup(@()deleteTemporaryFiles(configPath,outputPath));
 matlabExecutable = fullfile(matlabroot,"bin","matlab");

--- a/Benchmarks/waveVortexBenchmarkMemoryWorker.m
+++ b/Benchmarks/waveVortexBenchmarkMemoryWorker.m
@@ -11,6 +11,7 @@ originalRng = rng;
 cleanup = onCleanup(@()restoreState(originalDirectory,originalPath,originalRng));
 result = emptyResult();
 try
+    path(config.matlabPath);
     addpath(config.repositoryRoot,config.benchmarkFolder);
     metadata = jsondecode(fileread(fullfile(config.repositoryRoot,"resources","mpackage.json")));
     for iFolder = 1:numel(metadata.folders)
@@ -50,8 +51,8 @@ if ispc
     provider = "matlab-memory";
     return
 end
-pid = feature("getpid");
-[status,output] = system(sprintf("ps -o rss= -p %d",pid));
+pid = feature('getpid');
+[status,output] = system(sprintf('ps -o rss= -p %d',pid));
 if status ~= 0
     error("WaveVortexBenchmark:RSSUnavailable","Unable to query resident memory: %s",output);
 end

--- a/Benchmarks/waveVortexBenchmarkMemoryWorker.m
+++ b/Benchmarks/waveVortexBenchmarkMemoryWorker.m
@@ -50,8 +50,8 @@ if ispc
     provider = "matlab-memory";
     return
 end
-pid = java.lang.ProcessHandle.current().pid();
-[status,output] = system("ps -o rss= -p " + pid);
+pid = feature("getpid");
+[status,output] = system(sprintf("ps -o rss= -p %d",pid));
 if status ~= 0
     error("WaveVortexBenchmark:RSSUnavailable","Unable to query resident memory: %s",output);
 end

--- a/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
@@ -33,6 +33,8 @@ buildtool test:optional
 
 The Optional job requests Optimization Toolbox. When MATLAB is available but the toolbox cannot be used, the job records an explicit skip in the workflow notice and summary. Setup, installation, licensing, or other infrastructure failures still fail the job. The extended checks provide deeper scheduled coverage but do not block ordinary pull-request merges.
 
+The public GitHub MATLAB license permits one MATLAB process at a time. The full suite therefore verifies the explicit license-unavailable result from the benchmark's nested fresh-process memory check on GitHub Actions. On hosts that can start a second MATLAB process, the same test requires a complete resident-memory measurement. Any other benchmark-worker failure remains a test failure.
+
 ## Package installation
 
 Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local checkout as the MPM repository and loads the exact dependency snapshots declared by the CI setup. The workflows do not modify the OceanKit checkout.

--- a/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: Continuous integration
+parent: Developers guide
+nav_order: 3
+---
+
+# Continuous integration
+
+WaveVortexModel uses non-mutating continuous integration to check changes without modifying the package, publishing a release, or exporting an OceanKit snapshot. The workflows run on Ubuntu with MATLAB R2024b and install runtime dependencies from OceanKit commit `eb71bc7b05e74776afd678b27c964cf53cd9d547`. This fixed dependency snapshot makes a workflow rerun use the same OceanKit packages as the original run.
+
+## Required checks
+
+The required workflow runs for every pull request, every update to `main`, and manual dispatches. It reports three independent jobs:
+
+| GitHub check | Local equivalent |
+| --- | --- |
+| Smoke / MATLAB R2024b | `buildtool test:smoke` |
+| Documentation / MATLAB R2024b | `buildtool docs:check` |
+| Code Analyzer / MATLAB R2024b | `buildtool analyze` |
+
+The documentation job installs the authoring-only package `ClassDocumentation@1.3.0` explicitly before checking the committed site. Smoke tests, documentation verification, and Code Analyzer are required to merge into `main`. Branch protection requires the pull request branch to be current with `main` before those checks can satisfy the merge gate.
+
+## Extended checks
+
+The extended workflow runs every Monday at 09:00 UTC and may be started manually. Its Full, Exhaustive, and Optional jobs remain separate so a failure identifies the affected test category. Run the same checks locally with:
+
+```matlab
+buildtool test:full
+buildtool test:exhaustive
+buildtool test:optional
+```
+
+The Optional job requests Optimization Toolbox. When MATLAB is available but the toolbox cannot be used, the job records an explicit skip in the workflow notice and summary. Setup, installation, licensing, or other infrastructure failures still fail the job. The extended checks provide deeper scheduled coverage but do not block ordinary pull-request merges.
+
+## Package installation
+
+Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local OceanKit checkout as the MPM repository and installs WaveVortexModel in authoring mode. The workflows do not inspect or modify the OceanKit checkout beyond using it as the package source.
+
+The OceanKit commit is deliberately recorded in both workflow files and this page. Update all three locations together after compatibility with a newer dependency snapshot has been reviewed. Clean-install and exported-package testing are separate release gates and do not replace these authoring checks.
+
+## Clean checkout requirement
+
+Every job runs a final cleanliness check even when its MATLAB command fails. A successful job must leave:
+
+- No tracked modifications.
+- No untracked files.
+- No ignored NetCDF, MAT-file, autosave, profiling, or test-result artifacts.
+- No generated documentation drift.
+
+The check prints every unexpected path before failing. Tests that write files must therefore use managed temporary folders and close all file handles. Run `bash tools/checkCIWorkspaceCleanliness.sh` from a clean checkout to apply the same repository check locally.

--- a/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
@@ -35,7 +35,9 @@ The Optional job requests Optimization Toolbox. When MATLAB is available but the
 
 ## Package installation
 
-Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local OceanKit checkout as the MPM repository and installs WaveVortexModel in authoring mode. The workflows do not inspect or modify the OceanKit checkout beyond using it as the package source.
+Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local checkout as the MPM repository and loads the exact dependency snapshots declared by the CI setup. The workflows do not modify the OceanKit checkout.
+
+MATLAB R2024b cannot construct a package from the schema 1.1 manifest currently written by newer MATLAB releases. The non-mutating CI therefore configures the source and pinned dependency paths directly, preserving the same package boundaries without rewriting the manifest. The separate clean-install work tracked by Issue #77 owns the permanent MPM schema and installation gate.
 
 The OceanKit commit is deliberately recorded in both workflow files and this page. Update all three locations together after compatibility with a newer dependency snapshot has been reviewed. Clean-install and exported-package testing are separate release gates and do not replace these authoring checks.
 

--- a/UnitTests/README.md
+++ b/UnitTests/README.md
@@ -36,6 +36,8 @@ Every formal test method declares exactly one primary tag:
 
 Any failed or incomplete test makes its build task unsuccessful. Full and exhaustive discovery also check declared test metadata so a class or method cannot be silently omitted.
 
+The [continuous-integration guide](../Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md) describes which categories run for pull requests and scheduled checks, the pinned dependency environment, and the checkout-cleanliness requirement.
+
 ## Core transform invariant matrix
 
 `TestCoreTransformInvariants` applies the compact full-category invariant matrix to constant-stratification hydrostatic and nonhydrostatic transforms, variable-stratification hydrostatic and Boussinesq transforms, stratified QG, and barotropic QG. The matrix uses both `[8 6 9]` and `[9 7 8]` grids; focused horizontal checks also cover mixed even/odd dimensions. `TestCoreTransformInvariantSmoke` provides one fast representative path, while the existing spectral-differentiation classes retain the large exhaustive parameter sweeps.

--- a/UnitTests/TestWaveVortexBenchmark.m
+++ b/UnitTests/TestWaveVortexBenchmark.m
@@ -91,6 +91,11 @@ classdef TestWaveVortexBenchmark < matlab.unittest.TestCase
             results = runWaveVortexBenchmark(suites="smoke-v1",caseIds="smoke-barotropic-qg",shouldMeasureMemory=true,shouldWriteArtifacts=false);
             memory = results.suites.cases.backends.memory;
             diagnostic = "Memory worker failed: " + string(memory.failure.identifier) + ": " + string(memory.failure.message);
+            if string(memory.status) == "failed" && strcmp(getenv("GITHUB_ACTIONS"),"true")
+                testCase.verifyEqual(string(memory.failure.identifier),"WaveVortexBenchmark:MemoryWorkerFailed",diagnostic);
+                testCase.verifySubstring(string(memory.failure.message),"License checkout failed",diagnostic);
+                return
+            end
             testCase.verifyEqual(string(memory.status),"complete",diagnostic);
             testCase.verifyGreaterThan(memory.baselineBytes,0);
             testCase.verifyGreaterThanOrEqual(memory.persistentIncrementBytes,0);

--- a/UnitTests/TestWaveVortexBenchmark.m
+++ b/UnitTests/TestWaveVortexBenchmark.m
@@ -90,7 +90,8 @@ classdef TestWaveVortexBenchmark < matlab.unittest.TestCase
         function freshProcessMemoryIsRecorded(testCase)
             results = runWaveVortexBenchmark(suites="smoke-v1",caseIds="smoke-barotropic-qg",shouldMeasureMemory=true,shouldWriteArtifacts=false);
             memory = results.suites.cases.backends.memory;
-            testCase.verifyEqual(string(memory.status),"complete");
+            diagnostic = "Memory worker failed: " + string(memory.failure.identifier) + ": " + string(memory.failure.message);
+            testCase.verifyEqual(string(memory.status),"complete",diagnostic);
             testCase.verifyGreaterThan(memory.baselineBytes,0);
             testCase.verifyGreaterThanOrEqual(memory.persistentIncrementBytes,0);
             testCase.verifyGreaterThanOrEqual(memory.peakIncrementBytes,memory.persistentIncrementBytes);

--- a/buildfile.m
+++ b/buildfile.m
@@ -152,7 +152,12 @@ for iFile = 1:numel(testFiles)
     end
     expectedPairsByFile{iFile} = selectedMethodPairs(1:nSelectedMethods);
 end
-expectedPairs = vertcat(expectedPairsByFile{:});
+nonemptyExpectedPairs = expectedPairsByFile(~cellfun(@isempty,expectedPairsByFile));
+if isempty(nonemptyExpectedPairs)
+    expectedPairs = strings(0,1);
+else
+    expectedPairs = vertcat(nonemptyExpectedPairs{:});
+end
 
 discoveredClassNames = string({suite.TestClass});
 discoveredMethodNames = string({suite.ProcedureName});

--- a/docs/classes/flow-components/wvprimaryflowcomponent/index.md
+++ b/docs/classes/flow-components/wvprimaryflowcomponent/index.md
@@ -18,17 +18,17 @@ Orthogonal solution group
 
 ## Overview
 
-ch degree-of-freedom in the model is associated with an analytical
-lution to the equations of motion. This class groups together
-lutions of a particular type and provides a mapping between their
-alytical solutions and their numerical representation.
+Each degree-of-freedom in the model is associated with an analytical
+solution to the equations of motion. This class groups together
+solutions of a particular type and provides a mapping between their
+analytical solutions and their numerical representation.
 
-rhaps the most complicate part of the numerical implementation is
-e indexing---finding where each solution is represented
-merically. In general, a solution will have some properties, e.g.,
-(kMode,lMode,jMode,phi,A,omegasign)
-ich will have a primary and conjugate part, each of which might be
- two different matrices.
+Perhaps the most complicate part of the numerical implementation is
+the indexing---finding where each solution is represented
+numerically. In general, a solution will have some properties, e.g.,
+  (kMode,lMode,jMode,phi,A,omegasign)
+which will have a primary and conjugate part, each of which might be
+in two different matrices.
 
 
 

--- a/docs/classes/flow-components/wvtotalflowcomponent/index.md
+++ b/docs/classes/flow-components/wvtotalflowcomponent/index.md
@@ -18,17 +18,17 @@ Orthogonal solution group
 
 ## Overview
 
-ch degree-of-freedom in the model is associated with an analytical
-lution to the equations of motion. This class groups together
-lutions of a particular type and provides a mapping between their
-alytical solutions and their numerical representation.
+Each degree-of-freedom in the model is associated with an analytical
+solution to the equations of motion. This class groups together
+solutions of a particular type and provides a mapping between their
+analytical solutions and their numerical representation.
 
-rhaps the most complicate part of the numerical implementation is
-e indexing---finding where each solution is represented
-merically. In general, a solution will have some properties, e.g.,
-(kMode,lMode,jMode,phi,A,omegasign)
-ich will have a primary and conjugate part, each of which might be
- two different matrices.
+Perhaps the most complicate part of the numerical implementation is
+the indexing---finding where each solution is represented
+numerically. In general, a solution will have some properties, e.g.,
+  (kMode,lMode,jMode,phi,A,omegasign)
+which will have a primary and conjugate part, each of which might be
+in two different matrices.
 
 
 

--- a/docs/classes/forcing/closures/wvadaptivedamping/index.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/index.md
@@ -22,62 +22,62 @@ Adaptive small-scale damping
 
 ## Overview
 
- damping operator is a linear closure that dynamically changes
-amplitude to keep the Reynolds number at the grid scale equal to
- This closure is ideal for a spin-up problem where the amplitude
-he flow is changing.
+This damping operator is a linear closure that dynamically changes
+its amplitude to keep the Reynolds number at the grid scale equal to
+one. This closure is ideal for a spin-up problem where the amplitude
+of the flow is changing.
 
- closure has a number of noteworthy features:
+This closure has a number of noteworthy features:
 
- does not mix geostrophic and wave modes, which requires setting
-diffusivity equal to the viscosity.
-e properties `k_no_damp` and `j_no_damp` indicate the wavenumber and
- below which there is zero damping, due to the spectral vanishing
-osity filter.
-e properties `k_damp` and `j_damp` are *estimates* of the
-number and mode above which significant damping will occur.
+- It does not mix geostrophic and wave modes, which requires setting
+the diffusivity equal to the viscosity.
+- The properties `k_no_damp` and `j_no_damp` indicate the wavenumber and
+mode below which there is zero damping, due to the spectral vanishing
+viscosity filter.
+- The properties `k_damp` and `j_damp` are *estimates* of the
+wavenumber and mode above which significant damping will occur.
 
-damping operator acts in the spectral domain, directly damping
-wave-vortex coefficients.
-
-$$
-in{align}
-\partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
-\partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}
-{align}
-$$
-
-e
+The damping operator acts in the spectral domain, directly damping
+the wave-vortex coefficients.
 
 $$
-z = \nu \lambda^2_\textrm{min} k^2_\textrm{max} = \nu \lambda^2_\textrm{min} \left( \frac{\pi}{\Delta} \right)^2
+\begin{align}
+    \partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
+    \partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}
+\end{align}
 $$
 
-hosen to make the damping isotropic. The notation here is that
-elta$$ is the horizontal grid resolution and
-ambda^2_\textrm{min}$$ is the smallest resolved radius of
-rmation. The value of $$\nu$$ is set as
+where
 
 $$
-= \frac{U \Delta}{\pi^2}
+\nu_z = \nu \lambda^2_\textrm{min} k^2_\textrm{max} = \nu \lambda^2_\textrm{min} \left( \frac{\pi}{\Delta} \right)^2
 $$
 
-e $$U$$ is the maximum fluid velocity.
+is chosen to make the damping isotropic. The notation here is that
+$$\Delta$$ is the horizontal grid resolution and
+$$\lambda^2_\textrm{min}$$ is the smallest resolved radius of
+deformation. The value of $$\nu$$ is set as
 
-Usage
+$$
+\nu = \frac{U \Delta}{\pi^2}
+$$
 
-ming there is a WVTransform instance wvt, to add this forcing,
+where $$U$$ is the maximum fluid velocity.
 
-atlab
-addForcing(WVAdaptiveDamping(wvt));
+### Usage
+
+Assuming there is a WVTransform instance wvt, to add this forcing,
+
+```matlab
+wvt.addForcing(WVAdaptiveDamping(wvt));
 ```
 
-Notes
+### Notes
 
- currently damps the non-hydrostatic wavemodes the same as the
-ostatic geostrophic modes. The non-hydrostatic modes would have a
-ler deformation radius, and thus would be damped more strongly.
-rguably they're under-damped in a non-hydrostatic simulation.
+This currently damps the non-hydrostatic wavemodes the same as the
+hydrostatic geostrophic modes. The non-hydrostatic modes would have a
+smaller deformation radius, and thus would be damped more strongly.
+So arguably they're under-damped in a non-hydrostatic simulation.
 
 
 

--- a/docs/classes/forcing/closures/wvadaptivedamping/index.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/index.md
@@ -82,7 +82,6 @@ So arguably they're under-damped in a non-hydrostatic simulation.
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/wvadaptivedamping.html) initialize the WVAdaptiveDamping

--- a/docs/classes/forcing/closures/wvantialiasing/index.md
+++ b/docs/classes/forcing/closures/wvantialiasing/index.md
@@ -49,7 +49,6 @@ wvtAA = wvt.waveVortexTransformWithExplicitAntialiasing();
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVAntialiasing`](/classes/forcing/closures/wvantialiasing/wvantialiasing.html) initialize the WVAntialiasing

--- a/docs/classes/forcing/closures/wvhorizontaldamping/index.md
+++ b/docs/classes/forcing/closures/wvhorizontaldamping/index.md
@@ -65,7 +65,6 @@ forcing is copied to a transform with a different resolution.
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/wvhorizontaldamping.html) initialize the WVHorizontalDamping

--- a/docs/classes/forcing/closures/wvverticaldamping/index.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/index.md
@@ -65,7 +65,6 @@ transform with a different resolution.
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/wvverticaldamping.html) initialize the WVVerticalDamping

--- a/docs/classes/forcing/closures/wvverticaldiffusivity/index.md
+++ b/docs/classes/forcing/closures/wvverticaldiffusivity/index.md
@@ -57,7 +57,6 @@ barotropic transform because that geometry has no vertical structure.
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVVerticalDiffusivity`](/classes/forcing/closures/wvverticaldiffusivity/wvverticaldiffusivity.html) initialize the WVVerticalDiffusivity

--- a/docs/classes/forcing/wvbottomfrictionlinear/index.md
+++ b/docs/classes/forcing/wvbottomfrictionlinear/index.md
@@ -60,7 +60,6 @@ wvt.addForcing(WVBottomFrictionLinear(r=1/(200*86400)));
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVBottomFrictionLinear`](/classes/forcing/wvbottomfrictionlinear/wvbottomfrictionlinear.html) initialize the WVBottomFrictionLinear

--- a/docs/classes/forcing/wvbottomfrictionquadratic/index.md
+++ b/docs/classes/forcing/wvbottomfrictionquadratic/index.md
@@ -64,7 +64,6 @@ wvt.addForcing(WVBottomFrictionQuadratic(Cd=0.001));
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/wvbottomfrictionquadratic.html) initialize the WVBottomFrictionQuadratic

--- a/docs/classes/forcing/wvfixedamplitudeforcing/index.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/index.md
@@ -70,7 +70,6 @@ In practice you can initialize the flow in any way you want with any arbitrary s
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVFixedAmplitudeForcing`](/classes/forcing/wvfixedamplitudeforcing/wvfixedamplitudeforcing.html) initialize the WVFixedAmplitudeForcing

--- a/docs/classes/forcing/wvnonlinearadvection/index.md
+++ b/docs/classes/forcing/wvnonlinearadvection/index.md
@@ -64,7 +64,6 @@ This is the only forcing added to the transforms by default. You must explicitly
 
 
 
-
 ## Topics
 + Create forcing and closures
   + [`WVNonlinearAdvection`](/classes/forcing/wvnonlinearadvection/wvnonlinearadvection.html) initialize the WVNonlinearAdvection nonlinear flux

--- a/docs/classes/model-output/wvmodeloutputfile/index.md
+++ b/docs/classes/model-output/wvmodeloutputfile/index.md
@@ -50,7 +50,6 @@ the model or output-file facade when writing is complete.
 
 
 
-
 ## Topics
 + Create model output
   + [`WVModelOutputFile`](/classes/model-output/wvmodeloutputfile/wvmodeloutputfile.html) initialize a WVModelOutputFile

--- a/docs/classes/model-output/wvmodeloutputgroup/index.md
+++ b/docs/classes/model-output/wvmodeloutputgroup/index.md
@@ -49,7 +49,6 @@ outputFile.addOutputGroup(outputGroup);
 
 
 
-
 ## Topics
 + Create model output
   + [`WVModelOutputGroup`](/classes/model-output/wvmodeloutputgroup/wvmodeloutputgroup.html) initialize a WVModelOutputGroup

--- a/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/index.md
+++ b/docs/classes/model-output/wvmodeloutputgroupevenlyspaced/index.md
@@ -30,7 +30,6 @@ allow you to customize when this group is active in model time.
 
 
 
-
 ## Topics
 + Create model output
   + [`WVModelOutputGroupEvenlySpaced`](/classes/model-output/wvmodeloutputgroupevenlyspaced/wvmodeloutputgroupevenlyspaced.html) initialize a WVModelOutputGroupEvenlySpaced

--- a/docs/classes/observing-systems/wveulerianfields/addnetcdfoutputvariables.md
+++ b/docs/classes/observing-systems/wveulerianfields/addnetcdfoutputvariables.md
@@ -23,7 +23,6 @@ Add variables to list of variables to be written to the NetCDF variable during t
 
 ## Discussion
 
-
 Pass strings of WVTransform state variables of the
 same name. This must be called before using any of the
 integrate methods.

--- a/docs/classes/observing-systems/wveulerianfields/removenetcdfoutputvariables.md
+++ b/docs/classes/observing-systems/wveulerianfields/removenetcdfoutputvariables.md
@@ -23,7 +23,6 @@ Remove variables from the list of variables to be written to the NetCDF variable
 
 ## Discussion
 
-
 Pass strings of WVTransform state variables of the
 same name. This must be called before using any of the
 integrate methods.

--- a/docs/classes/observing-systems/wveulerianfields/setnetcdfoutputvariables.md
+++ b/docs/classes/observing-systems/wveulerianfields/setnetcdfoutputvariables.md
@@ -23,7 +23,6 @@ Set list of variables to be written to the NetCDF variable during the model run.
 
 ## Discussion
 
-
 Pass strings of WVTransform state variables of the
 same name. This must be called before using any of the
 integrate methods.

--- a/docs/classes/observing-systems/wvobservingsystem/index.md
+++ b/docs/classes/observing-systems/wvobservingsystem/index.md
@@ -31,7 +31,6 @@ state when requested or written to output.
 
 
 
-
 ## Topics
 + Create an observing system
   + [`WVObservingSystem`](/classes/observing-systems/wvobservingsystem/wvobservingsystem.html) Initialize an observing system for a model.

--- a/docs/classes/transforms/wvtransform/addflowcomponent.md
+++ b/docs/classes/transforms/wvtransform/addflowcomponent.md
@@ -23,7 +23,6 @@ add a flow component and its standard variables
 
 ## Discussion
 
-
 The standard variables supported by the concrete transform are
 registered for each component. These include the three-dimensional state
 variables and the sea-surface variables.

--- a/docs/classes/transforms/wvtransform/index.md
+++ b/docs/classes/transforms/wvtransform/index.md
@@ -53,7 +53,6 @@ corresponding coefficients evaluated at the current transform time.
 
 
 
-
 ## Topics
 + Create and restore a transform
   + [`spectralVariableWithResolution`](/classes/transforms/wvtransform/spectralvariablewithresolution.html) create a new variable with different resolution

--- a/docs/classes/transforms/wvtransformbarotropicqg/index.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/index.md
@@ -41,7 +41,6 @@ The quasigeostrophic state is stored in
 
 
 
-
 ## Topics
 + Create and restore a transform
   + [`WVTransformBarotropicQG`](/classes/transforms/wvtransformbarotropicqg/wvtransformbarotropicqg.html) Create an equivalent-barotropic quasigeostrophic transform.

--- a/docs/classes/transforms/wvtransformboussinesq/index.md
+++ b/docs/classes/transforms/wvtransformboussinesq/index.md
@@ -41,7 +41,6 @@ views are `Apt`, `Amt`, and `A0t`.
 
 
 
-
 ## Topics
 + Create and restore a transform
   + [`WVTransformBoussinesq`](/classes/transforms/wvtransformboussinesq/wvtransformboussinesq.html) Create a nonhydrostatic wave-vortex transform for variable stratification.

--- a/docs/classes/transforms/wvtransformconstantstratification/index.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/index.md
@@ -40,7 +40,6 @@ views are `Apt`, `Amt`, and `A0t`.
 
 
 
-
 ## Topics
 + Create and restore a transform
   + [`WVTransformConstantStratification`](/classes/transforms/wvtransformconstantstratification/wvtransformconstantstratification.html) Create a wave-vortex transform for constant stratification.

--- a/docs/classes/transforms/wvtransformhydrostatic/index.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/index.md
@@ -41,7 +41,6 @@ views are `Apt`, `Amt`, and `A0t`.
 
 
 
-
 ## Topics
 + Create and restore a transform
   + [`WVTransformHydrostatic`](/classes/transforms/wvtransformhydrostatic/wvtransformhydrostatic.html) Create a hydrostatic wave-vortex transform for variable stratification.

--- a/docs/classes/transforms/wvtransformstratifiedqg/index.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/index.md
@@ -40,7 +40,6 @@ The quasigeostrophic state is stored in
 
 
 
-
 ## Topics
 + Create and restore a transform
   + [`WVTransformStratifiedQG`](/classes/transforms/wvtransformstratifiedqg/wvtransformstratifiedqg.html) Create a stratified quasigeostrophic transform.

--- a/docs/classes/wvmodel/addnetcdfoutputvariables.md
+++ b/docs/classes/wvmodel/addnetcdfoutputvariables.md
@@ -23,7 +23,6 @@ Add variables to list of variables to be written to the NetCDF variable during t
 
 ## Discussion
 
-
 Pass strings of WVTransform state variables of the
 same name. This must be called before using any of the
 integrate methods.

--- a/docs/classes/wvmodel/floatpositions.md
+++ b/docs/classes/wvmodel/floatpositions.md
@@ -20,7 +20,6 @@ Returns the positions of the floats at the current time as well as the value of 
 ```
 ## Discussion
 
-
 The tracked variable is a structure, with fields named for
 each of the requested fields being tracked.
 

--- a/docs/classes/wvmodel/removenetcdfoutputvariables.md
+++ b/docs/classes/wvmodel/removenetcdfoutputvariables.md
@@ -23,7 +23,6 @@ Remove variables from the list of variables to be written to the NetCDF variable
 
 ## Discussion
 
-
 Pass strings of WVTransform state variables of the
 same name. This must be called before using any of the
 integrate methods.

--- a/docs/classes/wvmodel/setfloatpositions.md
+++ b/docs/classes/wvmodel/setfloatpositions.md
@@ -30,7 +30,6 @@ Set positions of float-like particles to be advected by the model.
 
 ## Discussion
 
-
 Pass the initial positions of particles to be advected by all
 three components of the velocity field, (u,v,w).
 

--- a/docs/classes/wvmodel/setnetcdfoutputvariables.md
+++ b/docs/classes/wvmodel/setnetcdfoutputvariables.md
@@ -23,7 +23,6 @@ Set list of variables to be written to the NetCDF variable during the model run.
 
 ## Discussion
 
-
 Pass strings of WVTransform state variables of the
 same name. This must be called before using any of the
 integrate methods.

--- a/docs/developers-guide/continuous-integration.md
+++ b/docs/developers-guide/continuous-integration.md
@@ -33,6 +33,8 @@ buildtool test:optional
 
 The Optional job requests Optimization Toolbox. When MATLAB is available but the toolbox cannot be used, the job records an explicit skip in the workflow notice and summary. Setup, installation, licensing, or other infrastructure failures still fail the job. The extended checks provide deeper scheduled coverage but do not block ordinary pull-request merges.
 
+The public GitHub MATLAB license permits one MATLAB process at a time. The full suite therefore verifies the explicit license-unavailable result from the benchmark's nested fresh-process memory check on GitHub Actions. On hosts that can start a second MATLAB process, the same test requires a complete resident-memory measurement. Any other benchmark-worker failure remains a test failure.
+
 ## Package installation
 
 Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local checkout as the MPM repository and loads the exact dependency snapshots declared by the CI setup. The workflows do not modify the OceanKit checkout.

--- a/docs/developers-guide/continuous-integration.md
+++ b/docs/developers-guide/continuous-integration.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: Continuous integration
+parent: Developers guide
+nav_order: 3
+---
+
+# Continuous integration
+
+WaveVortexModel uses non-mutating continuous integration to check changes without modifying the package, publishing a release, or exporting an OceanKit snapshot. The workflows run on Ubuntu with MATLAB R2024b and install runtime dependencies from OceanKit commit `eb71bc7b05e74776afd678b27c964cf53cd9d547`. This fixed dependency snapshot makes a workflow rerun use the same OceanKit packages as the original run.
+
+## Required checks
+
+The required workflow runs for every pull request, every update to `main`, and manual dispatches. It reports three independent jobs:
+
+| GitHub check | Local equivalent |
+| --- | --- |
+| Smoke / MATLAB R2024b | `buildtool test:smoke` |
+| Documentation / MATLAB R2024b | `buildtool docs:check` |
+| Code Analyzer / MATLAB R2024b | `buildtool analyze` |
+
+The documentation job installs the authoring-only package `ClassDocumentation@1.3.0` explicitly before checking the committed site. Smoke tests, documentation verification, and Code Analyzer are required to merge into `main`. Branch protection requires the pull request branch to be current with `main` before those checks can satisfy the merge gate.
+
+## Extended checks
+
+The extended workflow runs every Monday at 09:00 UTC and may be started manually. Its Full, Exhaustive, and Optional jobs remain separate so a failure identifies the affected test category. Run the same checks locally with:
+
+```matlab
+buildtool test:full
+buildtool test:exhaustive
+buildtool test:optional
+```
+
+The Optional job requests Optimization Toolbox. When MATLAB is available but the toolbox cannot be used, the job records an explicit skip in the workflow notice and summary. Setup, installation, licensing, or other infrastructure failures still fail the job. The extended checks provide deeper scheduled coverage but do not block ordinary pull-request merges.
+
+## Package installation
+
+Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local OceanKit checkout as the MPM repository and installs WaveVortexModel in authoring mode. The workflows do not inspect or modify the OceanKit checkout beyond using it as the package source.
+
+The OceanKit commit is deliberately recorded in both workflow files and this page. Update all three locations together after compatibility with a newer dependency snapshot has been reviewed. Clean-install and exported-package testing are separate release gates and do not replace these authoring checks.
+
+## Clean checkout requirement
+
+Every job runs a final cleanliness check even when its MATLAB command fails. A successful job must leave:
+
+- No tracked modifications.
+- No untracked files.
+- No ignored NetCDF, MAT-file, autosave, profiling, or test-result artifacts.
+- No generated documentation drift.
+
+The check prints every unexpected path before failing. Tests that write files must therefore use managed temporary folders and close all file handles. Run `bash tools/checkCIWorkspaceCleanliness.sh` from a clean checkout to apply the same repository check locally.

--- a/docs/developers-guide/continuous-integration.md
+++ b/docs/developers-guide/continuous-integration.md
@@ -35,7 +35,9 @@ The Optional job requests Optimization Toolbox. When MATLAB is available but the
 
 ## Package installation
 
-Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local OceanKit checkout as the MPM repository and installs WaveVortexModel in authoring mode. The workflows do not inspect or modify the OceanKit checkout beyond using it as the package source.
+Each job checks out WaveVortexModel in an isolated `source` directory and the pinned OceanKit repository in a sibling `OceanKit` directory. MATLAB registers that local checkout as the MPM repository and loads the exact dependency snapshots declared by the CI setup. The workflows do not modify the OceanKit checkout.
+
+MATLAB R2024b cannot construct a package from the schema 1.1 manifest currently written by newer MATLAB releases. The non-mutating CI therefore configures the source and pinned dependency paths directly, preserving the same package boundaries without rewriting the manifest. The separate clean-install work tracked by Issue #77 owns the permanent MPM schema and installation gate.
 
 The OceanKit commit is deliberately recorded in both workflow files and this page. Update all three locations together after compatibility with a newer dependency snapshot has been reviewed. Clean-install and exported-package testing are separate release gates and do not replace these authoring checks.
 

--- a/tools/checkCIWorkspaceCleanliness.sh
+++ b/tools/checkCIWorkspaceCleanliness.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+failure=0
+
+if ! git diff --check; then
+    failure=1
+fi
+
+repository_status="$(git status --porcelain=v1 --untracked-files=all)"
+if [[ -n "${repository_status}" ]]; then
+    printf 'Unexpected tracked or untracked source paths:\n%s\n' "${repository_status}"
+    failure=1
+fi
+
+artifact_paths="$(find . -path './.git' -prune -o -type f \( \
+    -name '*.nc' -o \
+    -name '*.mat' -o \
+    -name '*.asv' -o \
+    -name '*.prof' -o \
+    -name '*.profile' -o \
+    -name 'junit*.xml' -o \
+    -name 'test-results*.xml' -o \
+    -path './Benchmarks/results/runs/*' -o \
+    -path '*/profile-results/*' -o \
+    -path '*/profiling-output/*' -o \
+    -path '*/test-results/*' -o \
+    -path '*/TestResults/*' \
+\) -print | sort)"
+
+if [[ -n "${artifact_paths}" ]]; then
+    printf 'Unexpected generated artifacts:\n%s\n' "${artifact_paths}"
+    failure=1
+fi
+
+if (( failure != 0 )); then
+    printf 'The source checkout is not clean.\n'
+    exit 1
+fi
+
+printf 'The source checkout is clean.\n'

--- a/tools/check_website_documentation.m
+++ b/tools/check_website_documentation.m
@@ -16,9 +16,22 @@ validateWebsiteDocumentation(stagingFolder);
 comparison = compareDocumentationTrees(fullfile(repositoryRoot,"docs"),stagingFolder);
 printComparison(comparison);
 if ~comparison.IsEqual
+    preserveDiagnostics(stagingFolder);
     error("WaveVortexModel:DocumentationOutOfDate","Committed documentation does not match a clean ClassDocumentation 1.3.0 build.");
 end
 clear stagingCleanup
+end
+
+function preserveDiagnostics(stagingFolder)
+diagnosticFolder = string(getenv("WVM_DOCUMENTATION_DIAGNOSTIC_FOLDER"));
+if diagnosticFolder == ""
+    return
+end
+if isfolder(diagnosticFolder)
+    error("WaveVortexModel:DocumentationDiagnosticExists","The documentation diagnostic folder already exists: %s",diagnosticFolder);
+end
+copyfile(stagingFolder,diagnosticFolder);
+fprintf("Generated documentation diagnostics preserved at %s\n",diagnosticFolder);
 end
 
 function printComparison(comparison)

--- a/tools/configureCIEnvironment.m
+++ b/tools/configureCIEnvironment.m
@@ -1,0 +1,58 @@
+function configureCIEnvironment(sourceRoot,oceanKitRoot,options)
+arguments
+    sourceRoot (1,1) string {mustBeFolder}
+    oceanKitRoot (1,1) string {mustBeFolder}
+    options.documentationPackageSpecifier (1,1) string {mustBeMember(options.documentationPackageSpecifier,["","ClassDocumentation@1.3.0"])} = ""
+end
+
+% MATLAB R2024b cannot read the schema 1.1 MPM manifests currently committed
+% by newer MATLAB releases. Issue #77 owns the clean MPM-install gate. Until
+% then, CI loads the exact package snapshots from the pinned OceanKit checkout
+% without modifying either repository.
+snapshotNames = [
+    "Distributions-2.0.0"
+    "SplineCore-2.2.0"
+    "chebfun-5.7.0"
+    "InternalModes-1.3.0"
+    "NetCDF-1.0.2"
+    "ClassAnnotations-1.2.1"
+    ];
+
+if options.documentationPackageSpecifier ~= ""
+    snapshotNames(end+1) = replace(options.documentationPackageSpecifier,"@","-");
+end
+
+for snapshotName = snapshotNames'
+    addPackageSnapshotToPath(fullfile(oceanKitRoot,snapshotName));
+end
+addPackageSnapshotToPath(sourceRoot);
+end
+
+function addPackageSnapshotToPath(packageRoot)
+manifestPath = fullfile(packageRoot,"resources","mpackage.json");
+if ~isfile(manifestPath)
+    error("WaveVortexModel:MissingCIPackageManifest","The CI package manifest is missing: %s",manifestPath);
+end
+
+manifest = jsondecode(fileread(manifestPath));
+packagePaths = strings(numel(manifest.folders)+1,1);
+nPackagePaths = 0;
+if isstruct(manifest.folders)
+    for iFolder = 1:numel(manifest.folders)
+        packageFolder = fullfile(packageRoot,string(manifest.folders(iFolder).path));
+        if isfolder(packageFolder)
+            nPackagePaths = nPackagePaths + 1;
+            packagePaths(nPackagePaths) = packageFolder;
+        end
+    end
+end
+nPackagePaths = nPackagePaths + 1;
+packagePaths(nPackagePaths) = packageRoot;
+packagePaths = packagePaths(1:nPackagePaths);
+warningState = warning("query","MATLAB:mpath:uninstalledPackagesOnPath");
+warningCleanup = onCleanup(@()warning(warningState));
+warning("off","MATLAB:mpath:uninstalledPackagesOnPath");
+addpath(strjoin(packagePaths,pathsep));
+clear warningCleanup
+fprintf("CI package: %s %s (%s)\n",string(manifest.name),string(manifest.version),packageRoot);
+end

--- a/tools/generateWebsiteDocumentation.m
+++ b/tools/generateWebsiteDocumentation.m
@@ -110,13 +110,11 @@ function normalizeReflectedDocumentation(documentation)
 classMetadata = meta.class.fromName(documentation.name);
 classDescription = ClassDocumentation.trimDeclarationFromString(classMetadata.DetailedDescription);
 classDescription = Topic.trimTopicsFromString(classDescription);
-documentation.detailedDescription = removeCommonIndent(classDescription);
+documentation.detailedDescription = regexprep(removeCommonIndent(classDescription),'(?:\r?\n){3,}','\n\n');
 
 for iMethod = 1:numel(documentation.allMethodDocumentation)
     methodDocumentation = documentation.allMethodDocumentation(iMethod);
-    if ~isempty(methodDocumentation.detailedDescription)
-        methodDocumentation.detailedDescription = removeCommonIndent(methodDocumentation.detailedDescription);
-    end
+    methodDocumentation.detailedDescription = normalizedReflectedDescription(classMetadata,methodDocumentation);
     if string(methodDocumentation.name) == documentation.name && ...
             ~isempty(methodDocumentation.detailedDescription) && ...
             isequal(strtrim(string(methodDocumentation.detailedDescription)),strtrim(string(documentation.detailedDescription)))
@@ -127,6 +125,56 @@ for iMethod = 1:numel(documentation.allMethodDocumentation)
         methodDocumentation.declaration = [];
     end
 end
+end
+
+function description = normalizedReflectedDescription(classMetadata,methodDocumentation)
+description = methodDocumentation.detailedDescription;
+if isempty(description)
+    return
+end
+methodMetadata = classMetadata.MethodList;
+for iMetadata = 1:numel(methodMetadata)
+    item = methodMetadata(iMetadata);
+    if string(item.Name) == string(methodDocumentation.name) && ...
+            string(item.DefiningClass.Name) == string(methodDocumentation.definingClassName)
+        normalizedMetadata = MethodDocumentation(methodDocumentation.name);
+        normalizedMetadata.addMetadataFromDetailedDescription(char(removeCommonIndent(item.DetailedDescription)));
+        if descriptionsDifferOnlyByIndent(description,normalizedMetadata.detailedDescription)
+            description = normalizedMetadata.detailedDescription;
+        else
+            description = removeCommonIndent(description);
+        end
+        return
+    end
+end
+propertyMetadata = classMetadata.PropertyList;
+for iMetadata = 1:numel(propertyMetadata)
+    item = propertyMetadata(iMetadata);
+    if string(item.Name) == string(methodDocumentation.name) && ...
+            string(item.DefiningClass.Name) == string(methodDocumentation.definingClassName)
+        normalizedMetadata = MethodDocumentation(methodDocumentation.name);
+        normalizedMetadata.addMetadataFromDetailedDescription(char(removeCommonIndent(item.DetailedDescription)));
+        if descriptionsDifferOnlyByIndent(description,normalizedMetadata.detailedDescription)
+            description = normalizedMetadata.detailedDescription;
+        else
+            description = removeCommonIndent(description);
+        end
+        return
+    end
+end
+description = removeCommonIndent(methodDocumentation.detailedDescription);
+end
+
+function tf = descriptionsDifferOnlyByIndent(first,second)
+if isempty(first) || isempty(second)
+    tf = false;
+    return
+end
+first = regexprep(char(first),'\r\n?','\n');
+second = regexprep(char(second),'\r\n?','\n');
+first = regexprep(first,'^[ \t]+','','lineanchors');
+second = regexprep(second,'^[ \t]+','','lineanchors');
+tf = strcmp(strtrim(first),strtrim(second));
 end
 
 function text = removeCommonIndent(text)

--- a/tools/generateWebsiteDocumentation.m
+++ b/tools/generateWebsiteDocumentation.m
@@ -110,20 +110,36 @@ function normalizeReflectedDocumentation(documentation)
 classMetadata = meta.class.fromName(documentation.name);
 classDescription = ClassDocumentation.trimDeclarationFromString(classMetadata.DetailedDescription);
 classDescription = Topic.trimTopicsFromString(classDescription);
-documentation.detailedDescription = regexprep(removeCommonIndent(classDescription),'(?:\r?\n){3,}','\n\n');
+documentation.detailedDescription = removeCommonIndent(classDescription);
 
 for iMethod = 1:numel(documentation.allMethodDocumentation)
     methodDocumentation = documentation.allMethodDocumentation(iMethod);
     methodDocumentation.detailedDescription = normalizedReflectedDescription(classMetadata,methodDocumentation);
     if string(methodDocumentation.name) == documentation.name && ...
             ~isempty(methodDocumentation.detailedDescription) && ...
-            isequal(strtrim(string(methodDocumentation.detailedDescription)),strtrim(string(documentation.detailedDescription)))
+            (constructorUsesClassHelp(classMetadata) || ...
+            isequal(strtrim(string(methodDocumentation.detailedDescription)),strtrim(string(documentation.detailedDescription))))
         % R2024b exposes the class help as constructor help when the
         % constructor has no help block. Newer releases leave it empty.
         methodDocumentation.shortDescription = [];
         methodDocumentation.detailedDescription = [];
         methodDocumentation.declaration = [];
     end
+end
+end
+
+function tf = constructorUsesClassHelp(classMetadata)
+tf = false;
+methodMetadata = classMetadata.MethodList;
+for iMetadata = 1:numel(methodMetadata)
+    item = methodMetadata(iMetadata);
+    if string(item.Name) ~= string(classMetadata.Name) || isempty(item.DetailedDescription)
+        continue
+    end
+    constructorHelp = regexprep(strtrim(char(item.DetailedDescription)),'\s+',' ');
+    classHelp = regexprep(strtrim(char(classMetadata.DetailedDescription)),'\s+',' ');
+    tf = strcmp(constructorHelp,classHelp);
+    return
 end
 end
 
@@ -236,6 +252,8 @@ for iPage = 1:numel(pages)
     pagePath = fullfile(pages(iPage).folder,pages(iPage).name);
     pageText = fileread(pagePath);
     pageText = regexprep(pageText,'[ \t]+(?=\r?\n|$)','');
+    pageText = regexprep(pageText,'(## Discussion)(?:\r?\n){3,}','$1\n\n');
+    pageText = regexprep(pageText,'(?:\r?\n){5,}(?=## Topics)','\n\n\n\n\n');
     pageText = regexprep(pageText,'(?:\r?\n)*$','\n');
     writeTextFile(pagePath,pageText);
 end

--- a/tools/generateWebsiteDocumentation.m
+++ b/tools/generateWebsiteDocumentation.m
@@ -110,7 +110,7 @@ function normalizeReflectedDocumentation(documentation)
 classMetadata = meta.class.fromName(documentation.name);
 classDescription = ClassDocumentation.trimDeclarationFromString(classMetadata.DetailedDescription);
 classDescription = Topic.trimTopicsFromString(classDescription);
-documentation.detailedDescription = removeCommonIndent(classDescription);
+documentation.detailedDescription = regexprep(removeCommonIndent(classDescription),'(?:\r?\n){3,}','\n\n');
 
 for iMethod = 1:numel(documentation.allMethodDocumentation)
     methodDocumentation = documentation.allMethodDocumentation(iMethod);

--- a/tools/generateWebsiteDocumentation.m
+++ b/tools/generateWebsiteDocumentation.m
@@ -110,7 +110,7 @@ function normalizeReflectedDocumentation(documentation)
 classMetadata = meta.class.fromName(documentation.name);
 classDescription = ClassDocumentation.trimDeclarationFromString(classMetadata.DetailedDescription);
 classDescription = Topic.trimTopicsFromString(classDescription);
-documentation.detailedDescription = regexprep(removeCommonIndent(classDescription),'(?:\r?\n){3,}','\n\n');
+documentation.detailedDescription = regexprep(removeCommonIndent(classDescription),'(?:\r?\n[ \t]*){3,}','\n\n');
 
 for iMethod = 1:numel(documentation.allMethodDocumentation)
     methodDocumentation = documentation.allMethodDocumentation(iMethod);

--- a/tools/generateWebsiteDocumentation.m
+++ b/tools/generateWebsiteDocumentation.m
@@ -96,10 +96,64 @@ if grandparent ~= ""
     options = [options {"grandparent",grandparent}];
 end
 documentation = ClassDocumentation(className,options{:});
+normalizeReflectedDocumentation(documentation);
 mergeCanonicalSidecars(documentation,sidecarFolders);
 applyDocumentationTaxonomy(documentation);
 documentation.writeToFile();
 normalizeGeneratedMarkdown(documentation.pathOfClassFolderOnHardDrive);
+end
+
+function normalizeReflectedDocumentation(documentation)
+% MATLAB releases expose help-text indentation differently through the
+% metaclass API. Normalize it before ClassDocumentation writes Markdown so
+% one source tree produces the same documentation on every supported release.
+classMetadata = meta.class.fromName(documentation.name);
+classDescription = ClassDocumentation.trimDeclarationFromString(classMetadata.DetailedDescription);
+classDescription = Topic.trimTopicsFromString(classDescription);
+documentation.detailedDescription = removeCommonIndent(classDescription);
+
+for iMethod = 1:numel(documentation.allMethodDocumentation)
+    methodDocumentation = documentation.allMethodDocumentation(iMethod);
+    if ~isempty(methodDocumentation.detailedDescription)
+        methodDocumentation.detailedDescription = removeCommonIndent(methodDocumentation.detailedDescription);
+    end
+    if string(methodDocumentation.name) == documentation.name && ...
+            ~isempty(methodDocumentation.detailedDescription) && ...
+            isequal(strtrim(string(methodDocumentation.detailedDescription)),strtrim(string(documentation.detailedDescription)))
+        % R2024b exposes the class help as constructor help when the
+        % constructor has no help block. Newer releases leave it empty.
+        methodDocumentation.shortDescription = [];
+        methodDocumentation.detailedDescription = [];
+        methodDocumentation.declaration = [];
+    end
+end
+end
+
+function text = removeCommonIndent(text)
+lines = splitlines(string(text));
+nonblankLines = strlength(strtrim(lines)) > 0;
+if ~any(nonblankLines)
+    text = join(lines,newline);
+    return
+end
+
+leadingWhitespace = zeros(sum(nonblankLines),1);
+nonblankIndices = find(nonblankLines);
+for iLine = 1:numel(nonblankIndices)
+    line = char(lines(nonblankIndices(iLine)));
+    match = regexp(line,'^[ \t]*','match','once');
+    leadingWhitespace(iLine) = strlength(string(match));
+end
+commonIndent = min(leadingWhitespace);
+if commonIndent > 0
+    for iLine = 1:numel(lines)
+        line = char(lines(iLine));
+        if length(line) >= commonIndent
+            lines(iLine) = string(line(commonIndent+1:end));
+        end
+    end
+end
+text = join(lines,newline);
 end
 
 function mergeCanonicalSidecars(documentation,sidecarFolders)


### PR DESCRIPTION
## Summary

- add required smoke, documentation, and Code Analyzer jobs on MATLAB R2024b
- add independently visible weekly/manual full, exhaustive, and optional jobs
- pin OceanKit dependencies, enforce clean read-only checkouts, and document the CI contract

## Verification

- workflow YAML and shell syntax checks
- documentation build and two deterministic documentation checks
- smoke: 127 passed
- full: 602 passed, repeated twice
- exhaustive: 2440 passed
- optional: 1 passed with Optimization Toolbox
- Code Analyzer: 171 files, zero blockers
- intentional stale-documentation and generated-artifact failure checks

The pull request workflows provide the authoritative MATLAB R2024b validation.

Closes #76
