### PR TITLE
[FFTW backend] Add backend selection and geometry integration

### DIFF
--- a/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
+++ b/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
@@ -266,11 +266,6 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
                 notPrimaryCoeffs = notPrimaryCoeffs | WVGeometryDoublyPeriodic.maskForConjugateFourierCoefficients(self.Nk_dft,self.Nl_dft,conjugateDimension=self.conjugateDimension);
             end
             
-            % In theory we might have to re-do this for the FFTW grid, but
-            % because of Matlabs index ordering, it's the same.
-            % e.g., we do not need
-            %   notPrimaryCoeffs = notPrimaryCoeffs(:,1:(self.Ny/2 + 1));
-            %   [K,L] = ndgrid(self.k_dft,self.l_dft(1:(self.Ny/2 + 1)));
             [K,L] = ndgrid(self.k_dft,self.l_dft);
             Kh = sqrt(K.*K + L.*L);
 
@@ -280,48 +275,13 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
             % Now remove all the coefficients that we didn't want
             self.dftPrimaryIndices2D = self.dftPrimaryIndices2D(sortedMultiIndex(:,1) == 0);
 
-            canUseFFTW = false;
-            if options.fastTransform == "fftw"
-                if ~exist('RealToComplexTransform','class')
-                    warning("Unable to find the class RealToComplexTransform. Reverting to built-in transforms.");
-                else
-                    if exist('fftw_dft2','file') == 3
-                        fprintf('fftw_dft2 found. Will use fftw.\n')
-                        canUseFFTW = true;
-                    else
-                        try
-                            RealToComplexTransform.makeMexFiles();
-                            canUseFFTW = true;
-                        catch
-                            warning('Unable to compile fftw_dft2. Will use builtins.\n')
-                        end
-                    end
-                end
-            end
+            self.dftConjugateIndices2D = WVGeometryDoublyPeriodic.indicesOfFourierConjugates(self.Nx,self.Ny);
+            self.dftConjugateIndices2D = self.dftConjugateIndices2D(self.dftPrimaryIndices2D);
+            self.k = K(self.dftPrimaryIndices2D);
+            self.l = L(self.dftPrimaryIndices2D);
 
-            if canUseFFTW == true
-                self.dftConjugateIndices2D = WVGeometryDoublyPeriodic.indicesOfFourierConjugates(self.Nx,self.Ny);
-                self.dftConjugateIndices2D = self.dftConjugateIndices2D(self.dftPrimaryIndices2D);
-                self.k = K(self.dftPrimaryIndices2D);
-                self.l = L(self.dftPrimaryIndices2D);
-
-                self.fastTransform = WVFastTransformDoublyPeriodicFFTW(self,self.Nz);
-            else
-                self.dftConjugateIndices2D = WVGeometryDoublyPeriodic.indicesOfFourierConjugates(self.Nx,self.Ny);
-                self.dftConjugateIndices2D = self.dftConjugateIndices2D(self.dftPrimaryIndices2D);
-                self.k = K(self.dftPrimaryIndices2D);
-                self.l = L(self.dftPrimaryIndices2D);
-
-                self.fastTransform = WVFastTransformDoublyPeriodicMatlab(self,self.Nz);
-            end
-
-
-            % self.fastTransform = WVFastTransformDoublyPeriodicMatlab(self,self.Nz);
-
-            % if exist('RealToComplexTransform', 'class')
-            % 
-            %     fprintf("successfully loaded fftw.\n");
-            % end
+            factory = WVFastTransformDoublyPeriodicFactory();
+            self.fastTransform = factory.create(self,self.Nz,options.fastTransform);
         end
 
         function x = get.x(self)

--- a/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
@@ -41,6 +41,7 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
                 Lxyz (1,3) double {mustBePositive}
                 Nxyz (1,3) double {mustBePositive}
                 geomOptions.shouldAntialias (1,1) logical = true
+                geomOptions.fastTransform (1,1) string {mustBeMember(geomOptions.fastTransform,["builtin","fftw"])} = "builtin"
                 stratOptions.Nj (1,1) double {mustBePositive}
                 stratOptions.rho0 (1,1) double {mustBePositive} = 1025
                 stratOptions.planetaryRadius (1,1) double = 6.371e6

--- a/@WVTransform/waveVortexTransformFromFile.m
+++ b/@WVTransform/waveVortexTransformFromFile.m
@@ -31,19 +31,28 @@ function [wvt,ncfile] = waveVortexTransformFromFile(path,options)
 % - Parameter path: path to a NetCDF file
 % - Parameter iTime: (optional) time index to initialize from (default 1).
 % - Parameter shouldReadOnly: (optional) open the returned NetCDFFile read-only (default true).
+% - Parameter fastTransform: (optional) runtime backend for constant-stratification files, `"builtin"` (default) or `"fftw"`.
 % - Returns wvt: an instance of a WVTransform subclass
 % - Returns ncfile: a caller-owned NetCDFFile instance pointing to the file
 arguments (Input)
     path char {mustBeFile}
     options.iTime (1,1) double {mustBePositive} = 1
     options.shouldReadOnly logical = true
+    options.fastTransform (1,1) string {mustBeMember(options.fastTransform,["builtin","fftw"])} = "builtin"
 end
 arguments (Output)
     wvt WVTransform
     ncfile NetCDFFile
 end
 wvtClassName = transformClassNameFromFile(path);
-[wvt,ncfile] = feval(strcat(wvtClassName,'.waveVortexTransformFromFile'),path,'iTime',options.iTime,'shouldReadOnly',options.shouldReadOnly);
+if options.fastTransform == "fftw" && wvtClassName ~= "WVTransformConstantStratification"
+    error("WVTransform:UnsupportedFastTransform","fastTransform=""fftw"" is supported only for WVTransformConstantStratification files.");
+end
+if wvtClassName == "WVTransformConstantStratification"
+    [wvt,ncfile] = feval(strcat(wvtClassName,'.waveVortexTransformFromFile'),path,'iTime',options.iTime,'shouldReadOnly',options.shouldReadOnly,'fastTransform',options.fastTransform);
+else
+    [wvt,ncfile] = feval(strcat(wvtClassName,'.waveVortexTransformFromFile'),path,'iTime',options.iTime,'shouldReadOnly',options.shouldReadOnly);
+end
 
 if nargout < 2
     ncfile.close();

--- a/@WVTransformConstantStratification/WVTransformConstantStratification.m
+++ b/@WVTransformConstantStratification/WVTransformConstantStratification.m
@@ -84,12 +84,14 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
             % - Parameter options.isHydrostatic: use hydrostatic dynamics; default `false`
             % - Parameter options.latitude: latitude in the supported domain; default `33`
             % - Parameter options.shouldAntialias: exclude quadratically aliased modes; default `true`
+            % - Parameter options.fastTransform: horizontal transform backend, `"builtin"` (default) or explicitly requested `"fftw"`
             % - Parameter options.rho0: reference density in kilograms per cubic meter; default `1025`
             % - Returns wvt: new `WVTransformConstantStratification` instance
             arguments
                 Lxyz (1,3) double {mustBePositive}
                 Nxyz (1,3) double {mustBePositive}
                 options.shouldAntialias (1,1) logical = true
+                options.fastTransform (1,1) string {mustBeMember(options.fastTransform,["builtin","fftw"])} = "builtin"
 
                 options.N0 (1,1) double {mustBePositive} = 5.2e-3
                 options.rho0 (1,1) double {mustBePositive} = 1025
@@ -172,6 +174,7 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
                 optionArgs{2*i-1} = names{i};
                 optionArgs{2*i} = self.(names{i});
             end
+            optionArgs(end+1:end+2) = {'fastTransform',self.fastTransform.backendIdentifier};
             wvtX2 = WVTransformConstantStratification([self.Lx self.Ly self.Lz],m,optionArgs{:});
             wvtX2.shouldUseTrueNoMotionProfile = self.shouldUseTrueNoMotionProfile;
             forcing = WVForcing.empty(0,length(self.forcing));
@@ -198,6 +201,7 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
                     optionArgs{2*i} = false;
                 end
             end
+            optionArgs(end+1:end+2) = {'fastTransform',self.fastTransform.backendIdentifier};
             wvt2 = WVTransformConstantStratification([self.Lx self.Ly self.Lz],[self.Nx self.Ny self.Nz],optionArgs{:});
             wvt2.shouldUseTrueNoMotionProfile = self.shouldUseTrueNoMotionProfile;
             wvt2.removeAllForcing();
@@ -439,10 +443,12 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
             % - Parameter path: path to a NetCDF file
             % - Parameter iTime: (optional) time index to initialize from (default 1)
             % - Parameter shouldReadOnly: (optional) open the returned NetCDFFile read-only (default true)
+            % - Parameter fastTransform: (optional) runtime horizontal backend selection; default `"builtin"`
             arguments (Input)
                 path char {mustBeFile}
                 options.iTime (1,1) double {mustBePositive} = 1
                 options.shouldReadOnly logical = true
+                options.fastTransform (1,1) string {mustBeMember(options.fastTransform,["builtin","fftw"])} = "builtin"
             end
             arguments (Output)
                 wvt WVTransform
@@ -450,7 +456,7 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
             end
             ncfile = NetCDFFile(path,shouldReadOnly=options.shouldReadOnly);
             try
-                wvt = WVTransformConstantStratification.transformFromGroup(ncfile);
+                wvt = WVTransformConstantStratification.transformFromGroup(ncfile,fastTransform=options.fastTransform);
                 wvt.initFromNetCDFFile(ncfile,iTime=options.iTime,shouldDisplayInit=1);
                 wvt.initForcingFromNetCDFFile(ncfile);
             catch exception
@@ -465,15 +471,18 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
         end
 
 
-        function wvt = transformFromGroup(group)
+        function wvt = transformFromGroup(group,options)
             arguments (Input)
                 group NetCDFGroup {mustBeNonempty}
+                options.fastTransform (1,1) string {mustBeMember(options.fastTransform,["builtin","fftw"])} = "builtin"
             end
             arguments (Output)
                 wvt WVTransform {mustBeNonempty}
             end  
-            [Lxy, Nxy, options] = WVTransformConstantStratification.requiredPropertiesForTransformFromGroup(group);
-            wvt = WVTransformConstantStratification(Lxy,Nxy,options{:});
+            requestedBackend = options.fastTransform;
+            [Lxyz, Nxyz, constructorOptions] = WVTransformConstantStratification.requiredPropertiesForTransformFromGroup(group);
+            constructorOptions(end+1:end+2) = {'fastTransform',requestedBackend};
+            wvt = WVTransformConstantStratification(Lxyz,Nxyz,constructorOptions{:});
         end
 
     end

--- a/Benchmarks/createWaveVortexBenchmarkTransform.m
+++ b/Benchmarks/createWaveVortexBenchmarkTransform.m
@@ -4,25 +4,34 @@ arguments
     benchmarkCase (1,1) struct
     backendId (1,1) string = "builtin"
 end
-if backendId ~= "builtin"
-    error("WaveVortexBenchmark:UnsupportedBackend","Backend %s is not registered for transform construction.",backendId);
-end
-
 switch benchmarkCase.transformId
     case "constant-nonhydrostatic"
-        wvt = WVTransformConstantStratification(benchmarkCase.Lxyz,benchmarkCase.Nxyz,isHydrostatic=false,shouldAntialias=benchmarkCase.shouldAntialias);
+        wvt = WVTransformConstantStratification(benchmarkCase.Lxyz,benchmarkCase.Nxyz,isHydrostatic=false,shouldAntialias=benchmarkCase.shouldAntialias,fastTransform=backendId);
     case "constant-hydrostatic"
-        wvt = WVTransformConstantStratification(benchmarkCase.Lxyz,benchmarkCase.Nxyz,isHydrostatic=true,shouldAntialias=benchmarkCase.shouldAntialias);
+        wvt = WVTransformConstantStratification(benchmarkCase.Lxyz,benchmarkCase.Nxyz,isHydrostatic=true,shouldAntialias=benchmarkCase.shouldAntialias,fastTransform=backendId);
     case "hydrostatic"
+        requireBuiltinBackend(backendId,benchmarkCase.transformId);
         wvt = WVTransformHydrostatic(benchmarkCase.Lxyz,benchmarkCase.Nxyz,N2=@benchmarkN2,shouldAntialias=benchmarkCase.shouldAntialias);
     case "boussinesq"
+        requireBuiltinBackend(backendId,benchmarkCase.transformId);
         wvt = WVTransformBoussinesq(benchmarkCase.Lxyz,benchmarkCase.Nxyz,N2=@benchmarkN2,shouldAntialias=benchmarkCase.shouldAntialias);
     case "stratified-qg"
+        requireBuiltinBackend(backendId,benchmarkCase.transformId);
         wvt = WVTransformStratifiedQG(benchmarkCase.Lxyz,benchmarkCase.Nxyz,N2=@benchmarkN2,shouldAntialias=benchmarkCase.shouldAntialias);
     case "barotropic-qg"
+        requireBuiltinBackend(backendId,benchmarkCase.transformId);
         wvt = WVTransformBarotropicQG(benchmarkCase.Lxyz,benchmarkCase.Nxyz,shouldAntialias=benchmarkCase.shouldAntialias);
     otherwise
         error("WaveVortexBenchmark:UnknownTransform","Unknown transform ID %s.",benchmarkCase.transformId);
+end
+if wvt.fastTransform.backendIdentifier ~= backendId
+    error("WaveVortexBenchmark:RequestedBackendUnavailable","Requested benchmark backend %s, but the constructed transform is using %s.",backendId,wvt.fastTransform.backendIdentifier);
+end
+end
+
+function requireBuiltinBackend(backendId,transformId)
+if backendId ~= "builtin"
+    error("WaveVortexBenchmark:UnsupportedBackend","Backend %s is not supported for transform family %s.",backendId,transformId);
 end
 end
 

--- a/Benchmarks/waveVortexBenchmarkBackends.m
+++ b/Benchmarks/waveVortexBenchmarkBackends.m
@@ -3,7 +3,9 @@ function backends = waveVortexBenchmarkBackends(backendIds)
 arguments
     backendIds (1,:) string = "builtin"
 end
-registry = struct("id","builtin","description","MATLAB builtin WaveVortex transform implementation");
+registry = [ ...
+    struct("id","builtin","description","MATLAB builtin WaveVortex transform implementation") ...
+    struct("id","fftw","description","Optional FFTWTransforms half-x horizontal implementation")];
 unknownIds = setdiff(backendIds,string({registry.id}));
 if ~isempty(unknownIds)
     error("WaveVortexBenchmark:UnknownBackend","Unknown benchmark backend: %s.",strjoin(unknownIds,", "));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added `FFTWTransforms ^1.0.2` and an explicitly opt-in `fastTransform="fftw"` path for constant-stratification transforms. Backend discovery, validated local building, and safe fallback now pass through one layout-neutral factory; builtin remains the default and persisted files do not encode machine capability.
 - Replaced vertically replicated horizontal Fourier mappings with compact two-dimensional row mappings while preserving the canonical WaveVortex coefficients. On the Apple M5 Max/R2026a reference run, complete builtin forward transforms were 1.06x–2.00x faster and inverse transforms were 1.81x–3.58x faster across the `[256 256 65]` and `[512 512 129]` gate cases with antialiasing on and off; numerical results remained equivalent within the benchmark tolerance. See the issue #70 `transform-layout-integration-v1` artifact for the machine-specific measurements.
 - Rewrote the README, homepage, installation instructions, and user guidance around the current `WVTransform` and `WVModel` workflows; completed the NetCDF conventions guide; linked the canonical wavevortexmodel.org site prominently; and adopted the Avenir-first website typography while retaining search.
 - Reorganized the generated API reference around user tasks, moved implementation machinery into Developer Topics, replaced release-status jargon with direct descriptions of capabilities and limitations, and restored authored scientific context, coefficient-occupancy tables, and design rationale.

--- a/Documentation/WebsiteDocumentation/developers-guide/fourier-storage-layout.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/fourier-storage-layout.md
@@ -75,6 +75,14 @@ This contract makes mutation explicit without claiming that MATLAB will always u
 
 The adapter intentionally continues to use MATLAB's one-dimensional FFT implementation for `diffX` and `diffY`. Issue #74 owns the separate complete-call derivative comparison.
 
+## Backend selection
+
+`WVFastTransformDoublyPeriodicFactory` is the boundary between canonical geometry construction and backend-specific storage. `WVGeometryDoublyPeriodic` first completes the WV mode ordering, wavenumbers, and conjugate relationships. It then asks the factory for either the builtin full-complex adapter or the FFTW half-x adapter. Geometry construction never probes a MEX gateway and never changes coefficient ordering for a backend.
+
+The builtin path performs no FFTW discovery. For an explicit FFTW request, the factory queries `FFTWBackend.capabilities()`, validates the MATLAB-bundled r2c/c2r library identity, numerical self-tests, half-x ownership record, and lazy preserving-inverse scratch contract. If the modules are not ready but can be built, it makes one local build attempt and queries capabilities again. An unsuccessful request produces one actionable warning and a working builtin adapter.
+
+Each adapter exposes `backendIdentifier` so developer tools and benchmarks can verify which implementation actually executed. Benchmark code treats fallback as an unavailable FFTW candidate rather than labeling builtin measurements as FFTW.
+
 ## Developer contract
 
 The class is visible so backend developers can inspect its API and generated documentation. It is sealed and read-only because storage layouts are value-like descriptions, not extension points. A new backend should normally use the reshape and mapping methods. It may use the mapping properties directly when complete-expression benchmarks show that a specialized gather or assignment is materially better.

--- a/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file.md
+++ b/Documentation/WebsiteDocumentation/users-guide/reading-and-writing-to-file.md
@@ -30,6 +30,15 @@ Restore the transform through the static factory. The one-output form closes its
 wvtRestored = WVTransform.waveVortexTransformFromFile('transform.nc');
 ```
 
+Horizontal backend selection is runtime-only and is not written into the NetCDF file. Restoring a constant-stratification transform therefore uses builtin transforms by default, regardless of the backend used when the file was written. Request the optional backend again when appropriate for the current machine:
+
+```matlab
+wvtRestored = WVTransform.waveVortexTransformFromFile( ...
+    'transform.nc',fastTransform="fftw");
+```
+
+If FFTWTransforms is unavailable or fails validation, restoration continues with builtin transforms after one warning. Other transform families reject an FFTW restoration request.
+
 Pass additional registered variable names to `writeToFile` when physical fields or diagnostics should be stored alongside the reconstructable state:
 
 ```matlab

--- a/Documentation/WebsiteDocumentation/users-guide/supported-features.md
+++ b/Documentation/WebsiteDocumentation/users-guide/supported-features.md
@@ -20,7 +20,9 @@ WaveVortexModel provides five transform families together with model integration
 | `WVTransformStratifiedQG` | Stratified quasigeostrophic flow. |
 | `WVTransformBarotropicQG` | Equivalent-barotropic quasigeostrophic flow. |
 
-The rotating transforms accept either hemisphere for `5 <= abs(latitude) <= 85`, including the endpoints. Horizontal grids may contain independently chosen positive even or odd grid counts. The built-in MATLAB FFT implementation is used by the documented transform constructors.
+The rotating transforms accept either hemisphere for `5 <= abs(latitude) <= 85`, including the endpoints. Horizontal grids may contain independently chosen positive even or odd grid counts. The built-in MATLAB FFT implementation remains the default.
+
+Constant-stratification transforms also accept the experimental opt-in `fastTransform="fftw"`. This uses the source-only `FFTWTransforms ^1.0.2` package and locally built MEX modules only when its MATLAB-bundled r2c/c2r capability, ownership, and numerical checks pass. An unavailable explicit request emits one warning and continues with builtin transforms. The active implementation is available to developers as `wvt.fastTransform.backendIdentifier`. Variable-stratification and quasigeostrophic transforms remain builtin-only.
 
 Mode/index mappings accept scalars and column vectors. Resolution conversion and explicit antialiasing preserve coefficients identified by common integer mode numbers and initialize newly introduced modes to zero. Energy and, where defined, enstrophy agree between spectral and spatial representations within the transform discretization tolerance.
 
@@ -70,4 +72,4 @@ Custom operations and annotated variables use `WVOperation` and `WVVariableAnnot
 
 Optimization Toolbox is optional. `WVNoMotionProfileOperation` uses `lsqnonlin` when it is available and otherwise uses `fminsearch` with an advisory warning.
 
-FFTW selection and the low-level barotropic FINUFFT path remain development machinery. They are not selected through the documented transform constructors or public interpolation options, and FINUFFT is not a required package dependency.
+FFTWTransforms is a direct source dependency, but its compiled backend is optional and currently validated only for MATLAB R2026a on `maca64`. DCT-I/DST-I and derivative dispatch remain future milestone work. The low-level barotropic FINUFFT path remains development machinery and FINUFFT is not a required package dependency.

--- a/FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m
+++ b/FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m
@@ -75,6 +75,7 @@ classdef WVFastTransformDoublyPeriodicFFTW < WVFastTransformDoublyPeriodic
                 options.forwardMappingMethod (1,1) string {mustBeMember(options.forwardMappingMethod,["layout-methods","specialized-rows"])} = "layout-methods"
                 options.inverseMappingMethod (1,1) string {mustBeMember(options.inverseMappingMethod,["layout-methods","specialized-rows"])} = "specialized-rows"
             end
+            self.backendIdentifier = "fftw";
             self.wvg = wvg;
             self.Nz = Nz;
             self.forwardMappingMethod = options.forwardMappingMethod;

--- a/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/WVFastTransformDoublyPeriodicMatlab.m
+++ b/FastTransforms/@WVFastTransformDoublyPeriodicMatlab/WVFastTransformDoublyPeriodicMatlab.m
@@ -14,6 +14,7 @@ classdef WVFastTransformDoublyPeriodicMatlab < WVFastTransformDoublyPeriodic
 
     methods
         function self = WVFastTransformDoublyPeriodicMatlab(wvg,Nz)
+            self.backendIdentifier = "builtin";
             self.wvg = wvg;
             self.Nz=Nz;
             self.fourierStorageLayout = WVFourierStorageLayout(wvg,"full-complex");

--- a/FastTransforms/WVFastTransformDoublyPeriodic.m
+++ b/FastTransforms/WVFastTransformDoublyPeriodic.m
@@ -1,5 +1,11 @@
 classdef WVFastTransformDoublyPeriodic < handle
     properties (SetAccess=protected)
+        % Stable identifier for the active horizontal-transform backend.
+        %
+        % - Topic: Developer internals
+        % - Developer: true
+        backendIdentifier (1,1) string
+
         fourierStorageLayout
     end
 

--- a/FastTransforms/WVFastTransformDoublyPeriodicFactory.m
+++ b/FastTransforms/WVFastTransformDoublyPeriodicFactory.m
@@ -1,0 +1,275 @@
+classdef WVFastTransformDoublyPeriodicFactory < handle
+    % Select and construct a doubly periodic horizontal-transform backend.
+    %
+    % This developer-facing factory keeps optional FFTW package discovery,
+    % capability validation, local compilation, and fallback behavior out of
+    % the geometry classes. The canonical WV grid is complete before the
+    % factory is called; the selected adapter owns its Fourier storage layout.
+    %
+    % `"builtin"` never queries FFTWTransforms. An explicit `"fftw"` request
+    % accepts only the validated MATLAB-bundled half-x r2c/c2r contract from
+    % FFTWTransforms 1.0.2 or later. If required, one local build is attempted
+    % before the capabilities are queried again. An unavailable request emits
+    % one warning and returns the builtin adapter.
+    %
+    % ```matlab
+    % factory = WVFastTransformDoublyPeriodicFactory();
+    % [adapter,selection] = factory.create(geometry,Nz,"fftw");
+    % ```
+    %
+    % Protected service methods are narrow test seams. This class is developer
+    % infrastructure rather than an end-user modeling or extension API.
+    %
+    % - Topic: Developer internals
+    % - Declaration: classdef WVFastTransformDoublyPeriodicFactory
+
+    methods
+        function [adapter,selection] = create(self,geometry,Nz,requestedBackend)
+            % Construct the requested backend or a safe builtin fallback.
+            %
+            % - Topic: Developer internals
+            % - Parameter geometry: completed doubly periodic WV geometry
+            % - Parameter Nz: number of horizontal-transform batches
+            % - Parameter requestedBackend: `"builtin"` or `"fftw"`
+            % - Returns adapter: selected `WVFastTransformDoublyPeriodic`
+            % - Returns selection: structured selection and fallback record
+            % - Developer: true
+            arguments
+                self (1,1) WVFastTransformDoublyPeriodicFactory
+                geometry (1,1) WVGeometryDoublyPeriodic
+                Nz (1,1) double {mustBeInteger,mustBePositive}
+                requestedBackend (1,1) string {mustBeMember(requestedBackend,["builtin","fftw"])}
+            end
+
+            selection = self.emptySelection(requestedBackend);
+            if requestedBackend == "builtin"
+                adapter = self.constructBuiltin(geometry,Nz);
+                selection.activeBackend = "builtin";
+                return
+            end
+
+            if ~self.isFFTWTransformsInstalled()
+                reason = self.reason("package-missing","FFTWTransforms is not installed or is not on the MATLAB path.");
+                [adapter,selection] = self.fallback(geometry,Nz,selection,reason);
+                return
+            end
+
+            selection.packageAvailable = true;
+            [capabilities,queryReason] = self.queryCapabilitiesSafely();
+            selection.capabilityQueried = true;
+            selection = self.recordIdentity(selection,capabilities);
+            [isValid,validationReason] = self.validateHorizontalCapabilities(capabilities,queryReason);
+
+            if ~isValid && self.buildIsPossible(capabilities)
+                selection.buildAttempted = true;
+                try
+                    buildResult = self.buildBackend();
+                    if isstruct(buildResult) && isfield(buildResult,"build") && isfield(buildResult.build,"succeeded")
+                        selection.buildSucceeded = logical(buildResult.build.succeeded);
+                    end
+                    if isstruct(buildResult) && isfield(buildResult,"build") && isfield(buildResult.build,"reason")
+                        selection.buildReason = self.normalizedReason(buildResult.build.reason,"build-failed");
+                    end
+                catch exception
+                    selection.buildSucceeded = false;
+                    selection.buildReason = self.exceptionReason("build-failed",exception);
+                    validationReason = selection.buildReason;
+                end
+
+                [capabilities,queryReason] = self.queryCapabilitiesSafely();
+                selection.capabilityQueried = true;
+                selection = self.recordIdentity(selection,capabilities);
+                [isValid,requeryReason] = self.validateHorizontalCapabilities(capabilities,queryReason);
+                if isValid
+                    validationReason = self.emptyReason();
+                elseif requeryReason.code ~= ""
+                    validationReason = requeryReason;
+                end
+            end
+
+            if isValid
+                try
+                    adapter = self.constructFFTW(geometry,Nz);
+                    selection.activeBackend = "fftw";
+                    selection.reason = self.emptyReason();
+                    return
+                catch exception
+                    validationReason = self.exceptionReason("adapter-construction-failed",exception);
+                end
+            end
+
+            [adapter,selection] = self.fallback(geometry,Nz,selection,validationReason);
+        end
+    end
+
+    methods (Access=protected)
+        function tf = isFFTWTransformsInstalled(~)
+            tf = exist("FFTWBackend","class") == 8;
+        end
+
+        function capabilities = queryCapabilities(~)
+            capabilities = FFTWBackend.capabilities();
+        end
+
+        function capabilities = buildBackend(~)
+            capabilities = FFTWBackend.build();
+        end
+
+        function adapter = constructBuiltin(~,geometry,Nz)
+            adapter = WVFastTransformDoublyPeriodicMatlab(geometry,Nz);
+        end
+
+        function adapter = constructFFTW(~,geometry,Nz)
+            adapter = WVFastTransformDoublyPeriodicFFTW(geometry,Nz);
+        end
+    end
+
+    methods (Access=private)
+        function [capabilities,reason] = queryCapabilitiesSafely(self)
+            capabilities = struct();
+            reason = self.emptyReason();
+            try
+                capabilities = self.queryCapabilities();
+            catch exception
+                reason = self.exceptionReason("capability-query-failed",exception);
+            end
+        end
+
+        function [isValid,reason] = validateHorizontalCapabilities(self,capabilities,queryReason)
+            isValid = false;
+            reason = queryReason;
+            if reason.code ~= ""
+                return
+            end
+            try
+                if string(capabilities.provider.id) ~= "matlab-bundled"
+                    reason = self.reason("provider-mismatch","The active provider is not MATLAB's bundled FFTW provider.");
+                    return
+                end
+                if ~capabilities.modules.r2c.identityValidated
+                    reason = self.reason("library-identity-failed","The r2c module did not validate its loaded MATLAB FFTW library.");
+                    return
+                end
+                if ~capabilities.features.r2c.isAvailable || ~capabilities.features.c2r.isAvailable
+                    reason = self.capabilityReason(capabilities,"horizontal-feature-unavailable");
+                    return
+                end
+                errors = [capabilities.features.r2c.maximumRelativeError capabilities.features.c2r.maximumRelativeError];
+                if any(~isfinite(errors)) || any(errors > 1e-12)
+                    reason = self.reason("horizontal-self-test-failed","The r2c/c2r numerical self-test exceeded relative error 1e-12.");
+                    return
+                end
+                horizontal = capabilities.eligibility.horizontal;
+                expectedOwnership = "MATLAB-managed zero-copy forward and uniquely owned destructive inverse";
+                if ~horizontal.isReady || string(horizontal.layout) ~= "half-x" || ~isequal(double(horizontal.transformDimensions),[2 1])
+                    reason = self.reason("horizontal-eligibility-failed","The validated horizontal eligibility record is not READY for half-x dimensions [2 1].");
+                    return
+                end
+                if string(horizontal.ownership) ~= expectedOwnership
+                    reason = self.reason("ownership-contract-mismatch","The FFTWTransforms ownership contract is not the validated zero-copy/destructive contract.");
+                    return
+                end
+                scratch = capabilities.memory.preservingInverseScratch;
+                if string(scratch.policy) ~= "lazy-on-first-preserving-c2r" || scratch.allocatedBytesAtPlanCreation ~= 0 || scratch.allocatedBytesForDestructiveOnlyUse ~= 0
+                    reason = self.reason("scratch-contract-mismatch","Preserving c2r scratch is not lazy and zero-sized for destructive-only use.");
+                    return
+                end
+            catch exception
+                reason = self.exceptionReason("incompatible-capability-schema",exception);
+                return
+            end
+            isValid = true;
+            reason = self.emptyReason();
+        end
+
+        function tf = buildIsPossible(~,capabilities)
+            tf = false;
+            try
+                tf = logical(capabilities.build.isPossible);
+            catch
+            end
+        end
+
+        function reason = capabilityReason(self,capabilities,fallbackCode)
+            reason = self.reason(fallbackCode,"The bundled r2c/c2r capability is unavailable.");
+            candidates = {capabilities.features.r2c.reason,capabilities.features.c2r.reason,capabilities.reason};
+            for iCandidate = 1:numel(candidates)
+                candidate = candidates{iCandidate};
+                if isstruct(candidate) && isfield(candidate,"message") && strlength(string(candidate.message)) > 0
+                    reason = candidate;
+                    if ~isfield(reason,"code") || strlength(string(reason.code)) == 0
+                        reason.code = fallbackCode;
+                    end
+                    reason.code = string(reason.code);
+                    reason.message = string(reason.message);
+                    return
+                end
+            end
+        end
+
+        function selection = recordIdentity(~,selection,capabilities)
+            try
+                selection.providerId = string(capabilities.provider.id);
+            catch
+            end
+            try
+                selection.libraryPath = string(capabilities.modules.r2c.libraryPath);
+            catch
+            end
+        end
+
+        function [adapter,selection] = fallback(self,geometry,Nz,selection,reason)
+            adapter = self.constructBuiltin(geometry,Nz);
+            selection.activeBackend = "builtin";
+            selection.didFallback = true;
+            selection.reason = reason;
+            warning("WaveVortexModel:FFTWBackendUnavailable", ...
+                "The requested FFTW backend is unavailable (%s): %s Continuing with MATLAB builtin transforms. Install FFTWTransforms ^1.0.2 and inspect FFTWBackend.capabilities(); on a supported R2026a maca64 system, run FFTWBackend.build().", ...
+                reason.code,reason.message);
+        end
+
+        function selection = emptySelection(self,requestedBackend)
+            selection = struct( ...
+                "requestedBackend",requestedBackend, ...
+                "activeBackend","", ...
+                "didFallback",false, ...
+                "packageAvailable",false, ...
+                "capabilityQueried",false, ...
+                "buildAttempted",false, ...
+                "buildSucceeded",false, ...
+                "buildReason",self.emptyReason(), ...
+                "providerId","", ...
+                "libraryPath","", ...
+                "reason",self.emptyReason());
+        end
+
+        function reason = reason(~,code,message)
+            reason = struct("code",string(code),"identifier","","message",string(message));
+        end
+
+        function reason = exceptionReason(self,code,exception)
+            reason = self.reason(code,exception.message);
+            reason.identifier = string(exception.identifier);
+        end
+
+        function reason = normalizedReason(self,candidate,fallbackCode)
+            reason = self.reason(fallbackCode,"The FFTWTransforms build did not succeed.");
+            if ~isstruct(candidate)
+                return
+            end
+            if isfield(candidate,"code") && strlength(string(candidate.code)) > 0
+                reason.code = string(candidate.code);
+            end
+            if isfield(candidate,"identifier")
+                reason.identifier = string(candidate.identifier);
+            end
+            if isfield(candidate,"message") && strlength(string(candidate.message)) > 0
+                reason.message = string(candidate.message);
+            end
+        end
+
+        function reason = emptyReason(~)
+            reason = struct("code","","identifier","","message","");
+        end
+    end
+end

--- a/UnitTests/Support/MockFastTransformAdapter.m
+++ b/UnitTests/Support/MockFastTransformAdapter.m
@@ -1,0 +1,31 @@
+classdef MockFastTransformAdapter < WVFastTransformDoublyPeriodic
+    properties
+        geometry
+        Nz
+    end
+
+    methods
+        function self = MockFastTransformAdapter(geometry,Nz,identifier)
+            self.geometry = geometry;
+            self.Nz = Nz;
+            self.backendIdentifier = identifier;
+            self.fourierStorageLayout = WVFourierStorageLayout(geometry,"full-complex");
+        end
+
+        function output = transformFromSpatialDomainWithFourier(~,input)
+            output = input;
+        end
+
+        function output = transformToSpatialDomainWithFourier(~,input)
+            output = input;
+        end
+
+        function output = diffX(~,input,~)
+            output = input;
+        end
+
+        function output = diffY(~,input,~)
+            output = input;
+        end
+    end
+end

--- a/UnitTests/Support/MockWVBackendFactory.m
+++ b/UnitTests/Support/MockWVBackendFactory.m
@@ -1,0 +1,55 @@
+classdef MockWVBackendFactory < WVFastTransformDoublyPeriodicFactory
+    properties
+        installed (1,1) logical = true
+        capabilityResults cell = {struct()}
+        buildResult = struct("build",struct("succeeded",false))
+        queryException = MException.empty
+        buildException = MException.empty
+        shouldFailFFTWConstruction (1,1) logical = false
+        queryCount (1,1) double = 0
+        buildCount (1,1) double = 0
+    end
+
+    methods
+        function self = MockWVBackendFactory(results)
+            if nargin == 0
+                return
+            end
+            if iscell(results)
+                self.capabilityResults = results;
+            else
+                self.capabilityResults = {results};
+            end
+        end
+    end
+
+    methods (Access=protected)
+        function tf = isFFTWTransformsInstalled(self)
+            tf = self.installed;
+        end
+
+        function capabilities = queryCapabilities(self)
+            self.queryCount = self.queryCount + 1;
+            if ~isempty(self.queryException)
+                throw(self.queryException);
+            end
+            index = min(self.queryCount,numel(self.capabilityResults));
+            capabilities = self.capabilityResults{index};
+        end
+
+        function capabilities = buildBackend(self)
+            self.buildCount = self.buildCount + 1;
+            if ~isempty(self.buildException)
+                throw(self.buildException);
+            end
+            capabilities = self.buildResult;
+        end
+
+        function adapter = constructFFTW(self,geometry,Nz)
+            if self.shouldFailFFTWConstruction
+                error("MockWVBackendFactory:ConstructionFailed","injected adapter construction failure");
+            end
+            adapter = MockFastTransformAdapter(geometry,Nz,"fftw");
+        end
+    end
+end

--- a/UnitTests/TestProductionCodeAnalyzer.m
+++ b/UnitTests/TestProductionCodeAnalyzer.m
@@ -23,7 +23,7 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
     methods (Test,TestTags="full")
         function productionInventoryIsDeterministic(testCase)
             files = testCase.productionReport.Files;
-            testCase.verifyNumElements(files,171);
+            testCase.verifyNumElements(files,172);
             testCase.verifyEqual(files,sort(unique(files)));
             testCase.verifyTrue(all(isfile(fullfile(testCase.repositoryRoot,files))));
 
@@ -31,6 +31,7 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
                 "WVOperation.m"
                 "@WVTransform/WVTransform.m"
                 "FastTransforms/WVFourierStorageLayout.m"
+                "FastTransforms/WVFastTransformDoublyPeriodicFactory.m"
                 "FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m"
                 "Forcing/WVNonlinearAdvection.m"
                 "ObservingSystems/WVLagrangianParticles.m"
@@ -71,7 +72,7 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
         function reportContainsReleaseLocationsAndDiagnostics(testCase)
             output = evalc("analyzeProductionCode(testCase.repositoryRoot,ShouldFail=false);");
             testCase.verifySubstring(output,"MATLAB Code Analyzer: release=R");
-            testCase.verifySubstring(output,"files=171");
+            testCase.verifySubstring(output,"files=172");
             testCase.verifySubstring(output,"[AGROW, performance]");
             testCase.verifySubstring(output,"Variable appears to change size");
             testCase.verifyFalse(contains(output,testCase.repositoryRoot));

--- a/UnitTests/TestWVFastTransformDoublyPeriodicFFTW.m
+++ b/UnitTests/TestWVFastTransformDoublyPeriodicFFTW.m
@@ -19,6 +19,81 @@ classdef TestWVFastTransformDoublyPeriodicFFTW < matlab.unittest.TestCase
     end
 
     methods (Test,TestTags="optional")
+        function completeConstantTransformsSelectEquivalentBackends(testCase)
+            for isHydrostatic = [false true]
+                arguments = {'N0',sqrt(2e-5),'latitude',45,'isHydrostatic',isHydrostatic,'shouldAntialias',true};
+                builtin = WVTransformConstantStratification([4000 3000 1000],[8 6 5],arguments{:},fastTransform="builtin");
+                fftw = WVTransformConstantStratification([4000 3000 1000],[8 6 5],arguments{:},fastTransform="fftw");
+                cleanup = onCleanup(@()deleteTransforms(builtin,fftw));
+                testCase.verifyEqual(builtin.fastTransform.backendIdentifier,"builtin");
+                testCase.verifyEqual(fftw.fastTransform.backendIdentifier,"fftw");
+                testCase.verifyEqual(fftw.k,builtin.k);
+                testCase.verifyEqual(fftw.l,builtin.l);
+                testCase.verifyEqual(fftw.Nkl,builtin.Nkl);
+                testCase.verifyEqual(fftw.dftPrimaryIndices2D,builtin.dftPrimaryIndices2D);
+                testCase.verifyEqual(fftw.dftConjugateIndices2D,builtin.dftConjugateIndices2D);
+                testCase.verifyEqual(fftw.spatialMatrixSize,builtin.spatialMatrixSize);
+                testCase.verifyEqual(fftw.spectralMatrixSize,builtin.spectralMatrixSize);
+
+                rng(7200+isHydrostatic,"twister");
+                builtin.initWithRandomFlow(uvMax=0.01);
+                fftw.Ap = builtin.Ap;
+                fftw.Am = builtin.Am;
+                fftw.A0 = builtin.A0;
+                [builtinU,builtinV,builtinW,builtinEta] = builtin.variableWithName("u","v","w","eta");
+                [fftwU,fftwV,fftwW,fftwEta] = fftw.variableWithName("u","v","w","eta");
+                verifyArrays(testCase,{fftwU,fftwV,fftwW,fftwEta},{builtinU,builtinV,builtinW,builtinEta});
+                [builtinFp,builtinFm,builtinF0] = builtin.nonlinearFlux();
+                [fftwFp,fftwFm,fftwF0] = fftw.nonlinearFlux();
+                verifyArrays(testCase,{fftwFp,fftwFm,fftwF0},{builtinFp,builtinFm,builtinF0});
+                clear cleanup
+            end
+        end
+
+        function resolutionAndAntialiasingPreserveActiveBackend(testCase)
+            wvt = WVTransformConstantStratification([4000 3000 1000],[8 6 5],N0=sqrt(2e-5),latitude=45,shouldAntialias=true,fastTransform="fftw");
+            cleanup = onCleanup(@()delete(wvt));
+            resized = wvt.waveVortexTransformWithResolution([10 8 7]);
+            resizedCleanup = onCleanup(@()delete(resized));
+            explicit = wvt.waveVortexTransformWithExplicitAntialiasing();
+            explicitCleanup = onCleanup(@()delete(explicit));
+            testCase.verifyEqual(resized.fastTransform.backendIdentifier,"fftw");
+            testCase.verifyEqual(explicit.fastTransform.backendIdentifier,"fftw");
+            testCase.verifyFalse(explicit.shouldAntialias);
+            clear explicitCleanup resizedCleanup cleanup
+        end
+
+        function persistenceUsesRuntimeBackendOverride(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            pathname = fullfile(fixture.Folder,"fftw-runtime-selection.nc");
+            original = WVTransformConstantStratification([4000 3000 1000],[8 6 5],N0=sqrt(2e-5),latitude=45,shouldAntialias=false,fastTransform="fftw");
+            originalCleanup = onCleanup(@()delete(original));
+            file = original.writeToFile(pathname,shouldOverwriteExisting=true);
+            testCase.verifyFalse(file.hasVariableWithName("fastTransform"));
+            file.close();
+
+            restoredBuiltin = WVTransform.waveVortexTransformFromFile(pathname);
+            builtinCleanup = onCleanup(@()delete(restoredBuiltin));
+            restoredFFTW = WVTransform.waveVortexTransformFromFile(pathname,fastTransform="fftw");
+            fftwCleanup = onCleanup(@()delete(restoredFFTW));
+            testCase.verifyEqual(restoredBuiltin.fastTransform.backendIdentifier,"builtin");
+            testCase.verifyEqual(restoredFFTW.fastTransform.backendIdentifier,"fftw");
+            testCase.verifyEqual(restoredFFTW.k,restoredBuiltin.k);
+            testCase.verifyEqual(restoredFFTW.l,restoredBuiltin.l);
+            testCase.verifyEqual(restoredFFTW.Ap,restoredBuiltin.Ap);
+            testCase.verifyEqual(restoredFFTW.Am,restoredBuiltin.Am);
+            testCase.verifyEqual(restoredFFTW.A0,restoredBuiltin.A0);
+            clear fftwCleanup builtinCleanup originalCleanup
+        end
+
+        function benchmarkConstructionRejectsFallback(testCase)
+            benchmarkCase = struct("transformId","constant-nonhydrostatic","Lxyz",[4000 3000 1000],"Nxyz",[8 6 5],"shouldAntialias",false);
+            wvt = createWaveVortexBenchmarkTransform(benchmarkCase,"fftw");
+            cleanup = onCleanup(@()delete(wvt));
+            testCase.verifyEqual(wvt.fastTransform.backendIdentifier,"fftw");
+            clear cleanup
+        end
+
         function forwardInverseAndMappingImplementationsAgree(testCase)
             cases = struct( ...
                 "size",{[16 12 5],[15 11 4],[16 11 3]}, ...
@@ -166,6 +241,21 @@ for iAdapter = 1:numel(varargin)
     if ~isempty(adapter) && isvalid(adapter)
         delete(adapter);
     end
+end
+end
+
+function deleteTransforms(varargin)
+for iTransform = 1:numel(varargin)
+    transform = varargin{iTransform};
+    if ~isempty(transform) && isvalid(transform)
+        delete(transform);
+    end
+end
+end
+
+function verifyArrays(testCase,actual,expected)
+for iArray = 1:numel(actual)
+    testCase.verifyLessThanOrEqual(relativeError(actual{iArray},expected{iArray}),1e-12);
 end
 end
 

--- a/UnitTests/TestWVFastTransformDoublyPeriodicFactory.m
+++ b/UnitTests/TestWVFastTransformDoublyPeriodicFactory.m
@@ -1,0 +1,212 @@
+classdef TestWVFastTransformDoublyPeriodicFactory < matlab.unittest.TestCase
+    methods (TestClassSetup)
+        function addSupportPath(testCase)
+            supportFolder = fullfile(fileparts(mfilename("fullpath")),"Support");
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(supportFolder));
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function builtinBypassesFFTWServices(testCase)
+            geometry = testGeometry();
+            factory = MockWVBackendFactory();
+            factory.installed = false;
+            [adapter,selection] = factory.create(geometry,3,"builtin");
+            cleanup = onCleanup(@()delete(adapter));
+            testCase.verifyEqual(adapter.backendIdentifier,"builtin");
+            testCase.verifyEqual(selection.requestedBackend,"builtin");
+            testCase.verifyEqual(selection.activeBackend,"builtin");
+            testCase.verifyFalse(selection.didFallback);
+            testCase.verifyEqual(factory.queryCount,0);
+            testCase.verifyEqual(factory.buildCount,0);
+            clear cleanup
+        end
+
+        function validPartialCapabilitiesSelectFFTWWithoutBuild(testCase)
+            geometry = testGeometry();
+            capabilities = validCapabilities();
+            capabilities.features.dct1.isAvailable = false;
+            capabilities.features.dst1.isAvailable = false;
+            factory = MockWVBackendFactory(capabilities);
+            [adapter,selection] = factory.create(geometry,3,"fftw");
+            cleanup = onCleanup(@()delete(adapter));
+            testCase.verifyEqual(adapter.backendIdentifier,"fftw");
+            testCase.verifyEqual(selection.activeBackend,"fftw");
+            testCase.verifyFalse(selection.didFallback);
+            testCase.verifyTrue(selection.capabilityQueried);
+            testCase.verifyEqual(selection.providerId,"matlab-bundled");
+            testCase.verifyEqual(selection.libraryPath,"/validated/libmwfftw3.3.dylib");
+            testCase.verifyEqual(factory.queryCount,1);
+            testCase.verifyEqual(factory.buildCount,0);
+            clear cleanup
+        end
+
+        function unavailableCapabilityBuildsOnceAndRequeries(testCase)
+            geometry = testGeometry();
+            unavailable = validCapabilities();
+            unavailable.features.r2c.isAvailable = false;
+            unavailable.build.isPossible = true;
+            available = validCapabilities();
+            factory = MockWVBackendFactory({unavailable,available});
+            factory.buildResult = struct("build",struct("succeeded",true));
+            [adapter,selection] = factory.create(geometry,3,"fftw");
+            cleanup = onCleanup(@()delete(adapter));
+            testCase.verifyEqual(adapter.backendIdentifier,"fftw");
+            testCase.verifyTrue(selection.buildAttempted);
+            testCase.verifyTrue(selection.buildSucceeded);
+            testCase.verifyEqual(factory.queryCount,2);
+            testCase.verifyEqual(factory.buildCount,1);
+            clear cleanup
+        end
+
+        function missingPackageWarnsOnceAndFallsBack(testCase)
+            geometry = testGeometry();
+            factory = MockWVBackendFactory();
+            factory.installed = false;
+            testCase.verifyWarning(@()factory.create(geometry,3,"fftw"),"WaveVortexModel:FFTWBackendUnavailable");
+            warningState = warning("off","WaveVortexModel:FFTWBackendUnavailable");
+            cleanup = onCleanup(@()warning(warningState));
+            [adapter,selection] = factory.create(geometry,3,"fftw");
+            adapterCleanup = onCleanup(@()delete(adapter));
+            testCase.verifyEqual(adapter.backendIdentifier,"builtin");
+            testCase.verifyTrue(selection.didFallback);
+            testCase.verifyEqual(selection.reason.code,"package-missing");
+            testCase.verifyEqual(factory.queryCount,0);
+            clear adapterCleanup cleanup
+        end
+
+        function invalidContractsFallBackWithStructuredReasons(testCase)
+            cases = invalidCapabilityCases();
+            geometry = testGeometry();
+            warningState = warning("off","WaveVortexModel:FFTWBackendUnavailable");
+            cleanup = onCleanup(@()warning(warningState));
+            for iCase = 1:numel(cases)
+                factory = MockWVBackendFactory(cases(iCase).capabilities);
+                [adapter,selection] = factory.create(geometry,3,"fftw");
+                testCase.verifyEqual(adapter.backendIdentifier,"builtin",cases(iCase).id);
+                testCase.verifyTrue(selection.didFallback,cases(iCase).id);
+                testCase.verifyEqual(selection.reason.code,cases(iCase).reasonCode,cases(iCase).id);
+                testCase.verifyEqual(factory.buildCount,0,cases(iCase).id);
+                delete(adapter);
+            end
+            clear cleanup
+        end
+
+        function capabilityAndConstructionFailuresFallBack(testCase)
+            geometry = testGeometry();
+            warningState = warning("off","WaveVortexModel:FFTWBackendUnavailable");
+            cleanup = onCleanup(@()warning(warningState));
+
+            queryFactory = MockWVBackendFactory();
+            queryFactory.queryException = MException("TestFactory:QueryFailed","injected query failure");
+            [queryAdapter,querySelection] = queryFactory.create(geometry,3,"fftw");
+            testCase.verifyEqual(querySelection.reason.code,"capability-query-failed");
+            delete(queryAdapter);
+
+            constructorFactory = MockWVBackendFactory(validCapabilities());
+            constructorFactory.shouldFailFFTWConstruction = true;
+            [constructorAdapter,constructorSelection] = constructorFactory.create(geometry,3,"fftw");
+            testCase.verifyEqual(constructorSelection.reason.code,"adapter-construction-failed");
+            testCase.verifyEqual(constructorAdapter.backendIdentifier,"builtin");
+            delete(constructorAdapter);
+
+            unavailable = validCapabilities();
+            unavailable.features.r2c.isAvailable = false;
+            unavailable.build.isPossible = true;
+            buildFactory = MockWVBackendFactory(unavailable);
+            buildFactory.buildException = MException("MockWVBackendFactory:CompileFailed","injected compilation failure");
+            [buildAdapter,buildSelection] = buildFactory.create(geometry,3,"fftw");
+            testCase.verifyTrue(buildSelection.buildAttempted);
+            testCase.verifyFalse(buildSelection.buildSucceeded);
+            testCase.verifyEqual(buildSelection.buildReason.code,"build-failed");
+            testCase.verifyEqual(buildFactory.buildCount,1);
+            testCase.verifyEqual(buildFactory.queryCount,2);
+            delete(buildAdapter);
+            clear cleanup
+        end
+
+        function geometryConstructorContainsNoGatewayProbe(testCase)
+            repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            source = fileread(fullfile(repositoryRoot,"@WVGeometryDoublyPeriodic","WVGeometryDoublyPeriodic.m"));
+            forbidden = ["FFTWBackend" "RealToComplexTransform" "fftw_r2c" "fftw_dft2"];
+            for token = forbidden
+                testCase.verifyFalse(contains(source,token),token);
+            end
+        end
+
+        function packageDeclaresFFTWTransformsDependency(testCase)
+            repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            package = matlab.mpm.Package(repositoryRoot);
+            names = string({package.Dependencies.Name});
+            dependency = package.Dependencies(names == "FFTWTransforms");
+            testCase.verifyNumElements(dependency,1);
+            testCase.verifyEqual(string(dependency.VersionRange),"^1.0.2");
+            testCase.verifyEqual(string(dependency.ID),"c9f6616c-d26a-4fdc-8426-91ca8ffd751b");
+        end
+
+        function nonconstantRestorationRejectsFFTW(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            pathname = fullfile(fixture.Folder,"barotropic.nc");
+            original = WVTransformBarotropicQG([4000 3000],[8 6],latitude=45,shouldAntialias=false);
+            file = original.writeToFile(pathname,shouldOverwriteExisting=true);
+            file.close();
+            testCase.verifyError(@()WVTransform.waveVortexTransformFromFile(pathname,fastTransform="fftw"),"WVTransform:UnsupportedFastTransform");
+        end
+    end
+end
+
+function geometry = testGeometry()
+geometry = WVGeometryDoublyPeriodic([4000 3000],[8 6],Nz=3,shouldAntialias=false);
+end
+
+function capabilities = validCapabilities()
+emptyReason = struct("code","","identifier","","message","");
+feature = struct("isAvailable",true,"maximumRelativeError",1e-14,"reason",emptyReason);
+capabilities = struct();
+capabilities.provider = struct("id","matlab-bundled");
+capabilities.modules = struct("r2c",struct("identityValidated",true,"libraryPath","/validated/libmwfftw3.3.dylib"));
+capabilities.features = struct("r2c",feature,"c2r",feature,"dct1",feature,"dst1",feature);
+capabilities.eligibility.horizontal = struct( ...
+    "isReady",true, ...
+    "layout","half-x", ...
+    "transformDimensions",[2 1], ...
+    "ownership","MATLAB-managed zero-copy forward and uniquely owned destructive inverse");
+capabilities.memory.preservingInverseScratch = struct( ...
+    "policy","lazy-on-first-preserving-c2r", ...
+    "allocatedBytesAtPlanCreation",0, ...
+    "allocatedBytesForDestructiveOnlyUse",0);
+capabilities.build = struct("isPossible",false);
+capabilities.reason = emptyReason;
+end
+
+function cases = invalidCapabilityCases()
+cases = repmat(struct("id","","capabilities",struct(),"reasonCode",""),1,7);
+
+capabilities = validCapabilities();
+capabilities.provider.id = "native";
+cases(1) = struct("id","provider","capabilities",capabilities,"reasonCode","provider-mismatch");
+
+capabilities = validCapabilities();
+capabilities.modules.r2c.identityValidated = false;
+cases(2) = struct("id","library","capabilities",capabilities,"reasonCode","library-identity-failed");
+
+capabilities = validCapabilities();
+capabilities.features.c2r.isAvailable = false;
+cases(3) = struct("id","feature","capabilities",capabilities,"reasonCode","horizontal-feature-unavailable");
+
+capabilities = validCapabilities();
+capabilities.features.r2c.maximumRelativeError = 2e-12;
+cases(4) = struct("id","numerical","capabilities",capabilities,"reasonCode","horizontal-self-test-failed");
+
+capabilities = validCapabilities();
+capabilities.eligibility.horizontal.layout = "half-y";
+cases(5) = struct("id","eligibility","capabilities",capabilities,"reasonCode","horizontal-eligibility-failed");
+
+capabilities = validCapabilities();
+capabilities.eligibility.horizontal.ownership = "copying";
+cases(6) = struct("id","ownership","capabilities",capabilities,"reasonCode","ownership-contract-mismatch");
+
+capabilities = validCapabilities();
+capabilities.memory.preservingInverseScratch.allocatedBytesAtPlanCreation = 16;
+cases(7) = struct("id","scratch","capabilities",capabilities,"reasonCode","scratch-contract-mismatch");
+end

--- a/UnitTests/TestWaveVortexBenchmark.m
+++ b/UnitTests/TestWaveVortexBenchmark.m
@@ -32,6 +32,7 @@ classdef TestWaveVortexBenchmark < matlab.unittest.TestCase
             testCase.verifyTrue(all(ismember(["constant-nonhydrostatic" "constant-hydrostatic" "hydrostatic" "boussinesq" "stratified-qg" "barotropic-qg"],unique(string({suites(3).cases.transformId})))));
             testCase.verifyError(@()waveVortexBenchmarkSuites("missing-v1"),"WaveVortexBenchmark:UnknownSuite");
             testCase.verifyError(@()waveVortexBenchmarkBackends("missing"),"WaveVortexBenchmark:UnknownBackend");
+            testCase.verifyEqual(string({waveVortexBenchmarkBackends(["builtin" "fftw"]).id}),["builtin" "fftw"]);
         end
 
         function scoringUsesEqualFamilyWeights(testCase)

--- a/buildfile.m
+++ b/buildfile.m
@@ -68,6 +68,18 @@ repositoryRoot = fileparts(mfilename("fullpath"));
 testFolder = fullfile(repositoryRoot,"UnitTests");
 originalPath = path;
 pathCleanup = onCleanup(@()path(originalPath));
+addpath(repositoryRoot);
+metadata = jsondecode(fileread(fullfile(repositoryRoot,"resources","mpackage.json")));
+for iFolder = 1:numel(metadata.folders)
+    runtimeFolder = fullfile(repositoryRoot,metadata.folders(iFolder).path);
+    if isfolder(runtimeFolder)
+        addpath(runtimeFolder);
+    end
+end
+supportFolder = fullfile(testFolder,"Support");
+if isfolder(supportFolder)
+    addpath(supportFolder);
+end
 pathEntries = string(strsplit(path,pathsep));
 if ~any(pathEntries == string(testFolder))
     addpath(testFolder);

--- a/docs/classes/developer-internals/wvfasttransformdoublyperiodicfactory/create.md
+++ b/docs/classes/developer-internals/wvfasttransformdoublyperiodicfactory/create.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: create
+parent: WVFastTransformDoublyPeriodicFactory
+grand_parent: Developer internals
+nav_order: 2
+mathjax: true
+---
+
+#  create
+
+Construct the requested backend or a safe builtin fallback.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Parameters
++ `geometry`  completed doubly periodic WV geometry
++ `Nz`  number of horizontal-transform batches
++ `requestedBackend`  `"builtin"` or `"fftw"`
+
+## Returns
++ `adapter`  selected `WVFastTransformDoublyPeriodic`
++ `selection`  structured selection and fallback record
+
+## Discussion

--- a/docs/classes/developer-internals/wvfasttransformdoublyperiodicfactory/index.md
+++ b/docs/classes/developer-internals/wvfasttransformdoublyperiodicfactory/index.md
@@ -1,0 +1,57 @@
+---
+layout: default
+title: WVFastTransformDoublyPeriodicFactory
+has_children: false
+has_toc: false
+mathjax: true
+parent: Developer internals
+grand_parent: Class documentation
+nav_order: 3
+---
+
+#  WVFastTransformDoublyPeriodicFactory
+
+Select and construct a doubly periodic horizontal-transform backend.
+
+
+---
+
+## Declaration
+
+<div class="language-matlab highlighter-rouge"><div class="highlight"><pre class="highlight"><code>classdef WVFastTransformDoublyPeriodicFactory</code></pre></div></div>
+
+## Overview
+
+This developer-facing factory keeps optional FFTW package discovery,
+capability validation, local compilation, and fallback behavior out of
+the geometry classes. The canonical WV grid is complete before the
+factory is called; the selected adapter owns its Fourier storage layout.
+
+`"builtin"` never queries FFTWTransforms. An explicit `"fftw"` request
+accepts only the validated MATLAB-bundled half-x r2c/c2r contract from
+FFTWTransforms 1.0.2 or later. If required, one local build is attempted
+before the capabilities are queried again. An unavailable request emits
+one warning and returns the builtin adapter.
+
+```matlab
+factory = WVFastTransformDoublyPeriodicFactory();
+[adapter,selection] = factory.create(geometry,Nz,"fftw");
+```
+
+Protected service methods are narrow test seams. This class is developer
+infrastructure rather than an end-user modeling or extension API.
+
+
+
+
+## Topics
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Select a horizontal-transform backend
+  + [`WVFastTransformDoublyPeriodicFactory`](/classes/developer-internals/wvfasttransformdoublyperiodicfactory/wvfasttransformdoublyperiodicfactory.html)
+  + [`create`](/classes/developer-internals/wvfasttransformdoublyperiodicfactory/create.html) Construct the requested backend or a safe builtin fallback.
+
+
+---

--- a/docs/classes/developer-internals/wvfasttransformdoublyperiodicfactory/wvfasttransformdoublyperiodicfactory.md
+++ b/docs/classes/developer-internals/wvfasttransformdoublyperiodicfactory/wvfasttransformdoublyperiodicfactory.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: WVFastTransformDoublyPeriodicFactory
+parent: WVFastTransformDoublyPeriodicFactory
+grand_parent: Developer internals
+nav_order: 1
+mathjax: true
+---
+
+#  WVFastTransformDoublyPeriodicFactory
+
+
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---

--- a/docs/classes/transforms/wvtransform/wavevortextransformfromfile.md
+++ b/docs/classes/transforms/wvtransform/wavevortextransformfromfile.md
@@ -22,6 +22,7 @@ Initialize a WVTransform instance from an existing file
 + `path`  path to a NetCDF file
 + `iTime`  (optional) time index to initialize from (default 1).
 + `shouldReadOnly`  (optional) open the returned NetCDFFile read-only (default true).
++ `fastTransform`  (optional) runtime backend for constant-stratification files, `"builtin"` (default) or `"fftw"`.
 
 ## Returns
 + `wvt`  an instance of a WVTransform subclass

--- a/docs/classes/transforms/wvtransformconstantstratification/wvtransformconstantstratification.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wvtransformconstantstratification.md
@@ -25,6 +25,7 @@ Create a wave-vortex transform for constant stratification.
 + `options.isHydrostatic`  use hydrostatic dynamics; default `false`
 + `options.latitude`  latitude in the supported domain; default `33`
 + `options.shouldAntialias`  exclude quadratically aliased modes; default `true`
++ `options.fastTransform`  horizontal transform backend, `"builtin"` (default) or explicitly requested `"fftw"`
 + `options.rho0`  reference density in kilograms per cubic meter; default `1025`
 
 ## Returns

--- a/docs/developers-guide/fourier-storage-layout.md
+++ b/docs/developers-guide/fourier-storage-layout.md
@@ -75,6 +75,14 @@ This contract makes mutation explicit without claiming that MATLAB will always u
 
 The adapter intentionally continues to use MATLAB's one-dimensional FFT implementation for `diffX` and `diffY`. Issue #74 owns the separate complete-call derivative comparison.
 
+## Backend selection
+
+`WVFastTransformDoublyPeriodicFactory` is the boundary between canonical geometry construction and backend-specific storage. `WVGeometryDoublyPeriodic` first completes the WV mode ordering, wavenumbers, and conjugate relationships. It then asks the factory for either the builtin full-complex adapter or the FFTW half-x adapter. Geometry construction never probes a MEX gateway and never changes coefficient ordering for a backend.
+
+The builtin path performs no FFTW discovery. For an explicit FFTW request, the factory queries `FFTWBackend.capabilities()`, validates the MATLAB-bundled r2c/c2r library identity, numerical self-tests, half-x ownership record, and lazy preserving-inverse scratch contract. If the modules are not ready but can be built, it makes one local build attempt and queries capabilities again. An unsuccessful request produces one actionable warning and a working builtin adapter.
+
+Each adapter exposes `backendIdentifier` so developer tools and benchmarks can verify which implementation actually executed. Benchmark code treats fallback as an unavailable FFTW candidate rather than labeling builtin measurements as FFTW.
+
 ## Developer contract
 
 The class is visible so backend developers can inspect its API and generated documentation. It is sealed and read-only because storage layouts are value-like descriptions, not extension points. A new backend should normally use the reshape and mapping methods. It may use the mapping properties directly when complete-expression benchmarks show that a specialized gather or assignment is materially better.

--- a/docs/users-guide/reading-and-writing-to-file.md
+++ b/docs/users-guide/reading-and-writing-to-file.md
@@ -30,6 +30,15 @@ Restore the transform through the static factory. The one-output form closes its
 wvtRestored = WVTransform.waveVortexTransformFromFile('transform.nc');
 ```
 
+Horizontal backend selection is runtime-only and is not written into the NetCDF file. Restoring a constant-stratification transform therefore uses builtin transforms by default, regardless of the backend used when the file was written. Request the optional backend again when appropriate for the current machine:
+
+```matlab
+wvtRestored = WVTransform.waveVortexTransformFromFile( ...
+    'transform.nc',fastTransform="fftw");
+```
+
+If FFTWTransforms is unavailable or fails validation, restoration continues with builtin transforms after one warning. Other transform families reject an FFTW restoration request.
+
 Pass additional registered variable names to `writeToFile` when physical fields or diagnostics should be stored alongside the reconstructable state:
 
 ```matlab

--- a/docs/users-guide/supported-features.md
+++ b/docs/users-guide/supported-features.md
@@ -20,7 +20,9 @@ WaveVortexModel provides five transform families together with model integration
 | `WVTransformStratifiedQG` | Stratified quasigeostrophic flow. |
 | `WVTransformBarotropicQG` | Equivalent-barotropic quasigeostrophic flow. |
 
-The rotating transforms accept either hemisphere for `5 <= abs(latitude) <= 85`, including the endpoints. Horizontal grids may contain independently chosen positive even or odd grid counts. The built-in MATLAB FFT implementation is used by the documented transform constructors.
+The rotating transforms accept either hemisphere for `5 <= abs(latitude) <= 85`, including the endpoints. Horizontal grids may contain independently chosen positive even or odd grid counts. The built-in MATLAB FFT implementation remains the default.
+
+Constant-stratification transforms also accept the experimental opt-in `fastTransform="fftw"`. This uses the source-only `FFTWTransforms ^1.0.2` package and locally built MEX modules only when its MATLAB-bundled r2c/c2r capability, ownership, and numerical checks pass. An unavailable explicit request emits one warning and continues with builtin transforms. The active implementation is available to developers as `wvt.fastTransform.backendIdentifier`. Variable-stratification and quasigeostrophic transforms remain builtin-only.
 
 Mode/index mappings accept scalars and column vectors. Resolution conversion and explicit antialiasing preserve coefficients identified by common integer mode numbers and initialize newly introduced modes to zero. Energy and, where defined, enstrophy agree between spectral and spatial representations within the transform discretization tolerance.
 
@@ -70,4 +72,4 @@ Custom operations and annotated variables use `WVOperation` and `WVVariableAnnot
 
 Optimization Toolbox is optional. `WVNoMotionProfileOperation` uses `lsqnonlin` when it is available and otherwise uses `fminsearch` with an advisory warning.
 
-FFTW selection and the low-level barotropic FINUFFT path remain development machinery. They are not selected through the documented transform constructors or public interpolation options, and FINUFFT is not a required package dependency.
+FFTWTransforms is a direct source dependency, but its compiled backend is optional and currently validated only for MATLAB R2026a on `maca64`. DCT-I/DST-I and derivative dispatch remain future milestone work. The low-level barotropic FINUFFT path remains development machinery and FINUFFT is not a required package dependency.

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -8,6 +8,7 @@ nav_order: 100
 
 ## [Unreleased]
 
+- Added `FFTWTransforms ^1.0.2` and an explicitly opt-in `fastTransform="fftw"` path for constant-stratification transforms. Backend discovery, validated local building, and safe fallback now pass through one layout-neutral factory; builtin remains the default and persisted files do not encode machine capability.
 - Replaced vertically replicated horizontal Fourier mappings with compact two-dimensional row mappings while preserving the canonical WaveVortex coefficients. On the Apple M5 Max/R2026a reference run, complete builtin forward transforms were 1.06x–2.00x faster and inverse transforms were 1.81x–3.58x faster across the `[256 256 65]` and `[512 512 129]` gate cases with antialiasing on and off; numerical results remained equivalent within the benchmark tolerance. See the issue #70 `transform-layout-integration-v1` artifact for the machine-specific measurements.
 - Rewrote the README, homepage, installation instructions, and user guidance around the current `WVTransform` and `WVModel` workflows; completed the NetCDF conventions guide; linked the canonical wavevortexmodel.org site prominently; and adopted the Avenir-first website typography while retaining search.
 - Reorganized the generated API reference around user tasks, moved implementation machinery into Developer Topics, replaced release-status jargon with direct descriptions of capabilities and limitations, and restored authored scientific context, coefficient-occupancy tables, and design rationale.

--- a/resources/mpackage.json
+++ b/resources/mpackage.json
@@ -87,6 +87,11 @@
             "name": "chebfun",
             "compatibleVersions": "",
             "id": "809af0b0-0175-4c98-97d0-1537925cf2d5"
+        },
+        {
+            "name": "FFTWTransforms",
+            "compatibleVersions": "^1.0.2",
+            "id": "c9f6616c-d26a-4fdc-8426-91ca8ffd751b"
         }
     ],
     "releaseCompatibility": ">=R2024b",

--- a/tools/applyDocumentationTaxonomy.m
+++ b/tools/applyDocumentationTaxonomy.m
@@ -22,6 +22,9 @@ end
 function [topicPath,isDeveloper] = topicForMember(className,name)
 if className == "WVFourierStorageLayout"
     [topicPath,isDeveloper] = fourierStorageLayoutTopic(name);
+elseif className == "WVFastTransformDoublyPeriodicFactory"
+    topicPath = "Select a horizontal-transform backend";
+    isDeveloper = true;
 elseif className == "WVFastTransformDoublyPeriodicFFTW"
     [topicPath,isDeveloper] = fftwAdapterTopic(name);
 elseif startsWith(className,"WVTransform")
@@ -51,7 +54,7 @@ end
 
 function [topicPath,isDeveloper] = fftwAdapterTopic(name)
 isDeveloper = true;
-if ismember(name,["WVFastTransformDoublyPeriodicFFTW","wvg","Nz","fourierStorageLayout"])
+if ismember(name,["WVFastTransformDoublyPeriodicFFTW","wvg","Nz","backendIdentifier","fourierStorageLayout"])
     topicPath = "Create an FFTW adapter";
 elseif ismember(name,["transformFromSpatialDomainWithFourier","transformToSpatialDomainWithFourier"])
     topicPath = "Apply horizontal transforms";

--- a/tools/generateWebsiteDocumentation.m
+++ b/tools/generateWebsiteDocumentation.m
@@ -1,8 +1,20 @@
 function generateWebsiteDocumentation(repositoryRoot,buildFolder)
 arguments
-    repositoryRoot (1,1) string
+repositoryRoot (1,1) string
     buildFolder (1,1) string
 end
+
+originalPath = path;
+pathCleanup = onCleanup(@()path(originalPath));
+addpath(repositoryRoot,"-begin");
+metadata = jsondecode(fileread(fullfile(repositoryRoot,"resources","mpackage.json")));
+for iFolder = 1:numel(metadata.folders)
+    folder = fullfile(repositoryRoot,metadata.folders(iFolder).path);
+    if isfolder(folder) && metadata.folders(iFolder).path ~= "UnitTests"
+        addpath(folder,"-begin");
+    end
+end
+clear WVFourierStorageLayout WVFastTransformDoublyPeriodic WVFastTransformDoublyPeriodicFFTW WVFastTransformDoublyPeriodicFactory
 
 sourceFolder = fullfile(repositoryRoot,"Documentation","WebsiteDocumentation");
 rebuildWebsiteDocumentationFromSource(sourceFolder,buildFolder);
@@ -58,6 +70,8 @@ parentName = "Developer internals";
 websiteFolder = "classes/developer-internals";
 writeClassDocumentation("WVFourierStorageLayout",buildFolder,websiteFolder,parentName,classFolderName,parentName,1,{'handle'},string.empty(0,1));
 writeClassDocumentation("WVFastTransformDoublyPeriodicFFTW",buildFolder,websiteFolder,parentName,classFolderName,parentName,2,{'handle','WVFastTransformDoublyPeriodic'},string.empty(0,1));
+writeClassDocumentation("WVFastTransformDoublyPeriodicFactory",buildFolder,websiteFolder,parentName,classFolderName,parentName,3,{'handle'},string.empty(0,1));
+clear pathCleanup
 end
 
 function writeVersionHistory(repositoryRoot,buildFolder)


### PR DESCRIPTION
## Summary
- add a layout-neutral backend factory with validated FFTWTransforms 1.0.2 discovery, one build attempt, and one-warning builtin fallback
- keep canonical geometry independent of Fourier storage and expose the active backend through each adapter
- add runtime-only constant-stratification construction/restoration selection, benchmark registration, dependency metadata, tests, and developer documentation

## Verification
- buildtool test:full — 631 passed, 0 failed
- buildtool test:optional — 11 passed, 0 failed
- buildtool analyze — 0 blocking findings
- buildtool docs:check — 0 differences
- real FFTWTransforms 1.0.2 hydrostatic/nonhydrostatic integration and lifecycle tests passed on R2026a maca64

This targets the isolated FFTW integration branch and remains unreleased pending issues #73-#75, #47, and the post-v4.2.1 integration decision.

Refs #72