### PR TITLE
Fix documentation rendering regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,12 +99,33 @@ jobs:
             cd(sourceRoot);
             buildtool docs:check
 
+      - name: Build rendered website
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./source/docs
+          destination: ./rendered-site
+
+      - name: Verify rendered website
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            addpath(fullfile(pwd,"source","tools"));
+            validateRenderedWebsite(fullfile(pwd,"rendered-site"))
+
       - name: Upload generated documentation diagnostics
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: r2024b-generated-documentation
           path: ${{ runner.temp }}/wave-vortex-model-generated-docs
+          if-no-files-found: ignore
+
+      - name: Upload rendered website diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: r2024b-rendered-website
+          path: rendered-site
           if-no-files-found: ignore
 
       - name: Verify clean source checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,8 @@
 - initial mpm ci release
 
 ## [4.0.0](https://github.com/Energy-Pathways-Group/GLOceanKit/releases/tag/v4.0) - 2025-08-05
-- Added support for `WVForcing', a mechanism for adding arbitrary forcing to the model which also also the nonlinear fluxes to be automatically diagnosed.
-- Added `WVObservingSystems', a mechanism for adding user defined observing systems to the model, such as drifters, mooring, along-track altimetry.
+- Added support for `WVForcing`, a mechanism for adding arbitrary forcing to the model which also also the nonlinear fluxes to be automatically diagnosed.
+- Added `WVObservingSystems`, a mechanism for adding user defined observing systems to the model, such as drifters, mooring, along-track altimetry.
 
 ## [3.0.0](https://github.com/Energy-Pathways-Group/GLOceanKit/releases/tag/v3.0.0) - 2024-07-25
 - Full implemented non-hydrostatic forwards model, passing all unit tests.

--- a/Documentation/WebsiteDocumentation/acknowledgements.md
+++ b/Documentation/WebsiteDocumentation/acknowledgements.md
@@ -6,6 +6,8 @@ description: "Acknowledgements"
 permalink: /acknowledgements
 ---
 
+# Acknowledgements
+
 ## Developers & Contributors
 
 This project was primarily developed and is maintained by:

--- a/Documentation/WebsiteDocumentation/addons.md
+++ b/Documentation/WebsiteDocumentation/addons.md
@@ -6,6 +6,8 @@ description: Links to other useful tools that work with the WaveVortexModel
 permalink: /addons
 ---
 
+# Diagnostics & Add-ons
+
 ## Diagnostics
 
 We also have a suite of diagnostic tools that can be used to analyze model output. The [WVDiagnostics](https://energy-pathways-group.github.io/wave-vortex-model-diagnostics/) class is not as robust and user-friendly as the model itself, but you may find some useful starting points for your own analysis.

--- a/Documentation/WebsiteDocumentation/classes/index.md
+++ b/Documentation/WebsiteDocumentation/classes/index.md
@@ -6,5 +6,4 @@ has_children: true
 permalink: /classes
 ---
 
-
-
+# Class documentation

--- a/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/continuous-integration.md
@@ -19,7 +19,9 @@ The required workflow runs for every pull request, every update to `main`, and m
 | Documentation / MATLAB R2024b | `buildtool docs:check` |
 | Code Analyzer / MATLAB R2024b | `buildtool analyze` |
 
-The documentation job installs the authoring-only package `ClassDocumentation@1.3.0` explicitly before checking the committed site. Smoke tests, documentation verification, and Code Analyzer are required to merge into `main`. Branch protection requires the pull request branch to be current with `main` before those checks can satisfy the merge gate.
+The documentation job installs the authoring-only package `ClassDocumentation@1.3.0` explicitly before checking the committed Markdown. It then builds that exact tree with GitHub Pages' Jekyll action and validates the rendered HTML. This second stage catches malformed front matter, mathematical Markdown, expressions split across rendered table cells, or other source syntax that can pass a link check but disappear or remain raw in the deployed site. Valid math delimiters remain in the Jekyll output for browser-side MathJax. Failed rendered output is uploaded as a temporary diagnostic artifact and is never committed.
+
+Smoke tests, source-and-rendered documentation verification, and Code Analyzer are required to merge into `main`. Branch protection requires the pull request branch to be current with `main` before those checks can satisfy the merge gate.
 
 ## Extended checks
 

--- a/Documentation/WebsiteDocumentation/developers-guide/index.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/index.md
@@ -6,5 +6,4 @@ has_children: true
 permalink: /developers-guide
 ---
 
-
-
+# Developers guide

--- a/Documentation/WebsiteDocumentation/developers-guide/operations-and-variables.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/operations-and-variables.md
@@ -12,7 +12,7 @@ This document is meant to articulate the internal logic used for operations and 
 
 First note that `variableAnnotationNameMap` contains *all* variables, even those which are properties on the class. The `operationVariableNameMap` contains the subset of those that needs to be computed with an operation.
 
-Second note that `operationVariableNameMap
+Second note that `operationVariableNameMap`
 
 There are a couple of important points,
 1. One operation can produce many variables.

--- a/Documentation/WebsiteDocumentation/developers-guide/property-and-method-types.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/property-and-method-types.md
@@ -7,7 +7,7 @@ mathjax: true
 
 #  Annotations
 
-The methods and properties of the `WVTransform' are divided into 5 categories, depending on their functionality. These properties or methods are then annotated appropriately.
+The methods and properties of the `WVTransform` are divided into 5 categories, depending on their functionality. These properties or methods are then annotated appropriately.
 
 - *Dimension* are independent coordinate axes, such as $$x$$, $$t$$, or $$k$$ and are annotated with `WVDimensionAnnotation`.
 - *Properties* are fixed attributes of the `WVTransform` that are never time-dependent. The `WVPropertyAnnotation` class is used to annotate properties.
@@ -20,4 +20,3 @@ We need to distinguish between variables that have direct method (or even proper
 - *Methods* are everything else, and use `WVAnnotation` to annotate their functionality.
 
 If you are building a subclass the `WVTransform`, it is important to know that there are two types of variables: those that are directly computed by the class, and those that result from a `WVOperation`.
-

--- a/Documentation/WebsiteDocumentation/developers-guide/style-guide.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/style-guide.md
@@ -20,8 +20,6 @@ mathjax: true
 
 All classes can be initialized directly, or from NetCDF file and thus also written to file. 
 
-- A class has a single initialization method (constructor), such as ` WaveVortexTransformConstantStratification(Lxyz, Nxyz, N0, options)`
+- A class has a single initialization method (constructor), such as `WaveVortexTransformConstantStratification(Lxyz, Nxyz, N0, options)`
 - Each class has an instance method `-writeToFilePath` and `-writeToNetCDFFile`.
-- Each class has a class method (or static method) to re-initialize from file, e.g., `-transformFromFilePath' and `transformFromNetCDFFile'.
-
-
+- Each class has a class method (or static method) to re-initialize from file, e.g., `-transformFromFilePath` and `transformFromNetCDFFile`.

--- a/Documentation/WebsiteDocumentation/mathematical-introduction/index.md
+++ b/Documentation/WebsiteDocumentation/mathematical-introduction/index.md
@@ -6,4 +6,6 @@ has_children: true
 permalink: /mathematical-introduction
 ---
 
+# Mathematical introduction
+
 This document summarizes the linear transformations that form the foundation of the wave-vortex model.

--- a/Documentation/WebsiteDocumentation/users-guide/adding-forcing.md
+++ b/Documentation/WebsiteDocumentation/users-guide/adding-forcing.md
@@ -132,12 +132,12 @@ Custom forcing subclasses derive from `WVForcing`, declare one or more `WVForcin
 For example, horizontal and vertical spectral damping can be expressed as
 
 $$
-
-and implemented by overriding `addSpectralForcing`. Hydrostatic and nonhydrostatic physical forcing instead override `addHydrostaticSpatialForcing` or `addNonhydrostaticSpatialForcing`. QG forcing uses the potential-vorticity variants of the spatial, spectral, or amplitude interfaces.
-
-The transform validates that a forcing stage is compatible with its dynamics, applies stages in physical–spectral–amplitude order, and uses `priority` to order forcing objects within one stage. See [`WVForcing`](/classes/forcing/wvforcing/) and [`WVForcingType`](/classes/forcing/wvforcing/) before implementing a subclass.
     \begin{align}
         \partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
         \partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}
     \end{align}
 $$
+
+and implemented by overriding `addSpectralForcing`. Hydrostatic and nonhydrostatic physical forcing instead override `addHydrostaticSpatialForcing` or `addNonhydrostaticSpatialForcing`. QG forcing uses the potential-vorticity variants of the spatial, spectral, or amplitude interfaces.
+
+The transform validates that a forcing stage is compatible with its dynamics, applies stages in physical–spectral–amplitude order, and uses `priority` to order forcing objects within one stage. See [`WVForcing`](/classes/forcing/wvforcing/) and [`WVForcingType`](/classes/forcing/wvforcing/) before implementing a subclass.

--- a/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file-advanced.md
+++ b/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file-advanced.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Reading and writing files: advanced topics
+title: "Reading and writing files: advanced topics"
 parent: User guide
 mathjax: true
 nav_order: 12

--- a/Documentation/WebsiteDocumentation/users-guide/using-the-wvtransform.md
+++ b/Documentation/WebsiteDocumentation/users-guide/using-the-wvtransform.md
@@ -21,7 +21,7 @@ A `WVTransform` represents a fluid state in physical and wave–vortex coordinat
 | [`WVTransformStratifiedQG`](/classes/transforms/wvtransformstratifiedqg/) | Three-dimensional stratified quasigeostrophic flow. |
 | [`WVTransformBarotropicQG`](/classes/transforms/wvtransformbarotropicqg/) | Two-dimensional equivalent-barotropic quasigeostrophic flow. |
 
-All rotating transforms accept latitude in either hemisphere for $$5 \leq |\mathrm{latitude}| \leq 85$$ degrees.
+All rotating transforms accept latitude in either hemisphere for $$5 \leq \lvert\mathrm{latitude}\rvert \leq 85$$ degrees.
 
 ## Construct a transform
 

--- a/UnitTests/TestDocumentationTools.m
+++ b/UnitTests/TestDocumentationTools.m
@@ -79,7 +79,7 @@ classdef TestDocumentationTools < matlab.unittest.TestCase
             mkdir(classFolder);
             testCase.writeText(fullfile(classFolder,"index.md"),[
                 "---"
-                "title: ExampleClass"
+                "title: ""ExampleClass"""
                 "parent: Transforms"
                 "---"
                 "## Declaration"
@@ -121,6 +121,86 @@ classdef TestDocumentationTools < matlab.unittest.TestCase
             report = validateWebsiteDocumentation(root,ShouldFail=false,ShouldCheckHierarchy=false);
             testCase.verifyFalse(report.IsValid);
             testCase.verifyTrue(any(contains(report.Diagnostics,"historical truncated")));
+        end
+
+        function validFrontMatterAndMathMarkupPass(testCase)
+            root = fullfile(testCase.temporaryFolder,"valid-source");
+            mkdir(root);
+            testCase.writeText(fullfile(root,"index.md"),[
+                "---"
+                "layout: default"
+                "title: ""Guide: details"""
+                "---"
+                "# Guide"
+                "The literal delimiter `$$` may be discussed in code."
+                "Inline $$5 \\leq \\lvert x\\rvert \\leq 85$$ math."
+                "$$"
+                "\\begin{align}"
+                "x &= y"
+                "\\end{align}"
+                "$$"
+                ]);
+
+            report = validateWebsiteDocumentation(root,ShouldFail=false,ShouldCheckHierarchy=false,ShouldCheckGeneratedContent=false);
+            testCase.verifyTrue(report.IsValid,strjoin(report.Diagnostics,newline));
+        end
+
+        function malformedFrontMatterAndMathAreReported(testCase)
+            root = fullfile(testCase.temporaryFolder,"invalid-source");
+            mkdir(root);
+            testCase.writeText(fullfile(root,"unterminated.md"),["---"; "title: Missing end"]);
+            testCase.writeText(fullfile(root,"unquoted.md"),["---"; "title: Guide: details"; "---"]);
+            testCase.writeText(fullfile(root,"malformed-quote.md"),["---"; "title: ""Missing end"; "---"]);
+            testCase.writeText(fullfile(root,"duplicate.md"),["---"; "title: First"; "title: Second"; "---"]);
+            testCase.writeText(fullfile(root,"unbalanced-display.md"),["# Display"; "$$"; "x=y"]);
+            testCase.writeText(fullfile(root,"display-markdown.md"),["# Display"; "$$"; "[link](target.md) and `code`"; "## Heading"; "$$"]);
+            testCase.writeText(fullfile(root,"inline-bar.md"),"Inline $$|x|$$ math.");
+
+            report = validateWebsiteDocumentation(root,ShouldFail=false,ShouldCheckHierarchy=false,ShouldCheckGeneratedContent=false);
+            expected = [
+                "unterminated front matter"
+                "must be quoted"
+                "malformed quoted front matter value"
+                "duplicate front matter key"
+                "unbalanced display-math"
+                "Markdown link or image appears inside"
+                "Markdown backticks appear inside"
+                "Markdown heading appears inside"
+                "unescaped vertical bar"
+                ];
+            for diagnostic = expected'
+                testCase.verifyTrue(any(contains(report.Diagnostics,diagnostic)),"Missing diagnostic: " + diagnostic);
+            end
+        end
+
+        function renderedWebsiteRejectsRawMarkup(testCase)
+            root = fullfile(testCase.temporaryFolder,"rendered-site");
+            mkdir(root);
+            testCase.writeText(fullfile(root,"index.html"),'<main><h1>Home</h1><p>Rendered $$x$$ content.</p><code>`[example](target)`</code></main>');
+            cleanReport = validateRenderedWebsite(root,ShouldFail=false);
+            testCase.verifyTrue(cleanReport.IsValid,strjoin(cleanReport.Diagnostics,newline));
+
+            testCase.writeText(fullfile(root,"missing-main.html"),'<h1>Missing main</h1>');
+            testCase.writeText(fullfile(root,"missing-heading.html"),'<main><p>Missing heading</p></main>');
+            testCase.writeText(fullfile(root,"raw-math.html"),'<main><h1>Math</h1><p>Unbalanced $$x</p></main>');
+            testCase.writeText(fullfile(root,"table-math.html"),'<main><h1>Table</h1><table><tr><td>$$|x</td><td>|$$</td></tr></table></main>');
+            testCase.writeText(fullfile(root,"raw-link.html"),'<main><h1>Link</h1><p>[link](target.html)</p></main>');
+            testCase.writeText(fullfile(root,"raw-fence.html"),'<main><h1>Fence</h1><p>```matlab</p></main>');
+            testCase.writeText(fullfile(root,"raw-backtick.html"),'<main><h1>Code</h1><p>`code`</p></main>');
+
+            report = validateRenderedWebsite(root,ShouldFail=false);
+            expected = [
+                "missing main content element"
+                "missing level-one heading"
+                "unbalanced MathJax delimiters"
+                "MathJax expression is split across rendered table cells"
+                "raw Markdown link or image"
+                "raw fenced-code marker"
+                "raw Markdown backtick"
+                ];
+            for diagnostic = expected'
+                testCase.verifyTrue(any(contains(report.Diagnostics,diagnostic)),"Missing diagnostic: " + diagnostic);
+            end
         end
 
         function treeComparisonClassifiesDifferences(testCase)

--- a/UnitTests/TestUserDocumentation.m
+++ b/UnitTests/TestUserDocumentation.m
@@ -154,6 +154,27 @@ classdef TestUserDocumentation < matlab.unittest.TestCase
             advancedGuide = testCase.readCanonical(fullfile("users-guide","reading-and-writing-to-file-advanced.md"));
             testCase.verifyMatches(advancedGuide,'(?m)^title: "Reading and writing files: advanced topics"$');
             testCase.verifyMatches(advancedGuide,'(?m)^parent: User guide$');
+
+            landingPages = [
+                "acknowledgements.md"
+                "addons.md"
+                fullfile("classes","index.md")
+                fullfile("developers-guide","index.md")
+                fullfile("mathematical-introduction","index.md")
+                ];
+            for landingPage = landingPages'
+                testCase.verifyMatches(testCase.readCanonical(landingPage),'(?m)^# \S');
+            end
+
+            operationsGuide = testCase.readCanonical(fullfile("developers-guide","operations-and-variables.md"));
+            propertyGuide = testCase.readCanonical(fullfile("developers-guide","property-and-method-types.md"));
+            styleGuide = testCase.readCanonical(fullfile("developers-guide","style-guide.md"));
+            changelog = testCase.readFile(fullfile(testCase.repositoryRoot,"CHANGELOG.md"));
+            testCase.verifySubstring(operationsGuide,"`operationVariableNameMap`");
+            testCase.verifySubstring(propertyGuide,"`WVTransform`");
+            testCase.verifySubstring(styleGuide,"`WaveVortexTransformConstantStratification(Lxyz, Nxyz, N0, options)`");
+            testCase.verifySubstring(changelog,"`WVForcing`");
+            testCase.verifySubstring(changelog,"`WVObservingSystems`");
         end
     end
 

--- a/UnitTests/TestUserDocumentation.m
+++ b/UnitTests/TestUserDocumentation.m
@@ -135,6 +135,26 @@ classdef TestUserDocumentation < matlab.unittest.TestCase
             testCase.verifyEqual(canonicalCNAME,"wavevortexmodel.org");
             testCase.verifyEqual(generatedCNAME,canonicalCNAME);
         end
+
+        function renderingSensitiveMarkupIsWellFormed(testCase)
+            transformGuide = testCase.readCanonical(fullfile("users-guide","using-the-wvtransform.md"));
+            testCase.verifySubstring(transformGuide,'$$5 \leq \lvert\mathrm{latitude}\rvert \leq 85$$');
+            testCase.verifyFalse(contains(transformGuide,'|\mathrm{latitude}|'));
+
+            forcingGuide = testCase.readCanonical(fullfile("users-guide","adding-forcing.md"));
+            equationStart = strfind(forcingGuide,"$$" + newline + "    \begin{align}");
+            equationEnd = strfind(forcingGuide,"    \end{align}" + newline + "$$");
+            explanatoryText = strfind(forcingGuide,"and implemented by overriding `addSpectralForcing`");
+            testCase.verifyNumElements(equationStart,1);
+            testCase.verifyNumElements(equationEnd,1);
+            testCase.verifyNumElements(explanatoryText,1);
+            testCase.verifyLessThan(equationStart,equationEnd);
+            testCase.verifyLessThan(equationEnd,explanatoryText);
+
+            advancedGuide = testCase.readCanonical(fullfile("users-guide","reading-and-writing-to-file-advanced.md"));
+            testCase.verifyMatches(advancedGuide,'(?m)^title: "Reading and writing files: advanced topics"$');
+            testCase.verifyMatches(advancedGuide,'(?m)^parent: User guide$');
+        end
     end
 
     methods (Access=private)

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -6,6 +6,8 @@ description: "Acknowledgements"
 permalink: /acknowledgements
 ---
 
+# Acknowledgements
+
 ## Developers & Contributors
 
 This project was primarily developed and is maintained by:

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -6,6 +6,8 @@ description: Links to other useful tools that work with the WaveVortexModel
 permalink: /addons
 ---
 
+# Diagnostics & Add-ons
+
 ## Diagnostics
 
 We also have a suite of diagnostic tools that can be used to analyze model output. The [WVDiagnostics](https://energy-pathways-group.github.io/wave-vortex-model-diagnostics/) class is not as robust and user-friendly as the model itself, but you may find some useful starting points for your own analysis.

--- a/docs/classes/index.md
+++ b/docs/classes/index.md
@@ -6,5 +6,4 @@ has_children: true
 permalink: /classes
 ---
 
-
-
+# Class documentation

--- a/docs/developers-guide/continuous-integration.md
+++ b/docs/developers-guide/continuous-integration.md
@@ -19,7 +19,9 @@ The required workflow runs for every pull request, every update to `main`, and m
 | Documentation / MATLAB R2024b | `buildtool docs:check` |
 | Code Analyzer / MATLAB R2024b | `buildtool analyze` |
 
-The documentation job installs the authoring-only package `ClassDocumentation@1.3.0` explicitly before checking the committed site. Smoke tests, documentation verification, and Code Analyzer are required to merge into `main`. Branch protection requires the pull request branch to be current with `main` before those checks can satisfy the merge gate.
+The documentation job installs the authoring-only package `ClassDocumentation@1.3.0` explicitly before checking the committed Markdown. It then builds that exact tree with GitHub Pages' Jekyll action and validates the rendered HTML. This second stage catches malformed front matter, mathematical Markdown, expressions split across rendered table cells, or other source syntax that can pass a link check but disappear or remain raw in the deployed site. Valid math delimiters remain in the Jekyll output for browser-side MathJax. Failed rendered output is uploaded as a temporary diagnostic artifact and is never committed.
+
+Smoke tests, source-and-rendered documentation verification, and Code Analyzer are required to merge into `main`. Branch protection requires the pull request branch to be current with `main` before those checks can satisfy the merge gate.
 
 ## Extended checks
 

--- a/docs/developers-guide/index.md
+++ b/docs/developers-guide/index.md
@@ -6,5 +6,4 @@ has_children: true
 permalink: /developers-guide
 ---
 
-
-
+# Developers guide

--- a/docs/developers-guide/operations-and-variables.md
+++ b/docs/developers-guide/operations-and-variables.md
@@ -12,7 +12,7 @@ This document is meant to articulate the internal logic used for operations and 
 
 First note that `variableAnnotationNameMap` contains *all* variables, even those which are properties on the class. The `operationVariableNameMap` contains the subset of those that needs to be computed with an operation.
 
-Second note that `operationVariableNameMap
+Second note that `operationVariableNameMap`
 
 There are a couple of important points,
 1. One operation can produce many variables.

--- a/docs/developers-guide/property-and-method-types.md
+++ b/docs/developers-guide/property-and-method-types.md
@@ -7,7 +7,7 @@ mathjax: true
 
 #  Annotations
 
-The methods and properties of the `WVTransform' are divided into 5 categories, depending on their functionality. These properties or methods are then annotated appropriately.
+The methods and properties of the `WVTransform` are divided into 5 categories, depending on their functionality. These properties or methods are then annotated appropriately.
 
 - *Dimension* are independent coordinate axes, such as $$x$$, $$t$$, or $$k$$ and are annotated with `WVDimensionAnnotation`.
 - *Properties* are fixed attributes of the `WVTransform` that are never time-dependent. The `WVPropertyAnnotation` class is used to annotate properties.
@@ -20,4 +20,3 @@ We need to distinguish between variables that have direct method (or even proper
 - *Methods* are everything else, and use `WVAnnotation` to annotate their functionality.
 
 If you are building a subclass the `WVTransform`, it is important to know that there are two types of variables: those that are directly computed by the class, and those that result from a `WVOperation`.
-

--- a/docs/developers-guide/style-guide.md
+++ b/docs/developers-guide/style-guide.md
@@ -20,8 +20,6 @@ mathjax: true
 
 All classes can be initialized directly, or from NetCDF file and thus also written to file. 
 
-- A class has a single initialization method (constructor), such as ` WaveVortexTransformConstantStratification(Lxyz, Nxyz, N0, options)`
+- A class has a single initialization method (constructor), such as `WaveVortexTransformConstantStratification(Lxyz, Nxyz, N0, options)`
 - Each class has an instance method `-writeToFilePath` and `-writeToNetCDFFile`.
-- Each class has a class method (or static method) to re-initialize from file, e.g., `-transformFromFilePath' and `transformFromNetCDFFile'.
-
-
+- Each class has a class method (or static method) to re-initialize from file, e.g., `-transformFromFilePath` and `transformFromNetCDFFile`.

--- a/docs/mathematical-introduction/index.md
+++ b/docs/mathematical-introduction/index.md
@@ -6,4 +6,6 @@ has_children: true
 permalink: /mathematical-introduction
 ---
 
+# Mathematical introduction
+
 This document summarizes the linear transformations that form the foundation of the wave-vortex model.

--- a/docs/users-guide/adding-forcing.md
+++ b/docs/users-guide/adding-forcing.md
@@ -132,12 +132,12 @@ Custom forcing subclasses derive from `WVForcing`, declare one or more `WVForcin
 For example, horizontal and vertical spectral damping can be expressed as
 
 $$
-
-and implemented by overriding `addSpectralForcing`. Hydrostatic and nonhydrostatic physical forcing instead override `addHydrostaticSpatialForcing` or `addNonhydrostaticSpatialForcing`. QG forcing uses the potential-vorticity variants of the spatial, spectral, or amplitude interfaces.
-
-The transform validates that a forcing stage is compatible with its dynamics, applies stages in physical–spectral–amplitude order, and uses `priority` to order forcing objects within one stage. See [`WVForcing`](/classes/forcing/wvforcing/) and [`WVForcingType`](/classes/forcing/wvforcing/) before implementing a subclass.
     \begin{align}
         \partial_t A_\pm^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_\pm^{k\ell j} - \nu_z \lambda_j^{-2} A_\pm^{k\ell j} \\
         \partial_t A_0^{k\ell j} =& - \nu (k^2 + \ell^2 ) A_0^{k\ell j} - \nu_z \lambda_j^{-2} A_0^{k\ell j}
     \end{align}
 $$
+
+and implemented by overriding `addSpectralForcing`. Hydrostatic and nonhydrostatic physical forcing instead override `addHydrostaticSpatialForcing` or `addNonhydrostaticSpatialForcing`. QG forcing uses the potential-vorticity variants of the spatial, spectral, or amplitude interfaces.
+
+The transform validates that a forcing stage is compatible with its dynamics, applies stages in physical–spectral–amplitude order, and uses `priority` to order forcing objects within one stage. See [`WVForcing`](/classes/forcing/wvforcing/) and [`WVForcingType`](/classes/forcing/wvforcing/) before implementing a subclass.

--- a/docs/users-guide/reading-and-writing-to-file-advanced.md
+++ b/docs/users-guide/reading-and-writing-to-file-advanced.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Reading and writing files: advanced topics
+title: "Reading and writing files: advanced topics"
 parent: User guide
 mathjax: true
 nav_order: 12

--- a/docs/users-guide/using-the-wvtransform.md
+++ b/docs/users-guide/using-the-wvtransform.md
@@ -21,7 +21,7 @@ A `WVTransform` represents a fluid state in physical and wave–vortex coordinat
 | [`WVTransformStratifiedQG`](/classes/transforms/wvtransformstratifiedqg/) | Three-dimensional stratified quasigeostrophic flow. |
 | [`WVTransformBarotropicQG`](/classes/transforms/wvtransformbarotropicqg/) | Two-dimensional equivalent-barotropic quasigeostrophic flow. |
 
-All rotating transforms accept latitude in either hemisphere for $$5 \leq |\mathrm{latitude}| \leq 85$$ degrees.
+All rotating transforms accept latitude in either hemisphere for $$5 \leq \lvert\mathrm{latitude}\rvert \leq 85$$ degrees.
 
 ## Construct a transform
 

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -77,8 +77,8 @@ nav_order: 100
 - initial mpm ci release
 
 ## [4.0.0](https://github.com/Energy-Pathways-Group/GLOceanKit/releases/tag/v4.0) - 2025-08-05
-- Added support for `WVForcing', a mechanism for adding arbitrary forcing to the model which also also the nonlinear fluxes to be automatically diagnosed.
-- Added `WVObservingSystems', a mechanism for adding user defined observing systems to the model, such as drifters, mooring, along-track altimetry.
+- Added support for `WVForcing`, a mechanism for adding arbitrary forcing to the model which also also the nonlinear fluxes to be automatically diagnosed.
+- Added `WVObservingSystems`, a mechanism for adding user defined observing systems to the model, such as drifters, mooring, along-track altimetry.
 
 ## [3.0.0](https://github.com/Energy-Pathways-Group/GLOceanKit/releases/tag/v3.0.0) - 2024-07-25
 - Full implemented non-hydrostatic forwards model, passing all unit tests.

--- a/tools/README.md
+++ b/tools/README.md
@@ -21,6 +21,8 @@ buildtool docs:build
 buildtool docs:check
 ```
 
-`docs:build` generates into clean staging storage, validates internal routes and generated navigation, and transactionally replaces `docs`. `docs:check` performs the same build in temporary storage and fails on any difference from the committed tree without changing the checkout. Both tasks print the resolved ClassDocumentation version and path before generation.
+`docs:build` generates into clean staging storage, validates front matter, mathematical Markdown, internal routes, and generated navigation, and transactionally replaces `docs`. `docs:check` performs the same build in temporary storage and fails on any difference from the committed tree without changing the checkout. Both tasks print the resolved ClassDocumentation version and path before generation.
+
+The required documentation CI job also builds the committed tree with GitHub Pages' Jekyll action and runs `validateRenderedWebsite` on the resulting HTML. The rendered-site validator requires ordinary content pages to contain their main content and heading, rejects source Markdown that survived rendering outside code elements, and detects malformed MathJax delimiters or expressions split across table cells. Valid delimiters remain in Jekyll output for browser-side MathJax. Rendered output is temporary diagnostic data and is never committed.
 
 The OceanKit release workflow continues to call `build_website_documentation(rootDir=...)`. That entry point uses the same exact dependency check, clean generator, validation, and transactional replacement as `docs:build`.

--- a/tools/validateRenderedWebsite.m
+++ b/tools/validateRenderedWebsite.m
@@ -1,0 +1,72 @@
+function report = validateRenderedWebsite(renderedRoot,options)
+arguments
+    renderedRoot (1,1) string
+    options.ShouldFail (1,1) logical = true
+end
+
+htmlFiles = renderedHTMLFiles(renderedRoot);
+diagnostics = strings(0,1);
+for relativePath = htmlFiles'
+    pageText = string(fileread(fullfile(renderedRoot,relativePath)));
+    mainMatch = regexp(pageText,'(?is)<main(?:\s[^>]*)?>(?<content>.*?)</main>','names','once');
+    if isempty(mainMatch)
+        diagnostics(end+1,1) = relativePath + ": missing main content element";
+        continue
+    end
+    mainHTML = string(mainMatch.content);
+    if isempty(regexp(mainHTML,'(?is)<h1(?:\s|>)','once'))
+        diagnostics(end+1,1) = relativePath + ": missing level-one heading";
+    end
+
+    visibleHTML = mainHTML;
+    excludedElements = ["script","style","pre","code"];
+    for element = excludedElements
+        expression = "(?is)<" + element + "(?:\\s[^>]*)?>.*?</" + element + ">";
+        visibleHTML = regexprep(visibleHTML,expression,' ');
+    end
+    visibleText = regexprep(visibleHTML,'(?is)<[^>]+>',' ');
+    if mod(numel(strfind(visibleText,"$$")),2) ~= 0
+        diagnostics(end+1,1) = relativePath + ": unbalanced MathJax delimiters remain in rendered content";
+    end
+    tableMatches = regexp(visibleHTML,'(?is)<table(?:\s[^>]*)?>.*?</table>','match');
+    for iTable = 1:numel(tableMatches)
+        cells = regexp(tableMatches{iTable},'(?is)<t[dh](?:\s[^>]*)?>(?<content>.*?)</t[dh]>','names');
+        for iCell = 1:numel(cells)
+            if mod(numel(strfind(cells(iCell).content,"$$")),2) ~= 0
+                diagnostics(end+1,1) = relativePath + ": MathJax expression is split across rendered table cells";
+                break
+            end
+        end
+    end
+    if ~isempty(regexp(visibleText,'!?\[[^\]]*\]\([^)]*\)','once'))
+        diagnostics(end+1,1) = relativePath + ": raw Markdown link or image remains in rendered content";
+    end
+    if contains(visibleText,"```")
+        diagnostics(end+1,1) = relativePath + ": raw fenced-code marker remains in rendered content";
+    elseif contains(visibleText,"`")
+        diagnostics(end+1,1) = relativePath + ": raw Markdown backtick remains in rendered content";
+    end
+end
+
+diagnostics = sort(unique(diagnostics));
+report = struct("Files",htmlFiles,"Diagnostics",diagnostics,"IsValid",isempty(diagnostics));
+fprintf("Rendered documentation validation: files=%d, failures=%d\n",numel(htmlFiles),numel(diagnostics));
+if ~isempty(diagnostics)
+    fprintf("  %s\n",strjoin(diagnostics,newline + "  "));
+end
+if options.ShouldFail && ~report.IsValid
+    error("WaveVortexModel:InvalidRenderedDocumentation","Rendered documentation contains %d validation failure(s).",numel(diagnostics));
+end
+end
+
+function files = renderedHTMLFiles(rootFolder)
+entries = dir(fullfile(rootFolder,"**","*.html"));
+entries = entries(~[entries.isdir]);
+rootPrefix = char(rootFolder + filesep);
+files = strings(numel(entries),1);
+for iEntry = 1:numel(entries)
+    fullPath = fullfile(entries(iEntry).folder,entries(iEntry).name);
+    files(iEntry) = replace(string(fullPath(numel(rootPrefix)+1:end)),filesep,"/");
+end
+files = sort(unique(files));
+end

--- a/tools/validateWebsiteDocumentation.m
+++ b/tools/validateWebsiteDocumentation.m
@@ -14,6 +14,10 @@ markdownFiles = files(endsWith(files,".md"));
 for relativePath = markdownFiles'
     pagePath = fullfile(documentationRoot,relativePath);
     pageText = string(fileread(pagePath));
+    sourceDiagnostics = documentationSourceDiagnostics(pageText);
+    for diagnostic = sourceDiagnostics'
+        diagnostics(end+1,1) = relativePath + ": " + diagnostic;
+    end
     malformedDiagnostics = malformedLinkDiagnostics(pageText);
     for diagnostic = malformedDiagnostics'
         diagnostics(end+1,1) = relativePath + ": " + diagnostic;
@@ -26,21 +30,6 @@ for relativePath = markdownFiles'
         end
     end
 end
-
-function diagnostics = malformedLinkDiagnostics(pageText)
-diagnostics = strings(0,1);
-markdownStarts = regexp(pageText,'!?\[[^\]]*\]\(','start');
-markdownLinks = regexp(pageText,'!?\[[^\]]*\]\([^)]*\)','start');
-if numel(markdownStarts) ~= numel(markdownLinks)
-    diagnostics(end+1,1) = "malformed Markdown link or image";
-end
-htmlStarts = regexp(pageText,'(?i:href|src)\s*=\s*["'']','start');
-htmlLinks = regexp(pageText,'(?i:href|src)\s*=\s*(?:"[^"]*"|''[^'']*'')','start');
-if numel(htmlStarts) ~= numel(htmlLinks)
-    diagnostics(end+1,1) = "malformed HTML href or src attribute";
-end
-end
-
 if options.ShouldCheckHierarchy
     diagnostics = [diagnostics; hierarchyDiagnostics(documentationRoot,markdownFiles)];
 end
@@ -246,11 +235,141 @@ end
 end
 
 function value = frontMatterValue(pageText,name)
+[frontMatter,didFindFrontMatter] = frontMatterBlock(pageText);
+if ~didFindFrontMatter
+    value = "";
+    return
+end
 expression = '(?m)^' + regexptranslate("escape",name) + ':\s*(?<value>[^\r\n]+)\s*$';
-match = regexp(pageText,expression,'names','once');
+match = regexp(frontMatter,expression,'names','once');
 if isempty(match)
     value = "";
 else
     value = strtrim(string(match.value));
+    if strlength(value) >= 2 && ((startsWith(value,'"') && endsWith(value,'"')) || (startsWith(value,"'") && endsWith(value,"'")))
+        quotedValue = char(value);
+        value = string(quotedValue(2:end-1));
+    end
+end
+end
+
+function [frontMatter,didFindFrontMatter] = frontMatterBlock(pageText)
+normalizedText = replace(pageText,sprintf("\r\n"),newline);
+lines = split(normalizedText,newline);
+if isempty(lines) || strip(lines(1)) ~= "---"
+    didFindFrontMatter = false;
+    frontMatter = "";
+    return
+end
+closingDelimiter = find(strip(lines(2:end)) == "---",1,"first") + 1;
+didFindFrontMatter = ~isempty(closingDelimiter);
+if didFindFrontMatter
+    frontMatter = strjoin(lines(2:closingDelimiter-1),newline);
+else
+    frontMatter = "";
+end
+end
+
+function diagnostics = documentationSourceDiagnostics(pageText)
+diagnostics = [frontMatterDiagnostics(pageText); mathMarkupDiagnostics(pageText)];
+end
+
+function diagnostics = frontMatterDiagnostics(pageText)
+diagnostics = strings(0,1);
+if ~startsWith(pageText,"---" + newline) && ~startsWith(pageText,"---" + sprintf("\r\n"))
+    return
+end
+
+[frontMatter,didFindFrontMatter] = frontMatterBlock(pageText);
+if ~didFindFrontMatter
+    diagnostics(end+1,1) = "unterminated front matter";
+    return
+end
+
+lines = splitlines(frontMatter);
+frontMatterKeys = strings(0,1);
+for line = lines'
+    frontMatterLine = strip(line);
+    if frontMatterLine == "" || startsWith(frontMatterLine,"#")
+        continue
+    end
+    match = regexp(frontMatterLine,'^(?<key>[A-Za-z_][A-Za-z0-9_-]*):(?<value>.*)$','names','once');
+    if isempty(match)
+        diagnostics(end+1,1) = "malformed front matter line: " + frontMatterLine;
+        continue
+    end
+    key = string(match.key);
+    value = strtrim(string(match.value));
+    if any(frontMatterKeys == key)
+        diagnostics(end+1,1) = "duplicate front matter key " + key;
+    end
+    frontMatterKeys(end+1,1) = key;
+
+    isDoubleQuoted = startsWith(value,'"') && endsWith(value,'"');
+    isSingleQuoted = startsWith(value,"'") && endsWith(value,"'");
+    if xor(startsWith(value,'"'),endsWith(value,'"')) || xor(startsWith(value,"'"),endsWith(value,"'"))
+        diagnostics(end+1,1) = "malformed quoted front matter value for key " + key;
+    end
+    if contains(value,": ") && ~isDoubleQuoted && ~isSingleQuoted
+        diagnostics(end+1,1) = "front matter value containing ': ' must be quoted for key " + key;
+    end
+end
+end
+
+function diagnostics = mathMarkupDiagnostics(pageText)
+diagnostics = strings(0,1);
+mathScanText = maskMathDelimitersInCode(pageText);
+delimiterLocations = strfind(mathScanText,"$$");
+if mod(numel(delimiterLocations),2) ~= 0
+    diagnostics(end+1,1) = "unbalanced display-math delimiters";
+else
+    for iDelimiter = 1:2:numel(delimiterLocations)
+        openingLocation = delimiterLocations(iDelimiter);
+        closingLocation = delimiterLocations(iDelimiter+1);
+        mathContent = extractBetween(pageText,openingLocation+2,closingLocation-1);
+        isInline = ~contains(extractBetween(mathScanText,openingLocation,closingLocation+1),newline);
+        if isInline
+            if ~isempty(regexp(mathContent,'(?<!\\)\|','once'))
+                diagnostics(end+1,1) = "inline math contains an unescaped vertical bar; use \\lvert and \\rvert";
+            end
+            continue
+        end
+        if contains(mathContent,"```")
+            diagnostics(end+1,1) = "fenced code appears inside a display-math block";
+        elseif contains(mathContent,"`")
+            diagnostics(end+1,1) = "Markdown backticks appear inside a display-math block";
+        end
+        if ~isempty(regexp(mathContent,'!?\[[^\]]*\]\([^)]*\)','once'))
+            diagnostics(end+1,1) = "Markdown link or image appears inside a display-math block";
+        end
+        if ~isempty(regexp(mathContent,'(?m)^\s*#{1,6}\s+\S','once'))
+            diagnostics(end+1,1) = "Markdown heading appears inside a display-math block";
+        end
+    end
+end
+diagnostics = unique(diagnostics,'stable');
+end
+
+function maskedText = maskMathDelimitersInCode(pageText)
+maskedText = char(pageText);
+[codeStarts,codeEnds] = regexp(maskedText,'(?s)```.*?```|(?m)(?<!`)`[^`\r\n]*`(?!`)','start','end');
+for iCode = 1:numel(codeStarts)
+    codeText = maskedText(codeStarts(iCode):codeEnds(iCode));
+    maskedText(codeStarts(iCode):codeEnds(iCode)) = strrep(codeText,'$$','  ');
+end
+maskedText = string(maskedText);
+end
+
+function diagnostics = malformedLinkDiagnostics(pageText)
+diagnostics = strings(0,1);
+markdownStarts = regexp(pageText,'!?\[[^\]]*\]\(','start');
+markdownLinks = regexp(pageText,'!?\[[^\]]*\]\([^)]*\)','start');
+if numel(markdownStarts) ~= numel(markdownLinks)
+    diagnostics(end+1,1) = "malformed Markdown link or image";
+end
+htmlStarts = regexp(pageText,'(?i:href|src)\s*=\s*["'']','start');
+htmlLinks = regexp(pageText,'(?i:href|src)\s*=\s*(?:"[^"]*"|''[^'']*'')','start');
+if numel(htmlStarts) ~= numel(htmlLinks)
+    diagnostics(end+1,1) = "malformed HTML href or src attribute";
 end
 end


### PR DESCRIPTION
## Summary

- repair malformed forcing math, latitude notation, and advanced-guide front matter
- validate source front matter and mathematical Markdown during documentation builds
- build the committed site with GitHub Pages Jekyll and validate the rendered HTML in required CI

## Local verification

- focused documentation tests
- docs:build and docs:check twice
- smoke: 127 passed
- full: 620 passed
- exhaustive: 2,440 passed
- Code Analyzer: zero blocking findings
- changed-file analysis: no warning or error findings
- workflow YAML, whitespace, scope, artifact, and checkout-cleanliness checks

The PR's Documentation / MATLAB R2024b job is the authoritative Jekyll rendering check.