### PR TITLE
Add layout-neutral Fourier spectrum storage

### DIFF
--- a/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
+++ b/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
@@ -100,21 +100,6 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
         % - Topic: Domain attributes — WV grid
         dftConjugateIndices2D uint64
 
-        % index into the DFT grid of each WV mode
-        %
-        % - Topic: Domain attributes — WV grid      
-        dftPrimaryIndex uint64
-    
-        % index into the DFT grid of the conjugate of each WV mode
-        %
-        % - Topic: Domain attributes — WV grid
-        dftConjugateIndex uint64
-
-        % index into the WV mode that matches the dftConjugateIndices
-        %
-        % - Topic: Domain attributes — WV grid
-        wvConjugateIndex uint64
-
         % k-wavenumber dimension on the WV grid
         %
         % - Topic: Domain attributes — WV grid
@@ -136,9 +121,30 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
         %
         % - Topic: Domain attributes — Spatial grid
         Nz
+        legacyDftPrimaryIndex uint64 = uint64.empty(0,1)
+        legacyDftConjugateIndex uint64 = uint64.empty(0,1)
+        legacyWvConjugateIndex uint64 = uint64.empty(0,1)
+        legacyMappingsAreMaterialized (1,1) logical = false
     end
 
     properties (Dependent, SetAccess=private)
+        % legacy vertically replicated index into the active Fourier storage
+        %
+        % Materialized lazily for compatibility. Production transforms use
+        % WVFourierSpectrumLayout two-dimensional mappings instead.
+        %
+        % - Topic: Domain attributes — WV grid
+        dftPrimaryIndex uint64
+
+        % legacy vertically replicated conjugate index
+        %
+        % - Topic: Domain attributes — WV grid
+        dftConjugateIndex uint64
+
+        % legacy vertically replicated WV conjugate index
+        %
+        % - Topic: Domain attributes — WV grid
+        wvConjugateIndex uint64
         
         % x-dimension
         %
@@ -322,7 +328,6 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
                 self.k = K(self.dftPrimaryIndices2D);
                 self.l = L(self.dftPrimaryIndices2D);
 
-                [self.dftPrimaryIndex, self.dftConjugateIndex, self.wvConjugateIndex] = self.indicesFromWVGridToFFTWGrid(self.Nz,isHalfComplex=1);
                 self.fastTransform = WVFastTransformDoublyPeriodicFFTW(self,self.Nz);
             else
                 self.dftConjugateIndices2D = WVGeometryDoublyPeriodic.indicesOfFourierConjugates(self.Nx,self.Ny);
@@ -330,7 +335,6 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
                 self.k = K(self.dftPrimaryIndices2D);
                 self.l = L(self.dftPrimaryIndices2D);
 
-                [self.dftPrimaryIndex, self.dftConjugateIndex, self.wvConjugateIndex] = self.indicesFromWVGridToDFTGrid(self.Nz,isHalfComplex=1);
                 self.fastTransform = WVFastTransformDoublyPeriodicMatlab(self,self.Nz);
             end
 
@@ -347,6 +351,21 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % 
             dx = self.Lx/self.Nx;
             x = dx*(0:self.Nx-1)';
+        end
+
+        function value = get.dftPrimaryIndex(self)
+            self.materializeLegacyMappings();
+            value = self.legacyDftPrimaryIndex;
+        end
+
+        function value = get.dftConjugateIndex(self)
+            self.materializeLegacyMappings();
+            value = self.legacyDftConjugateIndex;
+        end
+
+        function value = get.wvConjugateIndex(self)
+            self.materializeLegacyMappings();
+            value = self.legacyWvConjugateIndex;
         end
 
         function y = get.y(self)
@@ -992,6 +1011,24 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
 
         [varargout] = transformToKLAxes(self,varargin);
         [varargout] = transformToRadialWavenumber(self,varargin);
+    end
+
+    methods (Access=private)
+        function materializeLegacyMappings(self)
+            if self.legacyMappingsAreMaterialized
+                return
+            end
+            [self.legacyDftPrimaryIndex,self.legacyDftConjugateIndex,self.legacyWvConjugateIndex] = self.fastTransform.fourierSpectrumLayout.expandedLegacyMappings(self.Nz);
+            self.legacyMappingsAreMaterialized = true;
+        end
+    end
+
+    methods (Hidden)
+        function diagnostics = fourierSpectrumLayoutDiagnostics(self)
+            layout = self.fastTransform.fourierSpectrumLayout;
+            legacyMappingBytes = 8*(numel(self.legacyDftPrimaryIndex)+numel(self.legacyDftConjugateIndex)+numel(self.legacyWvConjugateIndex));
+            diagnostics = struct("storageType",layout.storageType,"compressedDimension",layout.compressedDimension,"storageShape",layout.storageShape,"mappingStrategy",layout.mappingStrategy,"mappingBytes",layout.mappingBytes,"mappingLedger",layout.mappingLedger(),"legacyMappingsAreMaterialized",self.legacyMappingsAreMaterialized,"legacyMappingBytes",legacyMappingBytes);
+        end
     end
 
     methods (Static)

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -35,4 +35,12 @@ results = runWaveVortexBenchmark(suites="transform-layout-v1")
 
 It measures extraction, primary insertion, conjugate insertion, combined insertion, and complete horizontal forward/inverse calls. Each strategy owns and reuses a persistent full-complex buffer. Array setup and mapping construction are excluded, while indexing, allocation, conjugation, reshape, transpose, and MATLAB copy-on-write behavior inherent to each expression remain timed. The strict winner has the smallest median; the production `wv-sorted-linear` strategy remains preferred when it is within 3% of that median. MATLAB pointer and copy state is reported as unavailable because no supported API exposes it for these expressions. Whole-process memory comparisons remain separate from this suite.
 
+Issue #70 moved the builtin adapter to an internal row-oriented spectrum layout. Its integration gate compares the production adapter—not a stand-alone approximation—with the immutable issue #69 medians:
+
+```matlab
+results = runWVFourierSpectrumLayoutIntegrationBenchmark
+```
+
+The 3% regression threshold applies only to `[256 256 65]` and `[512 512 129]`, with antialiasing both disabled and enabled. Smaller cases remain descriptive because the row layout was selected as the single production representation even where MATLAB timing noise or fixed overhead can make a legacy expression faster. The integration artifact also confirms that the vertically replicated compatibility indices remain unallocated until a caller explicitly requests them.
+
 `WVTransformConstantStratificationSpeedTest`, `ProfileableSpeedTest`, and `ForcingSpectralMaskPerformanceTest` remain historical investigation scripts. Deterministic correctness checks belong in `UnitTests`; mixed scientific investigations belong in `DeveloperExperiments`.

--- a/Benchmarks/results/reference/transform-layout-integration-v1-m5-max-r2026a-builtin/benchmark.json
+++ b/Benchmarks/results/reference/transform-layout-integration-v1-m5-max-r2026a-builtin/benchmark.json
@@ -1,0 +1,1700 @@
+{
+  "schemaVersion": "1.0.0",
+  "status": "complete",
+  "runId": "transform-layout-integration-v1-m5-max-r2026a-builtin",
+  "environment": {
+    "matlabVersion": "26.1.0.3312084 (R2026a) Update 4",
+    "matlabRelease": "2026a",
+    "architecture": "maca64",
+    "os": "Darwin 25.5.0 Darwin Kernel Version 25.5.0: Tue Jun  9 22:28:34 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T6050 arm64",
+    "sourceCommit": "aeb158b7cdec79b686e9b997e5fb85c848e38278",
+    "sourceTree": "9667e8c9afb5b9f25e54568adfb7930700c6ca8e"
+  },
+  "configuration": {
+    "caseIds": [],
+    "correctnessTolerance": 1E-12,
+    "gateTolerance": 0.03,
+    "gateSizes": [
+      [
+        256,
+        256,
+        65
+      ],
+      [
+        512,
+        512,
+        129
+      ]
+    ]
+  },
+  "reference": {
+    "issue": 69,
+    "path": "Benchmarks/results/reference/transform-layout-v1-m5-max-r2026a-builtin/benchmark.json",
+    "sha256": "d07b40c6209e8b557b7f7cea63f9f5cdbd893a028888cc7e7e1b3f2cbeeaa7ec",
+    "strategy": "wv-sorted-linear"
+  },
+  "operationIds": [
+    "extract",
+    "insert-primary",
+    "insert-conjugate",
+    "insert-complete",
+    "forward-complete",
+    "inverse-complete"
+  ],
+  "cases": [
+    {
+      "id": "full-layout-64x48x17-antialias-0",
+      "Nxyz": [
+        64,
+        48,
+        17
+      ],
+      "shouldAntialias": false,
+      "seed": 6901,
+      "warmupCount": 2,
+      "sampleCount": 7,
+      "isGate": false,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        64,
+        48
+      ],
+      "mappingBytes": 24440,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 835584,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ],
+        [
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate"
+        ],
+        [
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete"
+        ],
+        [
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete"
+        ],
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            0.00032858333333333334,
+            0.000146,
+            0.0001465,
+            0.00017141666666666667,
+            0.000132125,
+            0.00034404166666666665,
+            0.00011633333333333333
+          ],
+          "medianSeconds": 0.0001465,
+          "referenceMedianSeconds": 8.004166666666667E-5,
+          "relativeToReference": 1.8302967204580949,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            9.5083333333333332E-5,
+            8.8166666666666664E-5,
+            9.5166666666666671E-5,
+            0.00010275,
+            0.000134625,
+            7.7166666666666668E-5,
+            7.2541666666666664E-5
+          ],
+          "medianSeconds": 9.5083333333333332E-5,
+          "referenceMedianSeconds": 0.00013820833333333334,
+          "relativeToReference": 0.687971058185107,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            5.6541666666666668E-5,
+            5.2375E-5,
+            5.9375E-5,
+            5.2958333333333331E-5,
+            5.5958333333333336E-5,
+            5.7541666666666665E-5,
+            5.225E-5
+          ],
+          "medianSeconds": 5.5958333333333336E-5,
+          "referenceMedianSeconds": 5.05E-5,
+          "relativeToReference": 1.108085808580858,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            0.00015183333333333333,
+            0.00012241666666666667,
+            0.00014045833333333334,
+            0.00016966666666666668,
+            0.00011320833333333334,
+            0.00023429166666666667,
+            0.00011716666666666666
+          ],
+          "medianSeconds": 0.00014045833333333334,
+          "referenceMedianSeconds": 0.00015558333333333334,
+          "relativeToReference": 0.902785216925549,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.00034979166666666665,
+            0.00032508333333333331,
+            0.000340375,
+            0.00039258333333333333,
+            0.00034966666666666669,
+            0.00035016666666666665,
+            0.000372
+          ],
+          "medianSeconds": 0.00034979166666666665,
+          "referenceMedianSeconds": 0.00025279166666666668,
+          "relativeToReference": 1.3837151804845886,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.00050341666666666666,
+            0.00045104166666666665,
+            0.00051308333333333338,
+            0.00045095833333333332,
+            0.00055141666666666663,
+            0.00056375,
+            0.00042845833333333332
+          ],
+          "medianSeconds": 0.00050341666666666666,
+          "referenceMedianSeconds": 0.00041629166666666664,
+          "relativeToReference": 1.2092883595235713,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        }
+      ]
+    },
+    {
+      "id": "full-layout-64x48x17-antialias-1",
+      "Nxyz": [
+        64,
+        48,
+        17
+      ],
+      "shouldAntialias": true,
+      "seed": 6902,
+      "warmupCount": 2,
+      "sampleCount": 7,
+      "isGate": false,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        64,
+        48
+      ],
+      "mappingBytes": 11976,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 835584,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ],
+        [
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate"
+        ],
+        [
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete"
+        ],
+        [
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete"
+        ],
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            0.00011391666666666667,
+            0.00025275,
+            0.00013008333333333334,
+            0.00011929166666666666,
+            0.00014995833333333332,
+            0.000145125,
+            0.00014891666666666666
+          ],
+          "medianSeconds": 0.000145125,
+          "referenceMedianSeconds": 3.3916666666666667E-5,
+          "relativeToReference": 4.2788697788697787,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            0.00012904166666666665,
+            7.6958333333333338E-5,
+            5.9625E-5,
+            5.7541666666666665E-5,
+            5.3541666666666669E-5,
+            6.1875E-5,
+            5.2875E-5
+          ],
+          "medianSeconds": 5.9625E-5,
+          "referenceMedianSeconds": 8.0958333333333327E-5,
+          "relativeToReference": 0.73648996397323729,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            7.0625E-5,
+            6.0125E-5,
+            6.7833333333333333E-5,
+            4.854166666666667E-5,
+            6.4166666666666663E-5,
+            5.5416666666666667E-5,
+            4.325E-5
+          ],
+          "medianSeconds": 6.0125E-5,
+          "referenceMedianSeconds": 1.125E-5,
+          "relativeToReference": 5.3444444444444441,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            9.7625E-5,
+            0.00010470833333333334,
+            0.00010433333333333334,
+            0.00010266666666666666,
+            9.9625E-5,
+            9.0291666666666661E-5,
+            8.375E-5
+          ],
+          "medianSeconds": 9.9625E-5,
+          "referenceMedianSeconds": 8.0541666666666668E-5,
+          "relativeToReference": 1.2369374030005174,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.00030583333333333336,
+            0.000336375,
+            0.00035516666666666666,
+            0.00041404166666666667,
+            0.00030654166666666666,
+            0.000361625,
+            0.00030129166666666667
+          ],
+          "medianSeconds": 0.000336375,
+          "referenceMedianSeconds": 0.00018979166666666667,
+          "relativeToReference": 1.7723380900109769,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.00039925,
+            0.00043720833333333334,
+            0.00043316666666666666,
+            0.00040975,
+            0.00046341666666666666,
+            0.00050054166666666671,
+            0.0003925
+          ],
+          "medianSeconds": 0.00043316666666666666,
+          "referenceMedianSeconds": 0.000296375,
+          "relativeToReference": 1.4615492759735695,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        }
+      ]
+    },
+    {
+      "id": "full-layout-65x63x17-antialias-0",
+      "Nxyz": [
+        65,
+        63,
+        17
+      ],
+      "shouldAntialias": false,
+      "seed": 6903,
+      "warmupCount": 2,
+      "sampleCount": 7,
+      "isGate": false,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        65,
+        63
+      ],
+      "mappingBytes": 33536,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 1.11384E+6,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ],
+        [
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate"
+        ],
+        [
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete"
+        ],
+        [
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete"
+        ],
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            0.00013266666666666667,
+            0.00047320833333333335,
+            0.0002345,
+            0.00017354166666666668,
+            0.00023508333333333335,
+            9.6541666666666664E-5,
+            8.0416666666666665E-5
+          ],
+          "medianSeconds": 0.00017354166666666668,
+          "referenceMedianSeconds": 9.8291666666666666E-5,
+          "relativeToReference": 1.765578635014837,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            0.00017733333333333333,
+            9.7041666666666663E-5,
+            0.00014741666666666665,
+            9.9583333333333333E-5,
+            0.00013825,
+            0.00014033333333333332,
+            8.1291666666666673E-5
+          ],
+          "medianSeconds": 0.00013825,
+          "referenceMedianSeconds": 4.8166666666666667E-5,
+          "relativeToReference": 2.8702422145328721,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            4.8875E-5,
+            4.9041666666666668E-5,
+            5.5291666666666664E-5,
+            5.4E-5,
+            5.3333333333333333E-5,
+            4.9625E-5,
+            4.5541666666666665E-5
+          ],
+          "medianSeconds": 4.9625E-5,
+          "referenceMedianSeconds": 9.7916666666666664E-6,
+          "relativeToReference": 5.0680851063829788,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            0.00011175,
+            0.00015595833333333333,
+            0.00012345833333333333,
+            0.0001535,
+            0.00015258333333333335,
+            0.000127875,
+            0.00010870833333333334
+          ],
+          "medianSeconds": 0.000127875,
+          "referenceMedianSeconds": 5.4083333333333331E-5,
+          "relativeToReference": 2.3644067796610173,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.0004295,
+            0.00037716666666666665,
+            0.000406,
+            0.00053083333333333335,
+            0.00039233333333333335,
+            0.00032579166666666667,
+            0.00028604166666666665
+          ],
+          "medianSeconds": 0.00039233333333333335,
+          "referenceMedianSeconds": 0.0002465,
+          "relativeToReference": 1.5916159567275188,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.00043275,
+            0.00044633333333333336,
+            0.00051741666666666668,
+            0.00059158333333333328,
+            0.00052983333333333333,
+            0.0005435,
+            0.00047704166666666668
+          ],
+          "medianSeconds": 0.00051741666666666668,
+          "referenceMedianSeconds": 0.00026691666666666666,
+          "relativeToReference": 1.9384951607867624,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        }
+      ]
+    },
+    {
+      "id": "full-layout-65x63x17-antialias-1",
+      "Nxyz": [
+        65,
+        63,
+        17
+      ],
+      "shouldAntialias": true,
+      "seed": 6904,
+      "warmupCount": 2,
+      "sampleCount": 7,
+      "isGate": false,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        65,
+        63
+      ],
+      "mappingBytes": 11976,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 1.11384E+6,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ],
+        [
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate"
+        ],
+        [
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete"
+        ],
+        [
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete"
+        ],
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            4.4958333333333333E-5,
+            4.9208333333333335E-5,
+            4.9291666666666668E-5,
+            4.2583333333333336E-5,
+            8.0875E-5,
+            4.3958333333333336E-5,
+            4.1E-5
+          ],
+          "medianSeconds": 4.4958333333333333E-5,
+          "referenceMedianSeconds": 2.0958333333333332E-5,
+          "relativeToReference": 2.1451292246520874,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            5.075E-5,
+            0.000114,
+            0.000120875,
+            8.5083333333333332E-5,
+            7.45E-5,
+            4.9916666666666669E-5,
+            7.3083333333333339E-5
+          ],
+          "medianSeconds": 7.45E-5,
+          "referenceMedianSeconds": 2.0625E-5,
+          "relativeToReference": 3.6121212121212118,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            3.8208333333333331E-5,
+            4.1208333333333337E-5,
+            4.3958333333333336E-5,
+            3.725E-5,
+            3.6E-5,
+            4.1708333333333335E-5,
+            3.8666666666666667E-5
+          ],
+          "medianSeconds": 3.8666666666666667E-5,
+          "referenceMedianSeconds": 7.7083333333333338E-6,
+          "relativeToReference": 5.0162162162162156,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            0.000116625,
+            8.1791666666666672E-5,
+            7.6791666666666672E-5,
+            8.945833333333333E-5,
+            7.2208333333333331E-5,
+            0.00013295833333333334,
+            7.495833333333333E-5
+          ],
+          "medianSeconds": 8.1791666666666672E-5,
+          "referenceMedianSeconds": 2.3833333333333334E-5,
+          "relativeToReference": 3.4318181818181817,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.00025908333333333333,
+            0.000275375,
+            0.00031075,
+            0.00025070833333333336,
+            0.00024804166666666665,
+            0.00025141666666666666,
+            0.000295125
+          ],
+          "medianSeconds": 0.00025908333333333333,
+          "referenceMedianSeconds": 0.00022025,
+          "relativeToReference": 1.17631479379493,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.00044741666666666665,
+            0.00043670833333333333,
+            0.00038416666666666666,
+            0.00047779166666666667,
+            0.00046229166666666668,
+            0.000446875,
+            0.000355375
+          ],
+          "medianSeconds": 0.000446875,
+          "referenceMedianSeconds": 0.00024958333333333332,
+          "relativeToReference": 1.790484140233723,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": false,
+          "performancePassed": true
+        }
+      ]
+    },
+    {
+      "id": "full-layout-256x256x65-antialias-0",
+      "Nxyz": [
+        256,
+        256,
+        65
+      ],
+      "shouldAntialias": false,
+      "seed": 6905,
+      "warmupCount": 2,
+      "sampleCount": 7,
+      "isGate": true,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        256,
+        256
+      ],
+      "mappingBytes": 523256,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 6.815744E+7,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ],
+        [
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate"
+        ],
+        [
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete"
+        ],
+        [
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete"
+        ],
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            0.0027723333333333332,
+            0.0027570833333333332,
+            0.0027297083333333331,
+            0.0027839583333333332,
+            0.0028119166666666666,
+            0.0027771666666666665,
+            0.002894
+          ],
+          "medianSeconds": 0.0027771666666666665,
+          "referenceMedianSeconds": 0.005341875,
+          "relativeToReference": 0.51988611988611988,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            0.0024710833333333334,
+            0.0024615,
+            0.002477375,
+            0.00246275,
+            0.0024562916666666665,
+            0.0025320416666666668,
+            0.0034477083333333334
+          ],
+          "medianSeconds": 0.0024710833333333334,
+          "referenceMedianSeconds": 0.013715875,
+          "relativeToReference": 0.18016228154115821,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            0.00012529166666666667,
+            0.00012420833333333332,
+            0.00013716666666666668,
+            0.00011895833333333333,
+            0.000119625,
+            0.00012254166666666666,
+            0.0003035
+          ],
+          "medianSeconds": 0.00012420833333333332,
+          "referenceMedianSeconds": 0.00012479166666666666,
+          "relativeToReference": 0.99532554257095152,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            0.0025274166666666665,
+            0.0025014166666666665,
+            0.0025418333333333334,
+            0.0025428333333333331,
+            0.0025464583333333333,
+            0.0024890833333333332,
+            0.0031855
+          ],
+          "medianSeconds": 0.0025418333333333334,
+          "referenceMedianSeconds": 0.013962458333333334,
+          "relativeToReference": 0.18204769336822849,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.004699,
+            0.0045354583333333332,
+            0.004569083333333333,
+            0.0047977916666666664,
+            0.0045652083333333334,
+            0.0045944583333333332,
+            0.0058179166666666665
+          ],
+          "medianSeconds": 0.0045944583333333332,
+          "referenceMedianSeconds": 0.00777425,
+          "relativeToReference": 0.59098412494238461,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.004765125,
+            0.0046392083333333337,
+            0.0046961666666666671,
+            0.004701,
+            0.0051000833333333332,
+            0.0046377916666666668,
+            0.0062820833333333331
+          ],
+          "medianSeconds": 0.004701,
+          "referenceMedianSeconds": 0.016834833333333334,
+          "relativeToReference": 0.27924244374263679,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        }
+      ]
+    },
+    {
+      "id": "full-layout-256x256x65-antialias-1",
+      "Nxyz": [
+        256,
+        256,
+        65
+      ],
+      "shouldAntialias": true,
+      "seed": 6906,
+      "warmupCount": 2,
+      "sampleCount": 7,
+      "isGate": true,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        256,
+        256
+      ],
+      "mappingBytes": 185064,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 6.815744E+7,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ],
+        [
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate"
+        ],
+        [
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete"
+        ],
+        [
+          "inverse-complete",
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete"
+        ],
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            0.00081945833333333328,
+            0.0010228333333333333,
+            0.00100275,
+            0.00098675,
+            0.0010659166666666666,
+            0.0010194583333333334,
+            0.0010550416666666666
+          ],
+          "medianSeconds": 0.0010194583333333334,
+          "referenceMedianSeconds": 0.0031182083333333335,
+          "relativeToReference": 0.32693721020350897,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            0.00103725,
+            0.000955625,
+            0.00098754166666666673,
+            0.00094254166666666661,
+            0.00097575,
+            0.00093620833333333338,
+            0.00094166666666666672
+          ],
+          "medianSeconds": 0.000955625,
+          "referenceMedianSeconds": 0.0042735833333333332,
+          "relativeToReference": 0.22361211317590624,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            6.8375E-5,
+            4.2208333333333334E-5,
+            4.7625E-5,
+            4.2625E-5,
+            4.525E-5,
+            3.9166666666666665E-5,
+            4.2958333333333332E-5
+          ],
+          "medianSeconds": 4.2958333333333332E-5,
+          "referenceMedianSeconds": 7.7333333333333334E-5,
+          "relativeToReference": 0.55549568965517238,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            0.00089566666666666668,
+            0.000804375,
+            0.00096370833333333334,
+            0.00081408333333333333,
+            0.0007626666666666667,
+            0.00076716666666666665,
+            0.000770375
+          ],
+          "medianSeconds": 0.000804375,
+          "referenceMedianSeconds": 0.0044815416666666667,
+          "relativeToReference": 0.17948622590812313,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.003642625,
+            0.0036327083333333333,
+            0.0035362083333333335,
+            0.0035457916666666667,
+            0.0037059583333333332,
+            0.0035720833333333334,
+            0.0035156666666666665
+          ],
+          "medianSeconds": 0.0035720833333333334,
+          "referenceMedianSeconds": 0.0038003333333333335,
+          "relativeToReference": 0.93993947899307073,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.0033745,
+            0.00313125,
+            0.0030432083333333335,
+            0.0030977916666666667,
+            0.0031036666666666665,
+            0.00294825,
+            0.0030714583333333332
+          ],
+          "medianSeconds": 0.0030977916666666667,
+          "referenceMedianSeconds": 0.0066432083333333334,
+          "relativeToReference": 0.46630957682344748,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        }
+      ]
+    },
+    {
+      "id": "full-layout-512x512x129-antialias-0",
+      "Nxyz": [
+        512,
+        512,
+        129
+      ],
+      "shouldAntialias": false,
+      "seed": 6907,
+      "warmupCount": 2,
+      "sampleCount": 3,
+      "isGate": true,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        512,
+        512
+      ],
+      "mappingBytes": 2.095096E+6,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 5.41065216E+8,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            0.02468125,
+            0.02496025,
+            0.024882916666666668
+          ],
+          "medianSeconds": 0.024882916666666668,
+          "referenceMedianSeconds": 0.088622708333333328,
+          "relativeToReference": 0.28077359781282546,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            0.0202465,
+            0.021250416666666667,
+            0.020467833333333334
+          ],
+          "medianSeconds": 0.020467833333333334,
+          "referenceMedianSeconds": 0.0761265,
+          "relativeToReference": 0.26886607598317713,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            0.0002,
+            0.00028108333333333333,
+            0.00022454166666666667
+          ],
+          "medianSeconds": 0.00022454166666666667,
+          "referenceMedianSeconds": 0.00031629166666666665,
+          "relativeToReference": 0.709919641680938,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            0.021498041666666665,
+            0.02171425,
+            0.020844083333333333
+          ],
+          "medianSeconds": 0.021498041666666665,
+          "referenceMedianSeconds": 0.076521291666666671,
+          "relativeToReference": 0.28094196005360161,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.048578125,
+            0.047576958333333336,
+            0.047661666666666665
+          ],
+          "medianSeconds": 0.047661666666666665,
+          "referenceMedianSeconds": 0.095419041666666662,
+          "relativeToReference": 0.49949848409886743,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.038732875,
+            0.039557666666666665,
+            0.038293083333333332
+          ],
+          "medianSeconds": 0.038732875,
+          "referenceMedianSeconds": 0.095180458333333329,
+          "relativeToReference": 0.40694146338687348,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        }
+      ]
+    },
+    {
+      "id": "full-layout-512x512x129-antialias-1",
+      "Nxyz": [
+        512,
+        512,
+        129
+      ],
+      "shouldAntialias": true,
+      "seed": 6908,
+      "warmupCount": 2,
+      "sampleCount": 3,
+      "isGate": true,
+      "status": "complete",
+      "failure": {
+        "identifier": "",
+        "message": "",
+        "stack": []
+      },
+      "mappingStrategy": "two-dimensional-rows",
+      "storageShape": [
+        512,
+        512
+      ],
+      "mappingBytes": 736320,
+      "legacyMappingsAreMaterialized": false,
+      "legacyMappingBytes": 0,
+      "persistentBufferBytes": 5.41065216E+8,
+      "warmupSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ]
+      ],
+      "sampleSchedules": [
+        [
+          "extract",
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete"
+        ],
+        [
+          "insert-primary",
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract"
+        ],
+        [
+          "insert-conjugate",
+          "insert-complete",
+          "forward-complete",
+          "inverse-complete",
+          "extract",
+          "insert-primary"
+        ]
+      ],
+      "operations": [
+        {
+          "id": "extract",
+          "rawSeconds": [
+            0.00879225,
+            0.0089057083333333332,
+            0.00886475
+          ],
+          "medianSeconds": 0.00886475,
+          "referenceMedianSeconds": 0.029760625,
+          "relativeToReference": 0.2978684083415587,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-primary",
+          "rawSeconds": [
+            0.008013208333333334,
+            0.0081609583333333326,
+            0.007813875
+          ],
+          "medianSeconds": 0.008013208333333334,
+          "referenceMedianSeconds": 0.026782458333333332,
+          "relativeToReference": 0.29919614673161388,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-conjugate",
+          "rawSeconds": [
+            0.00018,
+            0.00018658333333333333,
+            0.00021875
+          ],
+          "medianSeconds": 0.00018658333333333333,
+          "referenceMedianSeconds": 0.00022704166666666668,
+          "relativeToReference": 0.82180216553496055,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "insert-complete",
+          "rawSeconds": [
+            0.0081153333333333338,
+            0.0080756666666666668,
+            0.007938
+          ],
+          "medianSeconds": 0.0080756666666666668,
+          "referenceMedianSeconds": 0.027066166666666665,
+          "relativeToReference": 0.29836758068190916,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "forward-complete",
+          "rawSeconds": [
+            0.031146916666666667,
+            0.031209083333333332,
+            0.031397916666666664
+          ],
+          "medianSeconds": 0.031209083333333332,
+          "referenceMedianSeconds": 0.052373958333333331,
+          "relativeToReference": 0.595889337496768,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        },
+        {
+          "id": "inverse-complete",
+          "rawSeconds": [
+            0.025809125,
+            0.025314333333333335,
+            0.025484875
+          ],
+          "medianSeconds": 0.025484875,
+          "referenceMedianSeconds": 0.046071041666666666,
+          "relativeToReference": 0.55316472295955976,
+          "relativeError": 0,
+          "correctnessPassed": true,
+          "performanceGateApplies": true,
+          "performancePassed": true
+        }
+      ]
+    }
+  ],
+  "readiness": {
+    "passed": true,
+    "completeGateSet": true,
+    "gateCaseCount": 4,
+    "failedCriteria": []
+  }
+}

--- a/Benchmarks/results/reference/transform-layout-integration-v1-m5-max-r2026a-builtin/summary.md
+++ b/Benchmarks/results/reference/transform-layout-integration-v1-m5-max-r2026a-builtin/summary.md
@@ -1,0 +1,72 @@
+# Fourier spectrum layout integration
+
+- Status: `complete`
+- Gate passed: `true`
+- Reference: WaveVortex issue #69 (`wv-sorted-linear`)
+- Gate: no operation above `1.03x` the frozen median on the 256 and 512 workloads
+
+## Timing and frozen-baseline comparison
+
+| Case | Antialias | Gate | Operation | Production (ms) | Issue #69 (ms) | Relative | Error | Pass |
+|---|---:|---|---|---:|---:|---:|---:|---|
+| full-layout-64x48x17-antialias-0 | 0 | no | extract | 0.147 | 0.080 | 1.830 | 0 | yes |
+| full-layout-64x48x17-antialias-0 | 0 | no | insert-primary | 0.095 | 0.138 | 0.688 | 0 | yes |
+| full-layout-64x48x17-antialias-0 | 0 | no | insert-conjugate | 0.056 | 0.051 | 1.108 | 0 | yes |
+| full-layout-64x48x17-antialias-0 | 0 | no | insert-complete | 0.140 | 0.156 | 0.903 | 0 | yes |
+| full-layout-64x48x17-antialias-0 | 0 | no | forward-complete | 0.350 | 0.253 | 1.384 | 0 | yes |
+| full-layout-64x48x17-antialias-0 | 0 | no | inverse-complete | 0.503 | 0.416 | 1.209 | 0 | yes |
+| full-layout-64x48x17-antialias-1 | 1 | no | extract | 0.145 | 0.034 | 4.279 | 0 | yes |
+| full-layout-64x48x17-antialias-1 | 1 | no | insert-primary | 0.060 | 0.081 | 0.736 | 0 | yes |
+| full-layout-64x48x17-antialias-1 | 1 | no | insert-conjugate | 0.060 | 0.011 | 5.344 | 0 | yes |
+| full-layout-64x48x17-antialias-1 | 1 | no | insert-complete | 0.100 | 0.081 | 1.237 | 0 | yes |
+| full-layout-64x48x17-antialias-1 | 1 | no | forward-complete | 0.336 | 0.190 | 1.772 | 0 | yes |
+| full-layout-64x48x17-antialias-1 | 1 | no | inverse-complete | 0.433 | 0.296 | 1.462 | 0 | yes |
+| full-layout-65x63x17-antialias-0 | 0 | no | extract | 0.174 | 0.098 | 1.766 | 0 | yes |
+| full-layout-65x63x17-antialias-0 | 0 | no | insert-primary | 0.138 | 0.048 | 2.870 | 0 | yes |
+| full-layout-65x63x17-antialias-0 | 0 | no | insert-conjugate | 0.050 | 0.010 | 5.068 | 0 | yes |
+| full-layout-65x63x17-antialias-0 | 0 | no | insert-complete | 0.128 | 0.054 | 2.364 | 0 | yes |
+| full-layout-65x63x17-antialias-0 | 0 | no | forward-complete | 0.392 | 0.246 | 1.592 | 0 | yes |
+| full-layout-65x63x17-antialias-0 | 0 | no | inverse-complete | 0.517 | 0.267 | 1.938 | 0 | yes |
+| full-layout-65x63x17-antialias-1 | 1 | no | extract | 0.045 | 0.021 | 2.145 | 0 | yes |
+| full-layout-65x63x17-antialias-1 | 1 | no | insert-primary | 0.074 | 0.021 | 3.612 | 0 | yes |
+| full-layout-65x63x17-antialias-1 | 1 | no | insert-conjugate | 0.039 | 0.008 | 5.016 | 0 | yes |
+| full-layout-65x63x17-antialias-1 | 1 | no | insert-complete | 0.082 | 0.024 | 3.432 | 0 | yes |
+| full-layout-65x63x17-antialias-1 | 1 | no | forward-complete | 0.259 | 0.220 | 1.176 | 0 | yes |
+| full-layout-65x63x17-antialias-1 | 1 | no | inverse-complete | 0.447 | 0.250 | 1.790 | 0 | yes |
+| full-layout-256x256x65-antialias-0 | 0 | yes | extract | 2.777 | 5.342 | 0.520 | 0 | yes |
+| full-layout-256x256x65-antialias-0 | 0 | yes | insert-primary | 2.471 | 13.716 | 0.180 | 0 | yes |
+| full-layout-256x256x65-antialias-0 | 0 | yes | insert-conjugate | 0.124 | 0.125 | 0.995 | 0 | yes |
+| full-layout-256x256x65-antialias-0 | 0 | yes | insert-complete | 2.542 | 13.962 | 0.182 | 0 | yes |
+| full-layout-256x256x65-antialias-0 | 0 | yes | forward-complete | 4.594 | 7.774 | 0.591 | 0 | yes |
+| full-layout-256x256x65-antialias-0 | 0 | yes | inverse-complete | 4.701 | 16.835 | 0.279 | 0 | yes |
+| full-layout-256x256x65-antialias-1 | 1 | yes | extract | 1.019 | 3.118 | 0.327 | 0 | yes |
+| full-layout-256x256x65-antialias-1 | 1 | yes | insert-primary | 0.956 | 4.274 | 0.224 | 0 | yes |
+| full-layout-256x256x65-antialias-1 | 1 | yes | insert-conjugate | 0.043 | 0.077 | 0.555 | 0 | yes |
+| full-layout-256x256x65-antialias-1 | 1 | yes | insert-complete | 0.804 | 4.482 | 0.179 | 0 | yes |
+| full-layout-256x256x65-antialias-1 | 1 | yes | forward-complete | 3.572 | 3.800 | 0.940 | 0 | yes |
+| full-layout-256x256x65-antialias-1 | 1 | yes | inverse-complete | 3.098 | 6.643 | 0.466 | 0 | yes |
+| full-layout-512x512x129-antialias-0 | 0 | yes | extract | 24.883 | 88.623 | 0.281 | 0 | yes |
+| full-layout-512x512x129-antialias-0 | 0 | yes | insert-primary | 20.468 | 76.126 | 0.269 | 0 | yes |
+| full-layout-512x512x129-antialias-0 | 0 | yes | insert-conjugate | 0.225 | 0.316 | 0.710 | 0 | yes |
+| full-layout-512x512x129-antialias-0 | 0 | yes | insert-complete | 21.498 | 76.521 | 0.281 | 0 | yes |
+| full-layout-512x512x129-antialias-0 | 0 | yes | forward-complete | 47.662 | 95.419 | 0.499 | 0 | yes |
+| full-layout-512x512x129-antialias-0 | 0 | yes | inverse-complete | 38.733 | 95.180 | 0.407 | 0 | yes |
+| full-layout-512x512x129-antialias-1 | 1 | yes | extract | 8.865 | 29.761 | 0.298 | 0 | yes |
+| full-layout-512x512x129-antialias-1 | 1 | yes | insert-primary | 8.013 | 26.782 | 0.299 | 0 | yes |
+| full-layout-512x512x129-antialias-1 | 1 | yes | insert-conjugate | 0.187 | 0.227 | 0.822 | 0 | yes |
+| full-layout-512x512x129-antialias-1 | 1 | yes | insert-complete | 8.076 | 27.066 | 0.298 | 0 | yes |
+| full-layout-512x512x129-antialias-1 | 1 | yes | forward-complete | 31.209 | 52.374 | 0.596 | 0 | yes |
+| full-layout-512x512x129-antialias-1 | 1 | yes | inverse-complete | 25.485 | 46.071 | 0.553 | 0 | yes |
+
+## Storage contract
+
+| Case | Strategy | Mapping (MiB) | Persistent full buffer (MiB) | Legacy maps materialized | Legacy map bytes |
+|---|---|---:|---:|---|---:|
+| full-layout-64x48x17-antialias-0 | two-dimensional-rows | 0.023 | 0.797 | no | 0 |
+| full-layout-64x48x17-antialias-1 | two-dimensional-rows | 0.011 | 0.797 | no | 0 |
+| full-layout-65x63x17-antialias-0 | two-dimensional-rows | 0.032 | 1.062 | no | 0 |
+| full-layout-65x63x17-antialias-1 | two-dimensional-rows | 0.011 | 1.062 | no | 0 |
+| full-layout-256x256x65-antialias-0 | two-dimensional-rows | 0.499 | 65.000 | no | 0 |
+| full-layout-256x256x65-antialias-1 | two-dimensional-rows | 0.176 | 65.000 | no | 0 |
+| full-layout-512x512x129-antialias-0 | two-dimensional-rows | 1.998 | 516.000 | no | 0 |
+| full-layout-512x512x129-antialias-1 | two-dimensional-rows | 0.702 | 516.000 | no | 0 |

--- a/Benchmarks/runWVFourierSpectrumLayoutIntegrationBenchmark.m
+++ b/Benchmarks/runWVFourierSpectrumLayoutIntegrationBenchmark.m
@@ -1,0 +1,392 @@
+function results = runWVFourierSpectrumLayoutIntegrationBenchmark(options)
+% Compare the production row layout with the frozen issue-69 baseline.
+arguments
+    options.caseIds (1,:) string = strings(1,0)
+    options.outputDirectory (1,1) string = ""
+    options.shouldWriteArtifacts (1,1) logical = true
+    options.runId (1,1) string = ""
+    options.correctnessTolerance (1,1) double {mustBePositive} = 1e-12
+    options.gateTolerance (1,1) double {mustBeNonnegative} = 0.03
+end
+
+benchmarkFolder = string(fileparts(mfilename("fullpath")));
+repositoryRoot = string(fileparts(benchmarkFolder));
+originalDirectory = pwd;
+originalPath = path;
+originalRng = rng;
+stateCleanup = onCleanup(@()restoreState(originalDirectory,originalPath,originalRng));
+addpath(repositoryRoot,benchmarkFolder);
+
+suite = waveVortexBenchmarkSuites("transform-layout-v1");
+if ~isempty(options.caseIds)
+    selected = ismember(string({suite.cases.id}),options.caseIds);
+    unknown = setdiff(options.caseIds,string({suite.cases.id}));
+    if ~isempty(unknown)
+        error("WaveVortexBenchmark:UnknownCase","Unknown transform-layout case: %s.",strjoin(unknown,", "));
+    end
+    suite.cases = suite.cases(selected);
+end
+referencePath = fullfile(benchmarkFolder,"results","reference","transform-layout-v1-m5-max-r2026a-builtin","benchmark.json");
+reference = loadReference(referencePath);
+if options.runId == ""
+    options.runId = string(datetime("now","TimeZone","UTC","Format","yyyyMMdd'T'HHmmss'Z'"));
+end
+if options.outputDirectory == ""
+    options.outputDirectory = fullfile(benchmarkFolder,"results","runs",options.runId + "-layout-integration-" + computer("arch") + "-" + version("-release"));
+end
+
+operationIds = ["extract" "insert-primary" "insert-conjugate" "insert-complete" "forward-complete" "inverse-complete"];
+results = struct( ...
+    "schemaVersion","1.0.0", ...
+    "status","complete", ...
+    "runId",options.runId, ...
+    "environment",environmentRecord(repositoryRoot), ...
+    "configuration",struct("caseIds",options.caseIds,"correctnessTolerance",options.correctnessTolerance,"gateTolerance",options.gateTolerance,"gateSizes",[256 256 65;512 512 129]), ...
+    "reference",struct("issue",69,"path",relativePath(referencePath,repositoryRoot),"sha256",sha256File(referencePath),"strategy","wv-sorted-linear"), ...
+    "operationIds",operationIds, ...
+    "cases",emptyCaseResults(), ...
+    "readiness",struct("passed",false,"completeGateSet",false,"gateCaseCount",0,"failedCriteria",strings(0,1)));
+
+for iCase = 1:numel(suite.cases)
+    try
+        caseResult = runCase(suite.cases(iCase),reference,operationIds,options.correctnessTolerance,options.gateTolerance);
+    catch exception
+        caseResult = failedCase(suite.cases(iCase),exception);
+        results.status = "partial";
+    end
+    results.cases(end+1) = caseResult;
+end
+results.readiness = readinessRecord(results.cases);
+if ~results.readiness.passed
+    results.status = "failed";
+end
+if options.shouldWriteArtifacts
+    writeArtifacts(results,options.outputDirectory);
+end
+clear stateCleanup
+end
+
+function caseResult = runCase(benchmarkCase,reference,operationIds,tolerance,gateTolerance)
+Nx = benchmarkCase.Nxyz(1);
+Ny = benchmarkCase.Nxyz(2);
+Nz = benchmarkCase.Nxyz(3);
+rng(benchmarkCase.seed,"twister");
+geometry = WVGeometryDoublyPeriodic(benchmarkCase.Lxyz(1:2),[Nx Ny],Nz=Nz,shouldAntialias=benchmarkCase.shouldAntialias,shouldExcludeNyquist=true,shouldExcludeConjugates=true,conjugateDimension=2,fastTransform="builtin");
+transform = geometry.fastTransform;
+layout = transform.fourierSpectrumLayout;
+realInput = randn(Nx,Ny,Nz);
+fullSpectrum = fft(fft(realInput,Nx,1),Ny,2)/(Nx*Ny);
+fullSpectrumRows = reshape(fullSpectrum,layout.storageRowCount,[]);
+referenceWV = fullSpectrumRows(layout.directStorageRows,:).';
+referenceRows = layout.allocateStorage(Nz);
+referenceRows = layout.insertCanonical(referenceRows,referenceWV);
+referenceInverse = ifft(ifft(layout.spectrumFromRows(referenceRows),Nx,1),Ny,2,"symmetric")*(Nx*Ny);
+buffer = WVTransformLayoutBenchmarkBuffer([Nx Ny Nz],"rows-2d");
+
+errors = validateProduction(transform,layout,buffer,fullSpectrum,realInput,referenceWV,referenceRows,referenceInverse);
+errorValues = cell2mat(struct2cell(errors));
+if max(errorValues) > tolerance
+    error("WaveVortexBenchmark:LayoutIntegrationCorrectnessFailed","Production layout exceeded the relative-error tolerance (maximum %.3g).",max(errorValues));
+end
+
+warmupSchedules = strings(benchmarkCase.warmupCount,numel(operationIds));
+for iWarmup = 1:benchmarkCase.warmupCount
+    order = rotatedOrder(numel(operationIds),iWarmup);
+    warmupSchedules(iWarmup,:) = operationIds(order);
+    for iOperation = order
+        executeOperation(operationIds(iOperation),transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+    end
+end
+
+rawSeconds = NaN(numel(operationIds),benchmarkCase.sampleCount);
+sampleSchedules = strings(benchmarkCase.sampleCount,numel(operationIds));
+for iSample = 1:benchmarkCase.sampleCount
+    order = rotatedOrder(numel(operationIds),iSample);
+    sampleSchedules(iSample,:) = operationIds(order);
+    for iOperation = order
+        timer = tic;
+        executeOperation(operationIds(iOperation),transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+        rawSeconds(iOperation,iSample) = toc(timer);
+    end
+end
+
+referenceCase = referenceCaseFor(reference,benchmarkCase.id);
+operations = repmat(struct("id","","rawSeconds",[],"medianSeconds",NaN,"referenceMedianSeconds",NaN,"relativeToReference",NaN,"relativeError",NaN,"correctnessPassed",false,"performanceGateApplies",false,"performancePassed",false),1,numel(operationIds));
+isGate = isGateSize(benchmarkCase.Nxyz);
+for iOperation = 1:numel(operationIds)
+    samples = rawSeconds(iOperation,:);
+    currentMedian = median(samples);
+    baselineMedian = referenceMedian(referenceCase,operationIds(iOperation));
+    ratio = currentMedian/baselineMedian;
+    operations(iOperation) = struct( ...
+        "id",operationIds(iOperation), ...
+        "rawSeconds",samples, ...
+        "medianSeconds",currentMedian, ...
+        "referenceMedianSeconds",baselineMedian, ...
+        "relativeToReference",ratio, ...
+        "relativeError",errors.(errorField(operationIds(iOperation))), ...
+        "correctnessPassed",errors.(errorField(operationIds(iOperation))) <= tolerance, ...
+        "performanceGateApplies",isGate, ...
+        "performancePassed",~isGate || ratio <= 1+gateTolerance);
+end
+
+diagnostics = geometry.fourierSpectrumLayoutDiagnostics();
+caseResult = struct( ...
+    "id",benchmarkCase.id, ...
+    "Nxyz",benchmarkCase.Nxyz, ...
+    "shouldAntialias",benchmarkCase.shouldAntialias, ...
+    "seed",benchmarkCase.seed, ...
+    "warmupCount",benchmarkCase.warmupCount, ...
+    "sampleCount",benchmarkCase.sampleCount, ...
+    "isGate",isGate, ...
+    "status","complete", ...
+    "failure",emptyFailure(), ...
+    "mappingStrategy",layout.mappingStrategy, ...
+    "storageShape",layout.storageShape, ...
+    "mappingBytes",layout.mappingBytes, ...
+    "legacyMappingsAreMaterialized",diagnostics.legacyMappingsAreMaterialized, ...
+    "legacyMappingBytes",diagnostics.legacyMappingBytes, ...
+    "persistentBufferBytes",complexArrayBytes(transform.complexBuffer), ...
+    "warmupSchedules",warmupSchedules, ...
+    "sampleSchedules",sampleSchedules, ...
+    "operations",operations);
+end
+
+function errors = validateProduction(transform,layout,buffer,fullSpectrum,realInput,referenceWV,referenceRows,referenceInverse)
+extracted = executeOperation("extract",transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+buffer.reset();
+executeOperation("insert-primary",transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+primaryError = relativeError(buffer.value(layout.directStorageRows,:),referenceRows(layout.directStorageRows,:));
+buffer.reset();
+buffer.value(layout.directStorageRows,:) = referenceRows(layout.directStorageRows,:);
+executeOperation("insert-conjugate",transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+completionRows = [layout.completionStorageRows;layout.selfConjugateStorageRows];
+conjugateError = relativeError(buffer.value(completionRows,:),referenceRows(completionRows,:));
+buffer.reset();
+executeOperation("insert-complete",transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+forward = executeOperation("forward-complete",transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+inverse = executeOperation("inverse-complete",transform,layout,buffer,fullSpectrum,referenceWV,realInput);
+errors = struct( ...
+    "extract",relativeError(extracted,referenceWV), ...
+    "insertPrimary",primaryError, ...
+    "insertConjugate",conjugateError, ...
+    "insertComplete",relativeError(buffer.value,referenceRows), ...
+    "forwardComplete",relativeError(forward,referenceWV), ...
+    "inverseComplete",relativeError(inverse,referenceInverse));
+end
+
+function output = executeOperation(operationId,transform,layout,buffer,fullSpectrum,wvInput,realInput)
+switch operationId
+    case "extract"
+        output = layout.extractCanonical(reshape(fullSpectrum,layout.storageRowCount,[]));
+    case "insert-primary"
+        buffer.value(layout.directStorageRows,:) = wvInput(:,layout.directWVColumns).';
+        output = [];
+    case "insert-conjugate"
+        if ~isempty(layout.completionStorageRows)
+            buffer.value(layout.completionStorageRows,:) = conj(wvInput(:,layout.completionWVColumns).');
+        end
+        if ~isempty(layout.selfConjugateStorageRows)
+            buffer.value(layout.selfConjugateStorageRows,:) = real(buffer.value(layout.selfConjugateStorageRows,:));
+        end
+        output = [];
+    case "insert-complete"
+        buffer.value(layout.directStorageRows,:) = wvInput(:,layout.directWVColumns).';
+        if ~isempty(layout.completionStorageRows)
+            buffer.value(layout.completionStorageRows,:) = conj(wvInput(:,layout.completionWVColumns).');
+        end
+        if ~isempty(layout.selfConjugateStorageRows)
+            buffer.value(layout.selfConjugateStorageRows,:) = real(buffer.value(layout.selfConjugateStorageRows,:));
+        end
+        output = [];
+    case "forward-complete"
+        output = transform.transformFromSpatialDomainWithFourier(realInput);
+    case "inverse-complete"
+        output = transform.transformToSpatialDomainWithFourier(wvInput);
+    otherwise
+        error("WaveVortexBenchmark:UnknownLayoutOperation","Unknown transform-layout operation %s.",operationId);
+end
+end
+
+function reference = loadReference(pathname)
+if ~isfile(pathname)
+    error("WaveVortexBenchmark:MissingLayoutReference","The issue-69 reference artifact is missing: %s.",pathname);
+end
+reference = jsondecode(fileread(pathname));
+end
+
+function benchmarkCase = referenceCaseFor(reference,caseId)
+cases = reference.suites.cases;
+iCase = find(string({cases.id}) == caseId,1);
+if isempty(iCase)
+    error("WaveVortexBenchmark:MissingLayoutReferenceCase","The issue-69 artifact has no case %s.",caseId);
+end
+benchmarkCase = cases(iCase);
+end
+
+function value = referenceMedian(benchmarkCase,operationId)
+iStrategy = find(string({benchmarkCase.strategies.id}) == "wv-sorted-linear",1);
+operations = benchmarkCase.strategies(iStrategy).operations;
+iOperation = find(string({operations.id}) == operationId,1);
+value = operations(iOperation).medianSeconds;
+end
+
+function readiness = readinessRecord(cases)
+gateCases = cases([cases.isGate]);
+failed = strings(0,1);
+for benchmarkCase = gateCases
+    if benchmarkCase.status ~= "complete"
+        failed(end+1,1) = benchmarkCase.id + ": " + benchmarkCase.failure.identifier; %#ok<AGROW>
+        continue
+    end
+    for operation = benchmarkCase.operations
+        if ~operation.correctnessPassed
+            failed(end+1,1) = benchmarkCase.id + "/" + operation.id + ": correctness"; %#ok<AGROW>
+        end
+        if ~operation.performancePassed
+            failed(end+1,1) = benchmarkCase.id + "/" + operation.id + ": " + sprintf("%.3fx reference",operation.relativeToReference); %#ok<AGROW>
+        end
+    end
+end
+readiness = struct("passed",isempty(failed),"completeGateSet",numel(gateCases) == 4,"gateCaseCount",numel(gateCases),"failedCriteria",failed);
+end
+
+function tf = isGateSize(Nxyz)
+tf = isequal(Nxyz,[256 256 65]) || isequal(Nxyz,[512 512 129]);
+end
+
+function field = errorField(operationId)
+switch operationId
+    case "insert-primary"
+        field = "insertPrimary";
+    case "insert-conjugate"
+        field = "insertConjugate";
+    case "insert-complete"
+        field = "insertComplete";
+    case "forward-complete"
+        field = "forwardComplete";
+    case "inverse-complete"
+        field = "inverseComplete";
+    otherwise
+        field = operationId;
+end
+end
+
+function order = rotatedOrder(count,roundNumber)
+start = mod(roundNumber-1,count)+1;
+order = [start:count 1:start-1];
+end
+
+function value = relativeError(actual,expected)
+if isempty(actual) && isempty(expected)
+    value = 0;
+    return
+end
+value = max(abs(actual(:)-expected(:)))/max(max(abs(expected(:))),realmin("double"));
+end
+
+function bytes = complexArrayBytes(value)
+bytes = 16*numel(value);
+end
+
+function writeArtifacts(results,outputDirectory)
+if ~isfolder(outputDirectory)
+    mkdir(outputDirectory);
+end
+writeText(fullfile(outputDirectory,"benchmark.json"),jsonencode(results,PrettyPrint=true));
+writeText(fullfile(outputDirectory,"summary.md"),summaryText(results));
+end
+
+function summary = summaryText(results)
+lines = ["# Fourier spectrum layout integration";"";"- Status: `" + results.status + "`";"- Gate passed: `" + string(results.readiness.passed) + "`";"- Reference: WaveVortex issue #69 (`wv-sorted-linear`)";"- Gate: no operation above `1.03x` the frozen median on the 256 and 512 workloads";"";"## Timing and frozen-baseline comparison";"";"| Case | Antialias | Gate | Operation | Production (ms) | Issue #69 (ms) | Relative | Error | Pass |";"|---|---:|---|---|---:|---:|---:|---:|---|"];
+for benchmarkCase = results.cases
+    if benchmarkCase.status ~= "complete"
+        lines(end+1) = "| " + benchmarkCase.id + " | " + string(benchmarkCase.shouldAntialias) + " | " + yesNo(benchmarkCase.isGate) + " | failed | NaN | NaN | NaN | NaN | no |"; %#ok<AGROW>
+        continue
+    end
+    for operation = benchmarkCase.operations
+        lines(end+1) = sprintf("| %s | %d | %s | %s | %.3f | %.3f | %.3f | %.3g | %s |",benchmarkCase.id,benchmarkCase.shouldAntialias,yesNo(benchmarkCase.isGate),operation.id,1e3*operation.medianSeconds,1e3*operation.referenceMedianSeconds,operation.relativeToReference,operation.relativeError,yesNo(operation.correctnessPassed && operation.performancePassed)); %#ok<AGROW>
+    end
+end
+lines = [lines;"";"## Storage contract";"";"| Case | Strategy | Mapping (MiB) | Persistent full buffer (MiB) | Legacy maps materialized | Legacy map bytes |";"|---|---|---:|---:|---|---:|"];
+for benchmarkCase = results.cases
+    if benchmarkCase.status == "complete"
+        lines(end+1) = sprintf("| %s | %s | %.3f | %.3f | %s | %d |",benchmarkCase.id,benchmarkCase.mappingStrategy,benchmarkCase.mappingBytes/2^20,benchmarkCase.persistentBufferBytes/2^20,yesNo(benchmarkCase.legacyMappingsAreMaterialized),benchmarkCase.legacyMappingBytes); %#ok<AGROW>
+    end
+end
+if ~isempty(results.readiness.failedCriteria)
+    lines = [lines;"";"## Failed criteria";""];
+    for failure = string(results.readiness.failedCriteria(:)).'
+        lines(end+1) = "- " + failure; %#ok<AGROW>
+    end
+end
+summary = strjoin(lines,newline) + newline;
+end
+
+function value = yesNo(tf)
+if tf
+    value = "yes";
+else
+    value = "no";
+end
+end
+
+function environment = environmentRecord(repositoryRoot)
+[~,commit] = system("git -C " + quoted(repositoryRoot) + " rev-parse HEAD");
+[~,tree] = system("git -C " + quoted(repositoryRoot) + " rev-parse HEAD^{tree}");
+environment = struct("matlabVersion",string(version),"matlabRelease",string(version("-release")),"architecture",string(computer("arch")),"os",string(system_dependent("getos")),"sourceCommit",strtrim(string(commit)),"sourceTree",strtrim(string(tree)));
+end
+
+function value = quoted(value)
+value = "'" + string(value) + "'";
+end
+
+function path = relativePath(path,root)
+path = erase(string(path),string(root) + filesep);
+end
+
+function hash = sha256File(pathname)
+fileId = fopen(pathname,"r");
+if fileId < 0
+    error("WaveVortexBenchmark:UnreadableArtifact","Unable to read %s.",pathname);
+end
+cleanup = onCleanup(@()fclose(fileId));
+bytes = fread(fileId,Inf,"*uint8");
+digest = java.security.MessageDigest.getInstance("SHA-256");
+digest.update(bytes);
+hashBytes = typecast(digest.digest(),"uint8");
+hash = lower(string(reshape(dec2hex(hashBytes,2).',1,[])));
+clear cleanup
+end
+
+function writeText(pathname,text)
+fileId = fopen(pathname,"w");
+if fileId < 0
+    error("WaveVortexBenchmark:ArtifactWriteFailed","Unable to write %s.",pathname);
+end
+cleanup = onCleanup(@()fclose(fileId));
+fprintf(fileId,"%s",text);
+clear cleanup
+end
+
+function restoreState(originalDirectory,originalPath,originalRng)
+cd(originalDirectory);
+path(originalPath);
+rng(originalRng);
+end
+
+function result = failedCase(benchmarkCase,exception)
+result = struct("id",benchmarkCase.id,"Nxyz",benchmarkCase.Nxyz,"shouldAntialias",benchmarkCase.shouldAntialias,"seed",benchmarkCase.seed,"warmupCount",benchmarkCase.warmupCount,"sampleCount",benchmarkCase.sampleCount,"isGate",isGateSize(benchmarkCase.Nxyz),"status","failed","failure",struct("identifier",string(exception.identifier),"message",string(exception.message),"stack",string({exception.stack.name})),"mappingStrategy","","storageShape",[],"mappingBytes",NaN,"legacyMappingsAreMaterialized",false,"legacyMappingBytes",NaN,"persistentBufferBytes",NaN,"warmupSchedules",strings(0,0),"sampleSchedules",strings(0,0),"operations",emptyOperationResults());
+end
+
+function results = emptyCaseResults()
+results = struct("id",{},"Nxyz",{},"shouldAntialias",{},"seed",{},"warmupCount",{},"sampleCount",{},"isGate",{},"status",{},"failure",{},"mappingStrategy",{},"storageShape",{},"mappingBytes",{},"legacyMappingsAreMaterialized",{},"legacyMappingBytes",{},"persistentBufferBytes",{},"warmupSchedules",{},"sampleSchedules",{},"operations",{});
+end
+
+function results = emptyOperationResults()
+results = struct("id",{},"rawSeconds",{},"medianSeconds",{},"referenceMedianSeconds",{},"relativeToReference",{},"relativeError",{},"correctnessPassed",{},"performanceGateApplies",{},"performancePassed",{});
+end
+
+function failure = emptyFailure()
+failure = struct("identifier","","message","","stack",strings(0,1));
+end

--- a/FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m
+++ b/FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m
@@ -39,6 +39,9 @@ classdef WVFastTransformDoublyPeriodicFFTW < WVFastTransformDoublyPeriodic
             end
             self.wvg = wvg;
             self.Nz = Nz;
+            % This legacy adapter still owns full-complex buffers. Issue #71
+            % replaces its internals with the half-x production engine.
+            self.fourierSpectrumLayout = WVFourierSpectrumLayout(wvg,"full");
             self.complexBuffer = complex(zeros([wvg.Nx wvg.Ny Nz]));
 
             self.dftXY = RealToComplexTransform([wvg.Nx wvg.Ny Nz],dims=[1 2],nCores=options.nCores,planner="measure");

--- a/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/WVFastTransformDoublyPeriodicMatlab.m
+++ b/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/WVFastTransformDoublyPeriodicMatlab.m
@@ -1,19 +1,31 @@
 classdef WVFastTransformDoublyPeriodicMatlab < WVFastTransformDoublyPeriodic
+    properties (Dependent)
+        complexBuffer
+    end
+
     properties
         wvg
-
-        % memory buffer to hold the dft matrices
-        %
-        % - Topic: Domain attributes — WV grid
-        complexBuffer
         Nz
+    end
+
+    properties (Access=private)
+        complexBufferRows
     end
 
     methods
         function self = WVFastTransformDoublyPeriodicMatlab(wvg,Nz)
             self.wvg = wvg;
-            self.complexBuffer = complex(zeros([wvg.Nx wvg.Ny Nz]));
             self.Nz=Nz;
+            self.fourierSpectrumLayout = WVFourierSpectrumLayout(wvg,"full");
+            self.complexBufferRows = self.fourierSpectrumLayout.allocateStorage(Nz);
+        end
+
+        function value = get.complexBuffer(self)
+            value = self.fourierSpectrumLayout.spectrumFromRows(self.complexBufferRows);
+        end
+
+        function set.complexBuffer(self,value)
+            self.complexBufferRows = self.fourierSpectrumLayout.rowsFromSpectrum(value);
         end
     end
 

--- a/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/transformFromSpatialDomainWithFourier.m
+++ b/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/transformFromSpatialDomainWithFourier.m
@@ -9,5 +9,5 @@ function u_bar = transformFromSpatialDomainWithFourier(self,u)
 % - Parameter u: a real-valued matrix of size [Nx Ny Nz]
 % - Returns u_bar: a complex-valued matrix of size [Nz Nkl]
 u_bar = fft(fft(u,self.wvg.Nx,1),self.wvg.Ny,2)/(self.wvg.Nx*self.wvg.Ny);
-u_bar = reshape(u_bar(self.wvg.dftPrimaryIndex),[self.Nz self.wvg.Nkl]);
+u_bar = self.fourierSpectrumLayout.extractCanonical(reshape(u_bar,[],self.Nz));
 end

--- a/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/transformToSpatialDomainWithFourier.m
+++ b/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/transformToSpatialDomainWithFourier.m
@@ -1,5 +1,16 @@
 function u = transformToSpatialDomainWithFourier(self,u_bar)
-self.complexBuffer(self.wvg.dftPrimaryIndex) = u_bar;
-self.complexBuffer(self.wvg.dftConjugateIndex) = conj(u_bar(self.wvg.wvConjugateIndex));
-u = ifft(ifft(self.complexBuffer,self.wvg.Nx,1),self.wvg.Ny,2,'symmetric')*(self.wvg.Nx*self.wvg.Ny);
+layout = self.fourierSpectrumLayout;
+self.complexBufferRows(layout.directStorageRows,:) = u_bar(:,layout.directWVColumns).';
+if ~isempty(layout.completionStorageRows)
+    self.complexBufferRows(layout.completionStorageRows,:) = conj(u_bar(:,layout.completionWVColumns).');
+end
+if ~isempty(layout.selfConjugateStorageRows)
+    self.complexBufferRows(layout.selfConjugateStorageRows,:) = real(self.complexBufferRows(layout.selfConjugateStorageRows,:));
+end
+complexBuffer = layout.spectrumFromRows(self.complexBufferRows);
+if self.wvg.conjugateDimension == 1
+    u = ifft(ifft(complexBuffer,self.wvg.Ny,2),self.wvg.Nx,1,'symmetric')*(self.wvg.Nx*self.wvg.Ny);
+else
+    u = ifft(ifft(complexBuffer,self.wvg.Nx,1),self.wvg.Ny,2,'symmetric')*(self.wvg.Nx*self.wvg.Ny);
+end
 end

--- a/FastTransforms/WVFastTransformDoublyPeriodic.m
+++ b/FastTransforms/WVFastTransformDoublyPeriodic.m
@@ -1,4 +1,8 @@
 classdef WVFastTransformDoublyPeriodic < handle
+    properties (SetAccess=protected)
+        fourierSpectrumLayout
+    end
+
     methods (Abstract)
         u_bar = transformFromSpatialDomainWithFourier(self,u)
         u = transformToSpatialDomainWithFourier(self,u_bar)

--- a/FastTransforms/WVFourierSpectrumLayout.m
+++ b/FastTransforms/WVFourierSpectrumLayout.m
@@ -1,0 +1,231 @@
+classdef (Hidden) WVFourierSpectrumLayout
+    % Internal mapping contract between Fourier storage and WV coefficients.
+    properties (SetAccess=private)
+        storageType
+        compressedDimension
+        physicalShape
+        storageShape
+        storageRowCount
+        Nkl
+        mappingStrategy = "two-dimensional-rows"
+        directStorageRows uint64
+        directWVColumns uint64
+        conjugatedStorageRows uint64
+        conjugatedWVColumns uint64
+        completionStorageRows uint64
+        completionSourceRows uint64
+        completionWVColumns uint64
+        selfConjugateStorageRows uint64
+        mappingBytes
+    end
+
+    methods
+        function self = WVFourierSpectrumLayout(wvg,storageType,options)
+            arguments
+                wvg (1,1) WVGeometryDoublyPeriodic
+                storageType (1,1) string {mustBeMember(storageType,["full","hermitian-half"])}
+                options.compressedDimension (1,1) double {mustBeMember(options.compressedDimension,[0 1 2])} = 0
+            end
+            if storageType == "full" && options.compressedDimension ~= 0
+                error("WaveVortexModel:InvalidFullSpectrumLayout","Full spectrum storage requires compressedDimension=0.");
+            elseif storageType == "hermitian-half" && options.compressedDimension == 0
+                error("WaveVortexModel:InvalidHalfSpectrumLayout","Hermitian-half storage requires compressedDimension 1 or 2.");
+            end
+
+            self.storageType = storageType;
+            self.compressedDimension = options.compressedDimension;
+            self.physicalShape = [wvg.Nx wvg.Ny];
+            self.Nkl = wvg.Nkl;
+            if storageType == "full"
+                self.storageShape = self.physicalShape;
+                implicitHermitianDimension = wvg.conjugateDimension;
+            else
+                self.storageShape = self.physicalShape;
+                self.storageShape(options.compressedDimension) = floor(self.storageShape(options.compressedDimension)/2)+1;
+                implicitHermitianDimension = options.compressedDimension;
+            end
+            self.storageRowCount = prod(self.storageShape);
+
+            kMode = double(wvg.kMode_wv(:));
+            lMode = double(wvg.lMode_wv(:));
+            [self.directStorageRows,self.directWVColumns,self.conjugatedStorageRows,self.conjugatedWVColumns,representedK,representedL] = self.primaryMappings(kMode,lMode);
+            [self.completionStorageRows,self.completionSourceRows,self.selfConjugateStorageRows] = self.boundaryMappings(representedK,representedL,implicitHermitianDimension);
+            self.completionWVColumns = self.wvColumnsForDirectRows(self.completionSourceRows);
+            if self.storageType == "full"
+                % Preserve the measured builtin assignment contract. Valid
+                % real transforms already make self-conjugate values real.
+                self.selfConjugateStorageRows = uint64.empty(0,1);
+            end
+            self.mappingBytes = self.exactMappingBytes();
+        end
+
+        function uBar = extractCanonical(self,storageRows)
+            self.validateStorageRows(storageRows);
+            nBatch = size(storageRows,2);
+            if self.storageType == "full" && isempty(self.conjugatedWVColumns) && isequal(self.directWVColumns,uint64((1:self.Nkl)'))
+                uBar = storageRows(self.directStorageRows,:).';
+                return
+            end
+            uBar = complex(zeros(nBatch,self.Nkl));
+            uBar(:,self.directWVColumns) = storageRows(self.directStorageRows,:).';
+            if ~isempty(self.conjugatedWVColumns)
+                uBar(:,self.conjugatedWVColumns) = conj(storageRows(self.conjugatedStorageRows,:).');
+            end
+        end
+
+        function storageRows = allocateStorage(self,nBatch)
+            arguments
+                self (1,1) WVFourierSpectrumLayout
+                nBatch (1,1) double {mustBeInteger,mustBePositive}
+            end
+            storageRows = complex(zeros(self.storageRowCount,nBatch));
+        end
+
+        function storageRows = insertCanonical(self,storageRows,uBar)
+            self.validateStorageRows(storageRows);
+            if size(uBar,1) ~= size(storageRows,2) || size(uBar,2) ~= self.Nkl
+                error("WaveVortexModel:InvalidCanonicalSpectrumShape","Canonical coefficients must have shape [Nbatch,Nkl]=[%d,%d].",size(storageRows,2),self.Nkl);
+            end
+            storageRows(self.directStorageRows,:) = uBar(:,self.directWVColumns).';
+            if ~isempty(self.conjugatedStorageRows)
+                storageRows(self.conjugatedStorageRows,:) = conj(uBar(:,self.conjugatedWVColumns).');
+            end
+            if ~isempty(self.completionStorageRows)
+                storageRows(self.completionStorageRows,:) = conj(storageRows(self.completionSourceRows,:));
+            end
+            if ~isempty(self.selfConjugateStorageRows)
+                storageRows(self.selfConjugateStorageRows,:) = real(storageRows(self.selfConjugateStorageRows,:));
+            end
+        end
+
+        function storageRows = rowsFromSpectrum(self,spectrum)
+            spectrumSize = size(spectrum);
+            if numel(spectrumSize) < 2 || ~isequal(spectrumSize(1:2),self.storageShape)
+                error("WaveVortexModel:InvalidStoredSpectrumShape","Stored spectrum must begin with shape [%d,%d].",self.storageShape(1),self.storageShape(2));
+            end
+            if mod(numel(spectrum),self.storageRowCount) ~= 0
+                error("WaveVortexModel:InvalidStoredSpectrumShape","Stored spectrum size is incompatible with the layout.");
+            end
+            storageRows = reshape(spectrum,self.storageRowCount,[]);
+        end
+
+        function spectrum = spectrumFromRows(self,storageRows)
+            self.validateStorageRows(storageRows);
+            spectrum = reshape(storageRows,[self.storageShape size(storageRows,2)]);
+        end
+
+        function ledger = mappingLedger(self)
+            names = ["directStorageRows" "directWVColumns" "conjugatedStorageRows" "conjugatedWVColumns" "completionStorageRows" "completionSourceRows" "completionWVColumns" "selfConjugateStorageRows"];
+            ledger = repmat(struct("name","","class","","shape",[],"bytes",0),1,numel(names));
+            for iName = 1:numel(names)
+                value = self.(names(iName));
+                info = whos("value");
+                ledger(iName) = struct("name",names(iName),"class",string(class(value)),"shape",double(size(value)),"bytes",double(info.bytes));
+            end
+        end
+
+        function [dftPrimaryIndex,dftConjugateIndex,wvConjugateIndex] = expandedLegacyMappings(self,nBatch)
+            arguments
+                self (1,1) WVFourierSpectrumLayout
+                nBatch (1,1) double {mustBeInteger,mustBePositive}
+            end
+            if ~isempty(self.conjugatedWVColumns)
+                error("WaveVortexModel:LegacyMappingUnavailable","Legacy linear mappings cannot represent a layout whose canonical modes require conjugated extraction.");
+            end
+            offsets = uint64((0:nBatch-1)*self.storageRowCount);
+            primary = self.directStorageRows(:)+offsets;
+            dftPrimaryIndex = reshape(primary.',[],1);
+            completion = self.completionStorageRows(:)+offsets;
+            dftConjugateIndex = reshape(completion.',[],1);
+
+            sourceWVColumns = zeros(numel(self.completionSourceRows),1,"uint64");
+            for iSource = 1:numel(self.completionSourceRows)
+                iDirect = find(self.directStorageRows == self.completionSourceRows(iSource),1);
+                sourceWVColumns(iSource) = self.directWVColumns(iDirect);
+            end
+            wvIndices = uint64((0:nBatch-1)')+1+nBatch*(sourceWVColumns(:)'-1);
+            wvConjugateIndex = reshape(wvIndices,[],1);
+        end
+    end
+
+    methods (Access=private)
+        function [directRows,directColumns,conjugatedRows,conjugatedColumns,representedK,representedL] = primaryMappings(self,kMode,lMode)
+            wvColumns = uint64((1:numel(kMode))');
+            representedK = kMode;
+            representedL = lMode;
+            conjugated = false(size(kMode));
+            if self.storageType == "hermitian-half"
+                compressedModes = kMode;
+                if self.compressedDimension == 2
+                    compressedModes = lMode;
+                end
+                conjugated = compressedModes < 0;
+                representedK(conjugated) = -representedK(conjugated);
+                representedL(conjugated) = -representedL(conjugated);
+            end
+            rows = self.rowForModes(representedK,representedL);
+            directRows = rows(~conjugated);
+            directColumns = wvColumns(~conjugated);
+            conjugatedRows = rows(conjugated);
+            conjugatedColumns = wvColumns(conjugated);
+        end
+
+        function [destinationRows,sourceRows,selfRows] = boundaryMappings(self,kMode,lMode,implicitHermitianDimension)
+            boundaryModes = lMode;
+            boundaryLength = self.physicalShape(2);
+            if implicitHermitianDimension == 1
+                boundaryModes = kMode;
+                boundaryLength = self.physicalShape(1);
+            end
+            isBoundary = boundaryModes == 0;
+            if mod(boundaryLength,2) == 0
+                isBoundary = isBoundary | abs(boundaryModes) == boundaryLength/2;
+            end
+            sourceRows = self.rowForModes(kMode(isBoundary),lMode(isBoundary));
+            conjugateRows = self.rowForModes(-kMode(isBoundary),-lMode(isBoundary));
+            selfConjugate = sourceRows == conjugateRows;
+            selfRows = unique(sourceRows(selfConjugate),"stable");
+
+            assignedRows = [self.directStorageRows;self.conjugatedStorageRows];
+            needsCompletion = ~selfConjugate & ~ismember(conjugateRows,assignedRows);
+            destinationRows = conjugateRows(needsCompletion);
+            sourceRows = sourceRows(needsCompletion);
+            [destinationRows,uniqueIndices] = unique(destinationRows,"stable");
+            sourceRows = sourceRows(uniqueIndices);
+        end
+
+        function rows = rowForModes(self,kMode,lMode)
+            iK = mod(kMode,self.physicalShape(1))+1;
+            iL = mod(lMode,self.physicalShape(2))+1;
+            if self.storageType == "hermitian-half"
+                if self.compressedDimension == 1
+                    iK = min(iK,self.storageShape(1));
+                else
+                    iL = min(iL,self.storageShape(2));
+                end
+            end
+            rows = uint64(iK+self.storageShape(1)*(iL-1));
+        end
+
+        function bytes = exactMappingBytes(self)
+            ledger = self.mappingLedger();
+            bytes = sum([ledger.bytes]);
+        end
+
+        function columns = wvColumnsForDirectRows(self,rows)
+            columns = zeros(size(rows),"uint64");
+            for iRow = 1:numel(rows)
+                iDirect = find(self.directStorageRows == rows(iRow),1);
+                if ~isempty(iDirect)
+                    columns(iRow) = self.directWVColumns(iDirect);
+                end
+            end
+        end
+
+        function validateStorageRows(self,storageRows)
+            if ~ismatrix(storageRows) || size(storageRows,1) ~= self.storageRowCount
+                error("WaveVortexModel:InvalidStoredSpectrumShape","Spectrum rows must have shape [%d,Nbatch].",self.storageRowCount);
+            end
+        end
+    end
+end

--- a/UnitTests/TestProductionCodeAnalyzer.m
+++ b/UnitTests/TestProductionCodeAnalyzer.m
@@ -23,13 +23,14 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
     methods (Test,TestTags="full")
         function productionInventoryIsDeterministic(testCase)
             files = testCase.productionReport.Files;
-            testCase.verifyNumElements(files,171);
+            testCase.verifyNumElements(files,172);
             testCase.verifyEqual(files,sort(unique(files)));
             testCase.verifyTrue(all(isfile(fullfile(testCase.repositoryRoot,files))));
 
             expectedFiles = [
                 "WVOperation.m"
                 "@WVTransform/WVTransform.m"
+                "FastTransforms/WVFourierSpectrumLayout.m"
                 "FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m"
                 "Forcing/WVNonlinearAdvection.m"
                 "ObservingSystems/WVLagrangianParticles.m"
@@ -70,7 +71,7 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
         function reportContainsReleaseLocationsAndDiagnostics(testCase)
             output = evalc("analyzeProductionCode(testCase.repositoryRoot,ShouldFail=false);");
             testCase.verifySubstring(output,"MATLAB Code Analyzer: release=R");
-            testCase.verifySubstring(output,"files=171");
+            testCase.verifySubstring(output,"files=172");
             testCase.verifySubstring(output,"[AGROW, performance]");
             testCase.verifySubstring(output,"Variable appears to change size");
             testCase.verifyFalse(contains(output,testCase.repositoryRoot));

--- a/UnitTests/TestWVFourierSpectrumLayout.m
+++ b/UnitTests/TestWVFourierSpectrumLayout.m
@@ -1,0 +1,174 @@
+classdef TestWVFourierSpectrumLayout < matlab.unittest.TestCase
+    methods (Test,TestTags="full")
+        function fullHalfLayoutsAreEquivalent(testCase)
+            sizes = [8 6 3;9 7 4];
+            for iSize = 1:size(sizes,1)
+                Nx = sizes(iSize,1);
+                Ny = sizes(iSize,2);
+                nBatch = sizes(iSize,3);
+                for conjugateDimension = [1 2]
+                    for shouldAntialias = [false true]
+                        for shouldExcludeNyquist = [false true]
+                            geometry = WVGeometryDoublyPeriodic([4000 3000],[Nx Ny],Nz=nBatch,conjugateDimension=conjugateDimension,shouldAntialias=shouldAntialias,shouldExcludeNyquist=shouldExcludeNyquist,shouldExcludeConjugates=true);
+                            fullLayout = WVFourierSpectrumLayout(geometry,"full");
+                            halfXLayout = WVFourierSpectrumLayout(geometry,"hermitian-half",compressedDimension=1);
+                            halfYLayout = WVFourierSpectrumLayout(geometry,"hermitian-half",compressedDimension=2);
+
+                            rng(7000+100*iSize+10*conjugateDimension+2*shouldAntialias+shouldExcludeNyquist,"twister");
+                            realInput = randn(Nx,Ny,nBatch);
+                            fullSpectrum = fft(fft(realInput,Nx,1),Ny,2)/(Nx*Ny);
+                            canonical = fullLayout.extractCanonical(fullLayout.rowsFromSpectrum(fullSpectrum));
+                            halfXSpectrum = fullSpectrum(1:(floor(Nx/2)+1),:,:);
+                            halfYSpectrum = fullSpectrum(:,1:(floor(Ny/2)+1),:);
+
+                            testCase.verifyEqual(halfXLayout.extractCanonical(halfXLayout.rowsFromSpectrum(halfXSpectrum)),canonical,AbsTol=1e-12);
+                            testCase.verifyEqual(halfYLayout.extractCanonical(halfYLayout.rowsFromSpectrum(halfYSpectrum)),canonical,AbsTol=1e-12);
+
+                            fullRows = fullLayout.insertCanonical(fullLayout.allocateStorage(nBatch),canonical);
+                            halfXRows = halfXLayout.insertCanonical(halfXLayout.allocateStorage(nBatch),canonical);
+                            halfYRows = halfYLayout.insertCanonical(halfYLayout.allocateStorage(nBatch),canonical);
+                            testCase.verifyEqual(fullLayout.extractCanonical(fullRows),canonical,AbsTol=1e-12);
+                            testCase.verifyEqual(halfXLayout.extractCanonical(halfXRows),canonical,AbsTol=1e-12);
+                            testCase.verifyEqual(halfYLayout.extractCanonical(halfYRows),canonical,AbsTol=1e-12);
+
+                            fullReal = inverseFromFullLayout(fullLayout,fullRows,conjugateDimension,Nx,Ny);
+                            halfXReal = inverseFromHalfLayout(halfXLayout,halfXRows,Nx,Ny);
+                            halfYReal = inverseFromHalfLayout(halfYLayout,halfYRows,Nx,Ny);
+                            testCase.verifyEqual(halfXReal,fullReal,AbsTol=1e-12);
+                            testCase.verifyEqual(halfYReal,fullReal,AbsTol=1e-12);
+                        end
+                    end
+                end
+            end
+        end
+
+        function layoutMetadataAndStorageAreExact(testCase)
+            geometry = WVGeometryDoublyPeriodic([4000 3000],[10 7],Nz=5,shouldAntialias=false,shouldExcludeNyquist=false);
+            layouts = [WVFourierSpectrumLayout(geometry,"full") WVFourierSpectrumLayout(geometry,"hermitian-half",compressedDimension=1) WVFourierSpectrumLayout(geometry,"hermitian-half",compressedDimension=2)];
+            expectedShapes = [10 7;6 7;10 4];
+            for iLayout = 1:numel(layouts)
+                layout = layouts(iLayout);
+                testCase.verifyEqual(layout.storageShape,expectedShapes(iLayout,:));
+                testCase.verifyEqual(layout.storageRowCount,prod(expectedShapes(iLayout,:)));
+                testCase.verifyEqual(layout.mappingStrategy,"two-dimensional-rows");
+                ledger = layout.mappingLedger();
+                testCase.verifyEqual(layout.mappingBytes,sum([ledger.bytes]));
+                testCase.verifyTrue(all(string({ledger.class}) == "uint64"));
+                for entry = ledger
+                    testCase.verifyEqual(entry.bytes,8*prod(entry.shape));
+                end
+                rows = layout.allocateStorage(5);
+                testCase.verifySize(rows,[layout.storageRowCount 5]);
+                spectrum = layout.spectrumFromRows(rows);
+                testCase.verifyEqual(size(spectrum),[layout.storageShape 5]);
+                testCase.verifyEqual(layout.rowsFromSpectrum(spectrum),rows);
+                testCase.verifyTrue(all([layout.directStorageRows;layout.conjugatedStorageRows] >= 1));
+                testCase.verifyTrue(all([layout.directStorageRows;layout.conjugatedStorageRows] <= layout.storageRowCount));
+            end
+        end
+
+        function selfConjugateEntriesAreRealOnInsertion(testCase)
+            geometry = WVGeometryDoublyPeriodic([4000 3000],[8 6],Nz=2,shouldAntialias=false,shouldExcludeNyquist=false);
+            for compressedDimension = [1 2]
+                layout = WVFourierSpectrumLayout(geometry,"hermitian-half",compressedDimension=compressedDimension);
+                canonical = complex(randn(2,geometry.Nkl),randn(2,geometry.Nkl));
+                rows = layout.insertCanonical(layout.allocateStorage(2),canonical);
+                testCase.verifyEqual(imag(rows(layout.selfConjugateStorageRows,:)),zeros(numel(layout.selfConjugateStorageRows),2));
+            end
+        end
+
+        function invalidShapesAndConfigurationsAreRejected(testCase)
+            geometry = WVGeometryDoublyPeriodic([4000 3000],[8 6],Nz=2);
+            testCase.verifyError(@()WVFourierSpectrumLayout(geometry,"full",compressedDimension=1),"WaveVortexModel:InvalidFullSpectrumLayout");
+            testCase.verifyError(@()WVFourierSpectrumLayout(geometry,"hermitian-half"),"WaveVortexModel:InvalidHalfSpectrumLayout");
+            layout = WVFourierSpectrumLayout(geometry,"hermitian-half",compressedDimension=1);
+            testCase.verifyError(@()layout.extractCanonical(complex(zeros(layout.storageRowCount+1,2))),"WaveVortexModel:InvalidStoredSpectrumShape");
+            testCase.verifyError(@()layout.insertCanonical(layout.allocateStorage(2),complex(zeros(3,geometry.Nkl))),"WaveVortexModel:InvalidCanonicalSpectrumShape");
+            testCase.verifyError(@()layout.rowsFromSpectrum(complex(zeros(8,6,2))),"WaveVortexModel:InvalidStoredSpectrumShape");
+        end
+
+        function builtinUsesRowsAndPreservesLegacyMappings(testCase)
+            geometry = WVGeometryDoublyPeriodic([4000 3000],[16 12],Nz=5,shouldAntialias=false);
+            diagnostics = geometry.fourierSpectrumLayoutDiagnostics();
+            testCase.verifyEqual(diagnostics.storageType,"full");
+            testCase.verifyEqual(diagnostics.mappingStrategy,"two-dimensional-rows");
+            testCase.verifyFalse(diagnostics.legacyMappingsAreMaterialized);
+            testCase.verifyEqual(diagnostics.legacyMappingBytes,0);
+
+            rng(7100,"twister");
+            realInput = randn(16,12,5);
+            canonical = geometry.transformFromSpatialDomainWithFourier(realInput);
+            realOutput = geometry.transformToSpatialDomainWithFourier(canonical);
+            testCase.verifySize(canonical,[5 geometry.Nkl]);
+            testCase.verifySize(realOutput,[16 12 5]);
+            testCase.verifySize(geometry.fastTransform.complexBuffer,[16 12 5]);
+            diagnostics = geometry.fourierSpectrumLayoutDiagnostics();
+            testCase.verifyFalse(diagnostics.legacyMappingsAreMaterialized);
+
+            [expectedPrimary,expectedConjugate,expectedWVConjugate] = geometry.indicesFromWVGridToDFTGrid(5,isHalfComplex=true);
+            testCase.verifyEqual(geometry.dftPrimaryIndex,uint64(expectedPrimary));
+            testCase.verifyEqual(geometry.dftConjugateIndex,uint64(expectedConjugate));
+            testCase.verifyEqual(geometry.wvConjugateIndex,uint64(expectedWVConjugate));
+            diagnostics = geometry.fourierSpectrumLayoutDiagnostics();
+            testCase.verifyTrue(diagnostics.legacyMappingsAreMaterialized);
+            testCase.verifyEqual(diagnostics.legacyMappingBytes,8*(numel(expectedPrimary)+numel(expectedConjugate)+numel(expectedWVConjugate)));
+            testCase.verifyEqual(geometry.dftPrimaryIndex,uint64(expectedPrimary));
+        end
+
+        function builtinDefaultPathMatchesFrozenExpressions(testCase)
+            geometry = WVGeometryDoublyPeriodic([4000 3000],[16 12],Nz=5,shouldAntialias=false);
+            rng(7200,"twister");
+            realInput = randn(16,12,5);
+            fullSpectrum = fft(fft(realInput,16,1),12,2)/(16*12);
+            [primary,conjugate,wvConjugate] = geometry.indicesFromWVGridToDFTGrid(5,isHalfComplex=true);
+            expectedCanonical = reshape(fullSpectrum(primary),[5 geometry.Nkl]);
+            actualCanonical = geometry.transformFromSpatialDomainWithFourier(realInput);
+            testCase.verifyEqual(actualCanonical,expectedCanonical,AbsTol=1e-12);
+
+            expectedBuffer = complex(zeros(16,12,5));
+            expectedBuffer(primary) = expectedCanonical;
+            expectedBuffer(conjugate) = conj(expectedCanonical(wvConjugate));
+            expectedReal = ifft(ifft(expectedBuffer,16,1),12,2,"symmetric")*(16*12);
+            actualReal = geometry.transformToSpatialDomainWithFourier(actualCanonical);
+            testCase.verifyEqual(actualReal,expectedReal,AbsTol=1e-12);
+            testCase.verifyEqual(geometry.fastTransform.complexBuffer,expectedBuffer,AbsTol=1e-12);
+        end
+    end
+end
+
+function realOutput = inverseFromFullLayout(layout,rows,conjugateDimension,Nx,Ny)
+spectrum = layout.spectrumFromRows(rows);
+if conjugateDimension == 1
+    realOutput = ifft(ifft(spectrum,Ny,2),Nx,1,"symmetric")*(Nx*Ny);
+else
+    realOutput = ifft(ifft(spectrum,Nx,1),Ny,2,"symmetric")*(Nx*Ny);
+end
+end
+
+function realOutput = inverseFromHalfLayout(layout,rows,Nx,Ny)
+halfSpectrum = layout.spectrumFromRows(rows);
+fullSpectrum = expandHalfSpectrum(halfSpectrum,[Nx Ny],layout.compressedDimension);
+realOutput = ifft(ifft(fullSpectrum,Nx,1),Ny,2,"symmetric")*(Nx*Ny);
+end
+
+function fullSpectrum = expandHalfSpectrum(halfSpectrum,physicalShape,compressedDimension)
+Nx = physicalShape(1);
+Ny = physicalShape(2);
+nBatch = size(halfSpectrum,3);
+fullSpectrum = complex(zeros(Nx,Ny,nBatch));
+if compressedDimension == 1
+    fullSpectrum(1:size(halfSpectrum,1),:,:) = halfSpectrum;
+else
+    fullSpectrum(:,1:size(halfSpectrum,2),:) = halfSpectrum;
+end
+for iK = 1:Nx
+    for iL = 1:Ny
+        isStored = iK <= size(halfSpectrum,1) && iL <= size(halfSpectrum,2);
+        if ~isStored
+            conjugateK = mod(Nx-(iK-1),Nx)+1;
+            conjugateL = mod(Ny-(iL-1),Ny)+1;
+            fullSpectrum(iK,iL,:) = conj(fullSpectrum(conjugateK,conjugateL,:));
+        end
+    end
+end
+end

--- a/UnitTests/TestWVFourierSpectrumLayoutIntegrationBenchmark.m
+++ b/UnitTests/TestWVFourierSpectrumLayoutIntegrationBenchmark.m
@@ -1,0 +1,89 @@
+classdef TestWVFourierSpectrumLayoutIntegrationBenchmark < matlab.unittest.TestCase
+    properties
+        benchmarkFolder
+        temporaryFolder
+    end
+
+    methods (TestClassSetup)
+        function addBenchmarkPath(testCase)
+            repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            testCase.benchmarkFolder = fullfile(repositoryRoot,"Benchmarks");
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(testCase.benchmarkFolder));
+        end
+    end
+
+    methods (TestMethodSetup)
+        function createTemporaryFolder(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            testCase.temporaryFolder = string(fixture.Folder);
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function reducedRunComparesProductionWithFrozenReference(testCase)
+            caseId = "full-layout-64x48x17-antialias-0";
+            result = runWVFourierSpectrumLayoutIntegrationBenchmark(caseIds=caseId,shouldWriteArtifacts=false,runId="layout-integration-test");
+
+            testCase.verifyEqual(result.status,"complete");
+            testCase.verifyEqual(result.reference.issue,69);
+            testCase.verifyEqual(strlength(result.reference.sha256),64);
+            testCase.verifyTrue(result.readiness.passed);
+            testCase.verifyFalse(result.readiness.completeGateSet);
+            testCase.verifyEqual(result.readiness.gateCaseCount,0);
+            testCase.verifyEqual(result.operationIds,["extract" "insert-primary" "insert-conjugate" "insert-complete" "forward-complete" "inverse-complete"]);
+
+            benchmarkCase = result.cases;
+            testCase.verifyEqual(benchmarkCase.status,"complete");
+            testCase.verifyFalse(benchmarkCase.isGate);
+            testCase.verifyEqual(benchmarkCase.mappingStrategy,"two-dimensional-rows");
+            testCase.verifyEqual(benchmarkCase.storageShape,[64 48]);
+            testCase.verifyFalse(benchmarkCase.legacyMappingsAreMaterialized);
+            testCase.verifyEqual(benchmarkCase.legacyMappingBytes,0);
+            testCase.verifySize(benchmarkCase.warmupSchedules,[2 6]);
+            testCase.verifySize(benchmarkCase.sampleSchedules,[7 6]);
+            testCase.verifyEqual(numel(unique(benchmarkCase.sampleSchedules(1,:))),6);
+            testCase.verifyNotEqual(benchmarkCase.sampleSchedules(1,1),benchmarkCase.sampleSchedules(2,1));
+            for operation = benchmarkCase.operations
+                testCase.verifyNumElements(operation.rawSeconds,7);
+                testCase.verifyTrue(all(isfinite(operation.rawSeconds)));
+                testCase.verifyEqual(operation.medianSeconds,median(operation.rawSeconds),AbsTol=eps(operation.medianSeconds));
+                testCase.verifyGreaterThan(operation.referenceMedianSeconds,0);
+                testCase.verifyEqual(operation.relativeToReference,operation.medianSeconds/operation.referenceMedianSeconds,AbsTol=10*eps(operation.relativeToReference));
+                testCase.verifyLessThanOrEqual(operation.relativeError,1e-12);
+                testCase.verifyTrue(operation.correctnessPassed);
+                testCase.verifyFalse(operation.performanceGateApplies);
+                testCase.verifyTrue(operation.performancePassed);
+            end
+        end
+
+        function artifactsRoundTripAndStateIsRestored(testCase)
+            originalDirectory = pwd;
+            originalPath = path;
+            originalRng = rng;
+            outputDirectory = fullfile(testCase.temporaryFolder,"artifacts");
+            result = runWVFourierSpectrumLayoutIntegrationBenchmark(caseIds="full-layout-64x48x17-antialias-1",outputDirectory=outputDirectory,runId="layout-integration-artifact");
+
+            testCase.verifyTrue(isfile(fullfile(outputDirectory,"benchmark.json")));
+            testCase.verifyTrue(isfile(fullfile(outputDirectory,"summary.md")));
+            decoded = jsondecode(fileread(fullfile(outputDirectory,"benchmark.json")));
+            testCase.verifyEqual(string(decoded.runId),result.runId);
+            testCase.verifyEqual(string(decoded.cases.mappingStrategy),"two-dimensional-rows");
+            summary = string(fileread(fullfile(outputDirectory,"summary.md")));
+            testCase.verifySubstring(summary,"## Timing and frozen-baseline comparison");
+            testCase.verifySubstring(summary,"## Storage contract");
+            testCase.verifyEqual(pwd,originalDirectory);
+            testCase.verifyEqual(path,originalPath);
+            testCase.verifyEqual(rng,originalRng);
+        end
+
+        function invalidCaseRestoresState(testCase)
+            originalDirectory = pwd;
+            originalPath = path;
+            originalRng = rng;
+            testCase.verifyError(@()runWVFourierSpectrumLayoutIntegrationBenchmark(caseIds="missing-layout-case",shouldWriteArtifacts=false),"WaveVortexBenchmark:UnknownCase");
+            testCase.verifyEqual(pwd,originalDirectory);
+            testCase.verifyEqual(path,originalPath);
+            testCase.verifyEqual(rng,originalRng);
+        end
+    end
+end

--- a/docs/classes/transforms/wvtransformbarotropicqg/dftconjugateindex.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/dftconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftConjugateIndex
 
-index into the DFT grid of the conjugate of each WV mode
+legacy vertically replicated conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformbarotropicqg/dftprimaryindex.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/dftprimaryindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftPrimaryIndex
 
-index into the DFT grid of each WV mode
+legacy vertically replicated index into the active Fourier storage
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,3 +20,6 @@ index into the DFT grid of each WV mode
 + Class: `uint64`
 
 ## Discussion
+
+Materialized lazily for compatibility. Production transforms use
+WVFourierSpectrumLayout two-dimensional mappings instead.

--- a/docs/classes/transforms/wvtransformbarotropicqg/index.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/index.md
@@ -132,8 +132,8 @@ These items document internal implementation details and are not part of the pri
   + [`VA0`](/classes/transforms/wvtransformbarotropicqg/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 + Geometry and mode indexing
   + [`conjugateDimension`](/classes/transforms/wvtransformbarotropicqg/conjugatedimension.html) assumed conjugate dimension
-  + [`dftConjugateIndex`](/classes/transforms/wvtransformbarotropicqg/dftconjugateindex.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndex`](/classes/transforms/wvtransformbarotropicqg/dftprimaryindex.html) index into the DFT grid of each WV mode
+  + [`dftConjugateIndex`](/classes/transforms/wvtransformbarotropicqg/dftconjugateindex.html) legacy vertically replicated conjugate index
+  + [`dftPrimaryIndex`](/classes/transforms/wvtransformbarotropicqg/dftprimaryindex.html) legacy vertically replicated index into the active Fourier storage
   + [`indexFromKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
   + [`indexFromModeNumber`](/classes/transforms/wvtransformbarotropicqg/indexfrommodenumber.html)
   + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformbarotropicqg/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
@@ -160,7 +160,7 @@ These items document internal implementation details and are not part of the pri
   + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
   + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
   + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
-  + [`wvConjugateIndex`](/classes/transforms/wvtransformbarotropicqg/wvconjugateindex.html) index into the WV mode that matches the dftConjugateIndices
+  + [`wvConjugateIndex`](/classes/transforms/wvtransformbarotropicqg/wvconjugateindex.html) legacy vertically replicated WV conjugate index
 + Spectral transforms and operators
   + [`degreesOfFreedomForComplexMatrix`](/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforcomplexmatrix.html) a matrix with the number of degrees-of-freedom at each entry
   + [`degreesOfFreedomForRealMatrix`](/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforrealmatrix.html) a matrix with the number of degrees-of-freedom at each entry

--- a/docs/classes/transforms/wvtransformbarotropicqg/wvconjugateindex.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/wvconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  wvConjugateIndex
 
-index into the WV mode that matches the dftConjugateIndices
+legacy vertically replicated WV conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformboussinesq/dftconjugateindex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/dftconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftConjugateIndex
 
-index into the DFT grid of the conjugate of each WV mode
+legacy vertically replicated conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformboussinesq/dftprimaryindex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/dftprimaryindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftPrimaryIndex
 
-index into the DFT grid of each WV mode
+legacy vertically replicated index into the active Fourier storage
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,3 +20,6 @@ index into the DFT grid of each WV mode
 + Class: `uint64`
 
 ## Discussion
+
+Materialized lazily for compatibility. Production transforms use
+WVFourierSpectrumLayout two-dimensional mappings instead.

--- a/docs/classes/transforms/wvtransformboussinesq/index.md
+++ b/docs/classes/transforms/wvtransformboussinesq/index.md
@@ -204,8 +204,8 @@ These items document internal implementation details and are not part of the pri
 + Geometry and mode indexing
   + [`buildVerticalModeProjectionOperators`](/classes/transforms/wvtransformboussinesq/buildverticalmodeprojectionoperators.html)
   + [`conjugateDimension`](/classes/transforms/wvtransformboussinesq/conjugatedimension.html) assumed conjugate dimension
-  + [`dftConjugateIndex`](/classes/transforms/wvtransformboussinesq/dftconjugateindex.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndex`](/classes/transforms/wvtransformboussinesq/dftprimaryindex.html) index into the DFT grid of each WV mode
+  + [`dftConjugateIndex`](/classes/transforms/wvtransformboussinesq/dftconjugateindex.html) legacy vertically replicated conjugate index
+  + [`dftPrimaryIndex`](/classes/transforms/wvtransformboussinesq/dftprimaryindex.html) legacy vertically replicated index into the active Fourier storage
   + [`indexFromKLModeNumber`](/classes/transforms/wvtransformboussinesq/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
   + [`indexFromModeNumber`](/classes/transforms/wvtransformboussinesq/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
   + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformboussinesq/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
@@ -234,7 +234,7 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
   + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
   + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformboussinesq/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
-  + [`wvConjugateIndex`](/classes/transforms/wvtransformboussinesq/wvconjugateindex.html) index into the WV mode that matches the dftConjugateIndices
+  + [`wvConjugateIndex`](/classes/transforms/wvtransformboussinesq/wvconjugateindex.html) legacy vertically replicated WV conjugate index
 + Spectral transforms and operators
   + [`FMatrix`](/classes/transforms/wvtransformboussinesq/fmatrix.html) transformation matrix $$F_g$$
   + [`FinvMatrix`](/classes/transforms/wvtransformboussinesq/finvmatrix.html) transformation matrix $$F_g^{-1}$$

--- a/docs/classes/transforms/wvtransformboussinesq/wvconjugateindex.md
+++ b/docs/classes/transforms/wvtransformboussinesq/wvconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  wvConjugateIndex
 
-index into the WV mode that matches the dftConjugateIndices
+legacy vertically replicated WV conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformconstantstratification/dftconjugateindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/dftconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftConjugateIndex
 
-index into the DFT grid of the conjugate of each WV mode
+legacy vertically replicated conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformconstantstratification/dftprimaryindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/dftprimaryindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftPrimaryIndex
 
-index into the DFT grid of each WV mode
+legacy vertically replicated index into the active Fourier storage
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,3 +20,6 @@ index into the DFT grid of each WV mode
 + Class: `uint64`
 
 ## Discussion
+
+Materialized lazily for compatibility. Production transforms use
+WVFourierSpectrumLayout two-dimensional mappings instead.

--- a/docs/classes/transforms/wvtransformconstantstratification/index.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/index.md
@@ -196,8 +196,8 @@ These items document internal implementation details and are not part of the pri
 + Geometry and mode indexing
   + [`buildVerticalModeProjectionOperators`](/classes/transforms/wvtransformconstantstratification/buildverticalmodeprojectionoperators.html) Build the transformation matrices
   + [`conjugateDimension`](/classes/transforms/wvtransformconstantstratification/conjugatedimension.html) assumed conjugate dimension
-  + [`dftConjugateIndex`](/classes/transforms/wvtransformconstantstratification/dftconjugateindex.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndex`](/classes/transforms/wvtransformconstantstratification/dftprimaryindex.html) index into the DFT grid of each WV mode
+  + [`dftConjugateIndex`](/classes/transforms/wvtransformconstantstratification/dftconjugateindex.html) legacy vertically replicated conjugate index
+  + [`dftPrimaryIndex`](/classes/transforms/wvtransformconstantstratification/dftprimaryindex.html) legacy vertically replicated index into the active Fourier storage
   + [`indexFromKLModeNumber`](/classes/transforms/wvtransformconstantstratification/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
   + [`indexFromModeNumber`](/classes/transforms/wvtransformconstantstratification/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
   + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformconstantstratification/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
@@ -225,7 +225,7 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
   + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
   + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformconstantstratification/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
-  + [`wvConjugateIndex`](/classes/transforms/wvtransformconstantstratification/wvconjugateindex.html) index into the WV mode that matches the dftConjugateIndices
+  + [`wvConjugateIndex`](/classes/transforms/wvtransformconstantstratification/wvconjugateindex.html) legacy vertically replicated WV conjugate index
 + Spectral transforms and operators
   + [`CosineTransformBackMatrix`](/classes/transforms/wvtransformconstantstratification/cosinetransformbackmatrix.html) Discrete Cosine Transform (DCT-I) matrix
   + [`CosineTransformForwardMatrix`](/classes/transforms/wvtransformconstantstratification/cosinetransformforwardmatrix.html) Discrete Cosine Transform (DCT-I) matrix

--- a/docs/classes/transforms/wvtransformconstantstratification/wvconjugateindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wvconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  wvConjugateIndex
 
-index into the WV mode that matches the dftConjugateIndices
+legacy vertically replicated WV conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformhydrostatic/dftconjugateindex.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/dftconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftConjugateIndex
 
-index into the DFT grid of the conjugate of each WV mode
+legacy vertically replicated conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformhydrostatic/dftprimaryindex.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/dftprimaryindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftPrimaryIndex
 
-index into the DFT grid of each WV mode
+legacy vertically replicated index into the active Fourier storage
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,3 +20,6 @@ index into the DFT grid of each WV mode
 + Class: `uint64`
 
 ## Discussion
+
+Materialized lazily for compatibility. Production transforms use
+WVFourierSpectrumLayout two-dimensional mappings instead.

--- a/docs/classes/transforms/wvtransformhydrostatic/index.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/index.md
@@ -200,8 +200,8 @@ These items document internal implementation details and are not part of the pri
   + [`WAp`](/classes/transforms/wvtransformhydrostatic/wap.html)
 + Geometry and mode indexing
   + [`conjugateDimension`](/classes/transforms/wvtransformhydrostatic/conjugatedimension.html) assumed conjugate dimension
-  + [`dftConjugateIndex`](/classes/transforms/wvtransformhydrostatic/dftconjugateindex.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndex`](/classes/transforms/wvtransformhydrostatic/dftprimaryindex.html) index into the DFT grid of each WV mode
+  + [`dftConjugateIndex`](/classes/transforms/wvtransformhydrostatic/dftconjugateindex.html) legacy vertically replicated conjugate index
+  + [`dftPrimaryIndex`](/classes/transforms/wvtransformhydrostatic/dftprimaryindex.html) legacy vertically replicated index into the active Fourier storage
   + [`indexFromKLModeNumber`](/classes/transforms/wvtransformhydrostatic/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
   + [`indexFromModeNumber`](/classes/transforms/wvtransformhydrostatic/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
   + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformhydrostatic/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
@@ -230,7 +230,7 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
   + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
   + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformhydrostatic/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
-  + [`wvConjugateIndex`](/classes/transforms/wvtransformhydrostatic/wvconjugateindex.html) index into the WV mode that matches the dftConjugateIndices
+  + [`wvConjugateIndex`](/classes/transforms/wvtransformhydrostatic/wvconjugateindex.html) legacy vertically replicated WV conjugate index
 + Spectral transforms and operators
   + [`FMatrix`](/classes/transforms/wvtransformhydrostatic/fmatrix.html) transformation matrix $$F_g$$
   + [`FinvMatrix`](/classes/transforms/wvtransformhydrostatic/finvmatrix.html) transformation matrix $$F_g^{-1}$$

--- a/docs/classes/transforms/wvtransformhydrostatic/wvconjugateindex.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/wvconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  wvConjugateIndex
 
-index into the WV mode that matches the dftConjugateIndices
+legacy vertically replicated WV conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/dftconjugateindex.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/dftconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftConjugateIndex
 
-index into the DFT grid of the conjugate of each WV mode
+legacy vertically replicated conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/dftprimaryindex.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/dftprimaryindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dftPrimaryIndex
 
-index into the DFT grid of each WV mode
+legacy vertically replicated index into the active Fourier storage
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,3 +20,6 @@ index into the DFT grid of each WV mode
 + Class: `uint64`
 
 ## Discussion
+
+Materialized lazily for compatibility. Production transforms use
+WVFourierSpectrumLayout two-dimensional mappings instead.

--- a/docs/classes/transforms/wvtransformstratifiedqg/index.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/index.md
@@ -152,8 +152,8 @@ These items document internal implementation details and are not part of the pri
   + [`VA0`](/classes/transforms/wvtransformstratifiedqg/va0.html) matrix component that multiplies $$A_0$$ to compute $$\tilde{v}$$.
 + Geometry and mode indexing
   + [`conjugateDimension`](/classes/transforms/wvtransformstratifiedqg/conjugatedimension.html) assumed conjugate dimension
-  + [`dftConjugateIndex`](/classes/transforms/wvtransformstratifiedqg/dftconjugateindex.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndex`](/classes/transforms/wvtransformstratifiedqg/dftprimaryindex.html) index into the DFT grid of each WV mode
+  + [`dftConjugateIndex`](/classes/transforms/wvtransformstratifiedqg/dftconjugateindex.html) legacy vertically replicated conjugate index
+  + [`dftPrimaryIndex`](/classes/transforms/wvtransformstratifiedqg/dftprimaryindex.html) legacy vertically replicated index into the active Fourier storage
   + [`indexFromKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
   + [`indexFromModeNumber`](/classes/transforms/wvtransformstratifiedqg/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
   + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformstratifiedqg/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
@@ -182,7 +182,7 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
   + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
   + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformstratifiedqg/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
-  + [`wvConjugateIndex`](/classes/transforms/wvtransformstratifiedqg/wvconjugateindex.html) index into the WV mode that matches the dftConjugateIndices
+  + [`wvConjugateIndex`](/classes/transforms/wvtransformstratifiedqg/wvconjugateindex.html) legacy vertically replicated WV conjugate index
 + Spectral transforms and operators
   + [`FMatrix`](/classes/transforms/wvtransformstratifiedqg/fmatrix.html) transformation matrix $$F_g$$
   + [`FinvMatrix`](/classes/transforms/wvtransformstratifiedqg/finvmatrix.html) transformation matrix $$F_g^{-1}$$

--- a/docs/classes/transforms/wvtransformstratifiedqg/wvconjugateindex.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/wvconjugateindex.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  wvConjugateIndex
 
-index into the WV mode that matches the dftConjugateIndices
+legacy vertically replicated WV conjugate index
 
 > Developer documentation: this item describes internal implementation details.
 


### PR DESCRIPTION
Closes #70

Introduces the internal WVFourierSpectrumLayout contract for full, half-x, and half-y storage while preserving the canonical [Nz,Nkl] interface. The builtin adapter now uses the measured two-dimensional-row mapping, retains its persistent full spectrum, and materializes legacy Nz-replicated indices only on demand.

Verification:
- buildtool test:full — 616 passed
- canonical issue-70 integration gate — all four gate cases passed
- relative error — 0 in the canonical comparison
- legacy mapping bytes during production benchmark — 0

The implementation and canonical benchmark are separate commits; the artifact references source commit aeb158b7cdec79b686e9b997e5fb85c848e38278.