### PR TITLE
Add eligibility-aware vertical FFTW dispatch

### DIFF
--- a/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
@@ -7,6 +7,19 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
         F_g,G_g
         F_wg, G_wg
         DCT, iDCT, DST, iDST
+
+    end
+
+    properties (SetAccess=private)
+        % Layout-neutral vertical DCT-I/DST-I dispatch and plan cache.
+        %
+        % The strategy operates on canonical `[Nz,Nbatch]` arrays and is
+        % independent of horizontal Fourier storage. Call `dispatchRecords`
+        % on this object to inspect which operations used FFTW.
+        %
+        % - Topic: Developer internals
+        % - Developer: true
+        verticalTransform
     end
 
     properties
@@ -81,6 +94,7 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
             self.z_int = dz*ones(Nz,1);
             self.z_int(1) = dz/2; self.z_int(end) = dz/2; 
             self.buildVerticalModeProjectionOperators();
+            self.verticalTransform = WVVerticalTransformConstantStratification.create(self.Nz,self.Nj,self.fastTransform.backendIdentifier);
         end
         
         du = diffZF(self,u,options)
@@ -363,7 +377,8 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
             if isscalar(options.Apm) && isscalar(options.A0)
                 u = zeros(self.spatialMatrixSize);
             else
-                u_bar = self.transformToSpatialDomainWithF_MM(options.Apm./self.F_wg + options.A0);
+                coefficients = self.F_g .* (options.Apm./self.F_wg + options.A0);
+                u_bar = self.verticalTransform.transformBack(coefficients,"cosine",self.iDCT);
                 u = self.transformToSpatialDomainWithFourier(u_bar);
             end
         end
@@ -377,7 +392,8 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
             if isscalar(options.Apm) && isscalar(options.A0)
                 w = zeros(self.spatialMatrixSize);
             else
-                w_bar = self.transformToSpatialDomainWithG_MM(options.Apm./self.G_wg + options.A0 );
+                coefficients = self.G_g .* (options.Apm./self.G_wg + options.A0);
+                w_bar = self.verticalTransform.transformBack(coefficients,"sine",self.iDST);
                 w = self.transformToSpatialDomainWithFourier(w_bar);
             end
         end
@@ -387,16 +403,16 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
         end
 
         function u_bar = transformFromSpatialDomainWithFio(self,u)
-            u_bar = self.DCT*u;
+            u_bar = self.verticalTransform.transformForward(u,"cosine",self.DCT);
             u_bar = self.F_wg(:,1).*(u_bar./self.F_g(:,1));
         end
 
         function u_bar = transformFromSpatialDomainWithFg(self,u)
-            u_bar = (self.DCT*u)./self.F_g;
+            u_bar = self.verticalTransform.transformForward(u,"cosine",self.DCT)./self.F_g;
         end
 
         function w_bar = transformFromSpatialDomainWithGg(self,w)
-            w_bar = (self.DST*w)./self.G_g;
+            w_bar = self.verticalTransform.transformForward(w,"sine",self.DST)./self.G_g;
         end
     end
 

--- a/@WVTransformConstantStratification/transformUVWEtaToWaveVortex.m
+++ b/@WVTransformConstantStratification/transformUVWEtaToWaveVortex.m
@@ -26,8 +26,8 @@ zeta_bar = self.transformFromSpatialDomainWithFg(iK .* v_hat - iL .* u_hat);
 A0 = self.A0Z.*zeta_bar + self.A0N.*n_bar;
 nw_bar = self.transformWithG_wg(n_bar - self.NA0.*A0);
 
-delta_bar = self.ApmD_scaled .* (self.DCT * (self.cos_alpha .* u_hat + self.sin_alpha .* v_hat));
-w_bar = self.ApmW_scaled .* (self.DST * w_hat);
+delta_bar = self.ApmD_scaled .* self.verticalTransform.transformForward(self.cos_alpha .* u_hat + self.sin_alpha .* v_hat,"cosine",self.DCT);
+w_bar = self.ApmW_scaled .* self.verticalTransform.transformForward(w_hat,"sine",self.DST);
 Ap = delta_bar + w_bar + self.ApmN .* nw_bar;
 Am = delta_bar + w_bar - self.ApmN .* nw_bar;
 

--- a/Benchmarks/runWaveVortexBenchmark.m
+++ b/Benchmarks/runWaveVortexBenchmark.m
@@ -141,6 +141,7 @@ for iBackend = 1:numel(backends)
     executeWaveVortexBenchmarkOperation(models{iBackend},benchmarkCase.operation);
     backendResults(iBackend).sameStateCacheHitSeconds = toc(cacheTimer);
     backendResults(iBackend).correctnessPassed = backendResults(iBackend).relativeError <= options.correctnessTolerance;
+    backendResults(iBackend).metadata = backendMetadata(models{iBackend});
     if options.shouldMeasureMemory
         backendResults(iBackend).memory = measureCaseMemory(benchmarkCase,backends(iBackend).id,benchmarkFolder,repositoryRoot);
     end
@@ -150,7 +151,14 @@ clear models
 end
 
 function result = baseBackendResult(backendId,constructionSeconds,firstCallSeconds,sampleCount)
-result = struct("id",backendId,"status","complete","constructionSeconds",constructionSeconds,"firstCallSeconds",firstCallSeconds,"sameStateCacheHitSeconds",NaN,"rawSeconds",NaN(1,sampleCount),"medianSeconds",NaN,"relativeError",0,"correctnessPassed",false,"referenceMedianSeconds",NaN,"caseScore",NaN,"sameHostSpeedup",NaN,"memory",emptyMemory(),"failure",emptyFailure());
+result = struct("id",backendId,"status","complete","constructionSeconds",constructionSeconds,"firstCallSeconds",firstCallSeconds,"sameStateCacheHitSeconds",NaN,"rawSeconds",NaN(1,sampleCount),"medianSeconds",NaN,"relativeError",0,"correctnessPassed",false,"referenceMedianSeconds",NaN,"caseScore",NaN,"sameHostSpeedup",NaN,"memory",emptyMemory(),"metadata",struct(),"failure",emptyFailure());
+end
+
+function metadata = backendMetadata(model)
+metadata = struct();
+if isprop(model,"verticalTransform") && isa(model.verticalTransform,"WVVerticalTransformConstantStratification")
+    metadata.verticalTransformDispatch = model.verticalTransform.dispatchRecords();
+end
 end
 
 function caseResult = failedCaseResult(benchmarkCase,exception)
@@ -368,7 +376,7 @@ results = struct("id",{},"transformId",{},"scoreFamily",{},"operation",{},"Lxyz"
 end
 
 function results = emptyBackendResults()
-results = struct("id",{},"status",{},"constructionSeconds",{},"firstCallSeconds",{},"sameStateCacheHitSeconds",{},"rawSeconds",{},"medianSeconds",{},"relativeError",{},"correctnessPassed",{},"referenceMedianSeconds",{},"caseScore",{},"sameHostSpeedup",{},"memory",{},"failure",{});
+results = struct("id",{},"status",{},"constructionSeconds",{},"firstCallSeconds",{},"sameStateCacheHitSeconds",{},"rawSeconds",{},"medianSeconds",{},"relativeError",{},"correctnessPassed",{},"referenceMedianSeconds",{},"caseScore",{},"sameHostSpeedup",{},"memory",{},"metadata",{},"failure",{});
 end
 
 function results = emptyScores()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added eligibility-aware DCT-I/DST-I dispatch for constant-stratification transforms. The optional FFTW backend now reuses validated real-to-real plans only inside the exact FFTWTransforms issue #43 size and batch intervals, while every other vertical operation retains the existing dense matrix result.
 - Added `FFTWTransforms ^1.0.2` and an explicitly opt-in `fastTransform="fftw"` path for constant-stratification transforms. Backend discovery, validated local building, and safe fallback now pass through the static layout-neutral constructor on `WVFastTransformDoublyPeriodic`; builtin remains the default and persisted files do not encode machine capability.
 - Replaced vertically replicated horizontal Fourier mappings with compact two-dimensional row mappings while preserving the canonical WaveVortex coefficients. On the Apple M5 Max/R2026a reference run, complete builtin forward transforms were 1.06x–2.00x faster and inverse transforms were 1.81x–3.58x faster across the `[256 256 65]` and `[512 512 129]` gate cases with antialiasing on and off; numerical results remained equivalent within the benchmark tolerance. See the issue #70 `transform-layout-integration-v1` artifact for the machine-specific measurements.
 - Rewrote the README, homepage, installation instructions, and user guidance around the current `WVTransform` and `WVModel` workflows; completed the NetCDF conventions guide; linked the canonical wavevortexmodel.org site prominently; and adopted the Avenir-first website typography while retaining search.

--- a/Documentation/WebsiteDocumentation/developers-guide/constant-stratification-vertical-transforms.md
+++ b/Documentation/WebsiteDocumentation/developers-guide/constant-stratification-vertical-transforms.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Constant-stratification vertical transforms
+parent: Developers guide
+nav_order: 9
+mathjax: true
+---
+
+# Constant-stratification vertical transforms
+
+`WVVerticalTransformConstantStratification` is the strategy boundary between the constant-stratification model and its vertical DCT-I/DST-I implementation. It receives only canonical vertical arrays, chooses a validated FFTW plan when the exact operation is eligible, and otherwise evaluates the existing dense matrix expression. It has no knowledge of horizontal dimensions or Fourier storage.
+
+## Canonical representations
+
+The strategy uses vertical-first, two-dimensional arrays:
+
+| Representation | Shape | Meaning |
+|---|---:|---|
+| Physical values | `[Nz,Nbatch]` | Values on the endpoint-inclusive vertical grid |
+| WV coefficients | `[Nj,Nbatch]` | Retained vertical modes in canonical WV order |
+| FFTW cosine coefficients | `[Nz,Nbatch]` | Complete DCT-I coefficient set |
+| FFTW sine coefficients | `[Nz-2,Nbatch]` | Interior DST-I coefficient set |
+
+`Nbatch` is whatever collection of independent columns the caller supplies. In normal WaveVortexModel use it is the canonical horizontal WV-grid count, `Nkl`; it is not derived from a full or compressed horizontal Fourier array.
+
+## Cosine truncation and padding
+
+The forward DCT-I returns `Nz` coefficients. WaveVortexModel retains rows `1:Nj`, exactly matching the existing truncated `DCT` matrix. This discards excluded high modes and the Nyquist coefficient.
+
+The inverse receives `[Nj,Nbatch]` coefficients. The strategy pads the omitted rows with exact zeros, applies the normalized inverse DCT-I, and returns `[Nz,Nbatch]` values. The FFTWTransforms class owns DCT-I endpoint and Nyquist normalization; WaveVortexModel does not renormalize the raw transform.
+
+## Sine logical zero mode
+
+FFTW's DST-I acts on the `Nz-2` physical interior values and returns `Nz-2` interior coefficients. WaveVortexModel's canonical G grid additionally carries a logical `j=0` row:
+
+1. Forward DST-I creates an exact zero first row and copies the first `Nj-1` interior coefficients below it.
+2. Inverse DST-I removes that logical row, pads omitted interior modes with zeros, and returns `Nz` physical values with exact zero endpoints.
+
+The physical input endpoints are ignored by the normalized FFTWTransforms DST-I contract, matching the existing matrix convention.
+
+## Scaling ownership
+
+The strategy performs only the normalized DCT-I or DST-I and the canonical truncation or padding described above. Modal factors such as `F_g`, `G_g`, `F_wg`, and `G_wg` remain in the geometry methods that already own them. Keeping these factors outside the strategy preserves the existing wave-vortex normalization and makes matrix and FFTW dispatch interchangeable.
+
+## Exact eligibility
+
+An active `fastTransform="fftw"` model queries FFTWTransforms capabilities once when the strategy is created. A vertical call uses FFTW only when all of the following are true:
+
+- the provider is MATLAB's bundled FFTW and the loaded real-to-real module identity is validated;
+- the relevant DCT-I or DST-I numerical self-test has relative error at most `1e-12`;
+- the capability record uses schema `issue43-v1`;
+- one record exactly matches `Nz`, real or complex data, cosine or sine family, and forward or inverse direction; and
+- `Nbatch` lies inside one of that record's inclusive tested intervals.
+
+The strategy never interpolates between `Nz` values or extrapolates beyond a measured batch interval. Ordinary ineligibility is expected and silent: the supplied matrix expression runs unchanged.
+
+## Plans, failures, and inspection
+
+Eligible plans are created lazily and cached by `Nz`, `Nbatch`, transform family, and data type. Forward and inverse operations share one `RealToRealTransform` plan when both directions are eligible. No array-sized MATLAB work buffer is cached.
+
+A capability-schema exception, plan-construction failure, or execution failure falls back to the matrix result for the current call. The affected configuration is removed from the cache and blacklisted so it is not retried. The strategy emits `WaveVortexModel:FFTWVerticalTransformUnavailable` at most once during its lifetime; routine size ineligibility emits no warning.
+
+Backend developers and benchmark tools can call `dispatchRecords()` to inspect the actual implementation, matched interval, issue #43 source record, call count, plan creation count, reuse count, and any structured fallback reason. Plan handles and mutable cache state are deliberately not exposed.
+
+```mermaid
+flowchart LR
+    A["Canonical values<br/>Nz × Nbatch"] --> B{"Exact issue43-v1<br/>record is eligible?"}
+    B -->|"yes"| C["Cached normalized<br/>DCT-I or DST-I"]
+    B -->|"no"| D["Existing dense<br/>matrix expression"]
+    C --> E["Canonical WV coefficients<br/>Nj × Nbatch"]
+    D --> E
+```

--- a/FastTransforms/WVVerticalTransformConstantStratification.m
+++ b/FastTransforms/WVVerticalTransformConstantStratification.m
@@ -1,0 +1,525 @@
+classdef (Sealed) WVVerticalTransformConstantStratification < handle
+    % Select and cache constant-stratification vertical transforms.
+    %
+    % This developer-facing strategy applies normalized DCT-I and DST-I
+    % transforms to canonical vertical arrays shaped `[Nz,Nbatch]`. It is
+    % independent of horizontal Fourier storage. With the builtin backend it
+    % always evaluates the supplied dense matrix expression. With an active
+    % FFTW backend it uses only the exact issue #43 eligibility records and
+    % falls back to the same matrix expression everywhere else.
+    %
+    % Cosine transforms retain the first `Nj` coefficients and discard all
+    % excluded modes, including the Nyquist coefficient. Sine transforms add
+    % the WaveVortex logical `j=0` zero row around FFTW's `Nz-2` interior-mode
+    % representation. Scaling by `F_g`, `G_g`, `F_wg`, or `G_wg` remains the
+    % responsibility of the geometry.
+    %
+    % ```matlab
+    % strategy = WVVerticalTransformConstantStratification.create(Nz,Nj,"fftw");
+    % coefficients = strategy.transformForward(values,"cosine",DCT);
+    % values = strategy.transformBack(coefficients,"cosine",iDCT);
+    % records = strategy.dispatchRecords();
+    % ```
+    %
+    % - Topic: Developer internals
+    % - Declaration: classdef (Sealed) WVVerticalTransformConstantStratification < handle
+
+    properties (SetAccess=private)
+        % Number of physical vertical grid points.
+        %
+        % - Topic: Developer internals
+        % - Developer: true
+        Nz (1,1) double
+
+        % Number of retained WaveVortex vertical modes.
+        %
+        % - Topic: Developer internals
+        % - Developer: true
+        Nj (1,1) double
+
+        % Active model-wide transform backend, `"builtin"` or `"fftw"`.
+        %
+        % - Topic: Developer internals
+        % - Developer: true
+        backendIdentifier (1,1) string
+    end
+
+    properties (Access=private)
+        capabilities (1,1) struct = struct()
+        planConstructor
+        planCache
+        failedConfigurations
+        dispatchRecordMap
+        initializationFailure (1,1) struct
+        hasWarnedOfFailure (1,1) logical = false
+    end
+
+    properties (Constant, Access=private)
+        relativeErrorTolerance = 1e-12
+        eligibilitySchema = "issue43-v1"
+    end
+
+    methods (Static)
+        function strategy = create(Nz,Nj,activeBackend)
+            % Create a vertical strategy for the active model backend.
+            %
+            % Builtin construction performs no FFTW capability query. FFTW
+            % construction queries capabilities once and never attempts a
+            % build; horizontal backend construction owns the build attempt.
+            %
+            % - Topic: Developer internals
+            % - Parameter Nz: Number of physical vertical grid points.
+            % - Parameter Nj: Number of retained WV vertical modes.
+            % - Parameter activeBackend: `"builtin"` or `"fftw"`.
+            % - Returns strategy: Configured vertical transform strategy.
+            % - Developer: true
+            arguments
+                Nz (1,1) double {mustBeInteger,mustBePositive}
+                Nj (1,1) double {mustBeInteger,mustBePositive}
+                activeBackend (1,1) string {mustBeMember(activeBackend,["builtin","fftw"])}
+            end
+            services = WVVerticalTransformConstantStratification.defaultServices();
+            strategy = WVVerticalTransformConstantStratification.createWithServices(Nz,Nj,activeBackend,services);
+        end
+    end
+
+    methods (Static, Hidden)
+        function strategy = createWithServices(Nz,Nj,activeBackend,services)
+            % Create a strategy with injected authoring/test services.
+            arguments
+                Nz (1,1) double {mustBeInteger,mustBePositive}
+                Nj (1,1) double {mustBeInteger,mustBePositive}
+                activeBackend (1,1) string {mustBeMember(activeBackend,["builtin","fftw"])}
+                services (1,1) struct
+            end
+            if Nj > Nz-1
+                error("WaveVortexModel:InvalidVerticalModeCount","Nj must not exceed Nz-1 for constant-stratification transforms.");
+            end
+            WVVerticalTransformConstantStratification.validateServices(services);
+            capabilities = struct();
+            initializationFailure = WVVerticalTransformConstantStratification.emptyReason();
+            if activeBackend == "fftw"
+                try
+                    capabilities = services.queryCapabilities();
+                    WVVerticalTransformConstantStratification.validateCapabilitySchema(capabilities);
+                catch exception
+                    initializationFailure = WVVerticalTransformConstantStratification.exceptionReason("vertical-capability-query-failed",exception);
+                end
+            end
+            strategy = WVVerticalTransformConstantStratification(Nz,Nj,activeBackend,capabilities,initializationFailure,services.constructPlan);
+            if initializationFailure.code ~= ""
+                strategy.warnOnce(initializationFailure);
+            end
+        end
+    end
+
+    methods
+        function coefficients = transformForward(self,values,transformType,fallbackMatrix)
+            % Transform `[Nz,Nbatch]` values to `[Nj,Nbatch]` coefficients.
+            %
+            % The fallback matrix must be the existing normalized WV cosine
+            % or sine forward matrix with shape `[Nj,Nz]`.
+            %
+            % - Topic: Developer internals
+            % - Parameter values: Real or complex `[Nz,Nbatch]` values.
+            % - Parameter transformType: `"cosine"` or `"sine"`.
+            % - Parameter fallbackMatrix: Normalized `[Nj,Nz]` dense matrix.
+            % - Returns coefficients: Retained `[Nj,Nbatch]` coefficients.
+            % - Developer: true
+            arguments
+                self (1,1) WVVerticalTransformConstantStratification
+                values double
+                transformType (1,1) string {mustBeMember(transformType,["cosine","sine"])}
+                fallbackMatrix double
+            end
+            self.validateForwardShapes(values,fallbackMatrix);
+            [useFFTW,record,key,planKey] = self.dispatchDecision(values,transformType,"forward");
+            if ~useFFTW
+                coefficients = fallbackMatrix*values;
+                self.storeRecord(key,record,"matrix",false,false);
+                return
+            end
+
+            [plan,record,created,reused] = self.planForConfiguration(planKey,values,transformType,record);
+            if isempty(plan)
+                coefficients = fallbackMatrix*values;
+                self.storeRecord(key,record,"matrix",created,reused);
+                return
+            end
+            try
+                rawCoefficients = plan.transformForward(values);
+                if transformType == "cosine"
+                    coefficients = rawCoefficients(1:self.Nj,:);
+                else
+                    coefficients = zeros(self.Nj,size(values,2),"like",rawCoefficients);
+                    coefficients(2:self.Nj,:) = rawCoefficients(1:self.Nj-1,:);
+                end
+                self.storeRecord(key,record,"fftw",created,reused);
+            catch exception
+                record.reason = self.failConfiguration(planKey,"vertical-transform-execution-failed",exception);
+                coefficients = fallbackMatrix*values;
+                self.storeRecord(key,record,"matrix",created,reused);
+            end
+        end
+
+        function values = transformBack(self,coefficients,transformType,fallbackMatrix)
+            % Transform `[Nj,Nbatch]` coefficients to `[Nz,Nbatch]` values.
+            %
+            % The fallback matrix must be the existing normalized WV cosine
+            % or sine inverse matrix with shape `[Nz,Nj]`.
+            %
+            % - Topic: Developer internals
+            % - Parameter coefficients: Real or complex retained coefficients.
+            % - Parameter transformType: `"cosine"` or `"sine"`.
+            % - Parameter fallbackMatrix: Normalized `[Nz,Nj]` dense matrix.
+            % - Returns values: Reconstructed `[Nz,Nbatch]` values.
+            % - Developer: true
+            arguments
+                self (1,1) WVVerticalTransformConstantStratification
+                coefficients double
+                transformType (1,1) string {mustBeMember(transformType,["cosine","sine"])}
+                fallbackMatrix double
+            end
+            self.validateBackShapes(coefficients,fallbackMatrix);
+            [useFFTW,record,key,planKey] = self.dispatchDecision(coefficients,transformType,"inverse");
+            if ~useFFTW
+                values = fallbackMatrix*coefficients;
+                self.storeRecord(key,record,"matrix",false,false);
+                return
+            end
+
+            [plan,record,created,reused] = self.planForConfiguration(planKey,coefficients,transformType,record);
+            if isempty(plan)
+                values = fallbackMatrix*coefficients;
+                self.storeRecord(key,record,"matrix",created,reused);
+                return
+            end
+            try
+                if transformType == "cosine"
+                    paddedCoefficients = zeros(self.Nz,size(coefficients,2),"like",coefficients);
+                    paddedCoefficients(1:self.Nj,:) = coefficients;
+                else
+                    paddedCoefficients = zeros(self.Nz-2,size(coefficients,2),"like",coefficients);
+                    paddedCoefficients(1:self.Nj-1,:) = coefficients(2:self.Nj,:);
+                end
+                values = plan.transformBack(paddedCoefficients);
+                if transformType == "sine"
+                    values([1 end],:) = 0;
+                end
+                self.storeRecord(key,record,"fftw",created,reused);
+            catch exception
+                record.reason = self.failConfiguration(planKey,"vertical-transform-execution-failed",exception);
+                values = fallbackMatrix*coefficients;
+                self.storeRecord(key,record,"matrix",created,reused);
+            end
+        end
+
+        function records = dispatchRecords(self)
+            % Return stable, JSON-safe records for encountered operations.
+            %
+            % - Topic: Developer internals
+            % - Returns records: Configuration, implementation, eligibility,
+            %   failure, call-count, and plan-reuse records sorted by key.
+            % - Developer: true
+            keys = sort(string(self.dispatchRecordMap.keys));
+            records = WVVerticalTransformConstantStratification.emptyDispatchRecords();
+            for iKey = 1:numel(keys)
+                records(end+1) = self.dispatchRecordMap(char(keys(iKey))); %#ok<AGROW>
+            end
+        end
+
+        function delete(self)
+            if isempty(self.planCache) || self.planCache.Count == 0
+                return
+            end
+            keys = self.planCache.keys;
+            for iKey = 1:numel(keys)
+                plan = self.planCache(keys{iKey});
+                if ~isempty(plan) && isvalid(plan)
+                    delete(plan);
+                end
+            end
+            remove(self.planCache,self.planCache.keys);
+        end
+    end
+
+    methods (Hidden)
+        function diagnostics = cacheDiagnostics(self)
+            diagnostics = struct( ...
+                "planCount",self.planCache.Count, ...
+                "failedConfigurationCount",self.failedConfigurations.Count, ...
+                "hasWarnedOfFailure",self.hasWarnedOfFailure);
+        end
+
+        function record = dispatchForConfiguration(self,Nbatch,dataType,transformType,direction)
+            % Return eligibility without allocating an input or creating a plan.
+            arguments
+                self (1,1) WVVerticalTransformConstantStratification
+                Nbatch (1,1) double {mustBeInteger,mustBePositive}
+                dataType (1,1) string {mustBeMember(dataType,["real","complex"])}
+                transformType (1,1) string {mustBeMember(transformType,["cosine","sine"])}
+                direction (1,1) string {mustBeMember(direction,["forward","inverse"])}
+            end
+            [~,record] = self.dispatchDecisionForConfiguration(Nbatch,dataType,transformType,direction);
+        end
+    end
+
+    methods (Access=private)
+        function self = WVVerticalTransformConstantStratification(Nz,Nj,activeBackend,capabilities,initializationFailure,planConstructor)
+            self.Nz = Nz;
+            self.Nj = Nj;
+            self.backendIdentifier = activeBackend;
+            self.capabilities = capabilities;
+            self.initializationFailure = initializationFailure;
+            self.planConstructor = planConstructor;
+            self.planCache = containers.Map("KeyType","char","ValueType","any");
+            self.failedConfigurations = containers.Map("KeyType","char","ValueType","any");
+            self.dispatchRecordMap = containers.Map("KeyType","char","ValueType","any");
+        end
+
+        function validateForwardShapes(self,values,fallbackMatrix)
+            if ~ismatrix(values) || size(values,1) ~= self.Nz
+                error("WaveVortexModel:InvalidVerticalTransformShape","Forward vertical values must have shape [Nz,Nbatch].");
+            end
+            if ~isequal(size(fallbackMatrix),[self.Nj self.Nz])
+                error("WaveVortexModel:InvalidVerticalFallbackShape","Forward fallback matrix must have shape [Nj,Nz].");
+            end
+        end
+
+        function validateBackShapes(self,coefficients,fallbackMatrix)
+            if ~ismatrix(coefficients) || size(coefficients,1) ~= self.Nj
+                error("WaveVortexModel:InvalidVerticalTransformShape","Inverse vertical coefficients must have shape [Nj,Nbatch].");
+            end
+            if ~isequal(size(fallbackMatrix),[self.Nz self.Nj])
+                error("WaveVortexModel:InvalidVerticalFallbackShape","Inverse fallback matrix must have shape [Nz,Nj].");
+            end
+        end
+
+        function [useFFTW,record,key,planKey] = dispatchDecision(self,values,transformType,direction)
+            dataType = "real";
+            if ~isreal(values)
+                dataType = "complex";
+            end
+            batchCount = size(values,2);
+            key = char(sprintf("%s|%s|%s|%d",transformType,direction,dataType,batchCount));
+            planKey = char(sprintf("%s|%s|%d",transformType,dataType,batchCount));
+            [useFFTW,record] = self.dispatchDecisionForConfiguration(batchCount,dataType,transformType,direction);
+        end
+
+        function [useFFTW,record] = dispatchDecisionForConfiguration(self,batchCount,dataType,transformType,direction)
+            key = char(sprintf("%s|%s|%s|%d",transformType,direction,dataType,batchCount));
+            planKey = char(sprintf("%s|%s|%d",transformType,dataType,batchCount));
+            record = self.newDispatchRecord(key,batchCount,dataType,transformType,direction);
+            useFFTW = false;
+
+            if self.backendIdentifier ~= "fftw"
+                record.reason = self.reason("builtin-backend","The builtin backend uses the existing dense vertical matrices.");
+                return
+            end
+            if self.initializationFailure.code ~= ""
+                record.reason = self.initializationFailure;
+                return
+            end
+            if isKey(self.failedConfigurations,planKey)
+                record.reason = self.failedConfigurations(planKey);
+                return
+            end
+
+            try
+                capabilities = self.capabilities;
+                if string(capabilities.provider.id) ~= "matlab-bundled"
+                    record.reason = self.reason("provider-mismatch","The active FFTW provider is not matlab-bundled.");
+                    return
+                end
+                if ~capabilities.modules.r2r.identityValidated
+                    record.reason = self.reason("r2r-library-identity-failed","The r2r module did not validate its loaded FFTW library.");
+                    return
+                end
+                featureName = "dct1";
+                if transformType == "sine"
+                    featureName = "dst1";
+                end
+                feature = capabilities.features.(featureName);
+                if ~feature.isAvailable
+                    record.reason = self.reason("vertical-feature-unavailable","The requested FFTW real-to-real feature is unavailable.");
+                    return
+                end
+                if ~isfinite(feature.maximumRelativeError) || feature.maximumRelativeError > self.relativeErrorTolerance
+                    record.reason = self.reason("vertical-self-test-failed","The FFTW real-to-real self-test exceeded relative error 1e-12.");
+                    return
+                end
+                eligibility = capabilities.eligibility.realToReal;
+                if string(eligibility.schemaVersion) ~= self.eligibilitySchema
+                    error("WaveVortexModel:IncompatibleR2REligibility","Expected issue43-v1 real-to-real eligibility records.");
+                end
+                records = eligibility.records;
+                matches = [records.Nz] == self.Nz & string({records.dataType}) == dataType & ...
+                    string({records.transformType}) == transformType & string({records.direction}) == direction;
+                if nnz(matches) ~= 1
+                    record.reason = self.reason("eligibility-record-missing","No exact issue #43 eligibility record matches this operation.");
+                    return
+                end
+                eligibilityRecord = records(matches);
+                if ~eligibilityRecord.eligible
+                    record.reason = self.reason("eligibility-record-ineligible","Issue #43 did not establish a qualifying FFTW speedup for this operation.");
+                    return
+                end
+                intervals = eligibilityRecord.intervals;
+                intervalMask = batchCount >= [intervals.minimumBatchCount] & batchCount <= [intervals.maximumBatchCount];
+                if ~any(intervalMask)
+                    record.reason = self.reason("batch-outside-eligibility","Nbatch is outside the validated issue #43 intervals.");
+                    return
+                end
+                interval = intervals(find(intervalMask,1));
+                record.isEligible = true;
+                record.minimumBatchCount = interval.minimumBatchCount;
+                record.maximumBatchCount = interval.maximumBatchCount;
+                record.sourceIssue = eligibility.sourceIssue;
+                record.sourceArtifact = string(eligibility.sourceArtifact);
+                useFFTW = true;
+            catch exception
+                record.reason = self.exceptionReason("incompatible-vertical-capability-schema",exception);
+                self.failedConfigurations(planKey) = record.reason;
+                self.warnOnce(record.reason);
+            end
+        end
+
+        function [plan,record,created,reused] = planForConfiguration(self,planKey,values,transformType,record)
+            created = false;
+            reused = false;
+            plan = [];
+            if isKey(self.failedConfigurations,planKey)
+                record.reason = self.failedConfigurations(planKey);
+                return
+            end
+            if isKey(self.planCache,planKey)
+                plan = self.planCache(planKey);
+                reused = true;
+                return
+            end
+            dataType = "real";
+            if ~isreal(values)
+                dataType = "complex";
+            end
+            try
+                plan = self.planConstructor([self.Nz size(values,2)],transformType,dataType);
+                self.planCache(planKey) = plan;
+                created = true;
+            catch exception
+                record.reason = self.failConfiguration(planKey,"vertical-plan-construction-failed",exception);
+            end
+        end
+
+        function reason = failConfiguration(self,planKey,code,exception)
+            if isKey(self.planCache,planKey)
+                plan = self.planCache(planKey);
+                remove(self.planCache,planKey);
+                if ~isempty(plan) && isvalid(plan)
+                    delete(plan);
+                end
+            end
+            reason = self.exceptionReason(code,exception);
+            self.failedConfigurations(planKey) = reason;
+            self.warnOnce(reason);
+        end
+
+        function storeRecord(self,key,record,implementation,created,reused)
+            if isKey(self.dispatchRecordMap,key)
+                previous = self.dispatchRecordMap(key);
+                record.callCount = previous.callCount;
+                record.planCreationCount = previous.planCreationCount;
+                record.planReuseCount = previous.planReuseCount;
+            end
+            record.callCount = record.callCount+1;
+            record.planCreationCount = record.planCreationCount+double(created);
+            record.planReuseCount = record.planReuseCount+double(reused);
+            record.implementation = string(implementation);
+            self.dispatchRecordMap(key) = record;
+        end
+
+        function record = newDispatchRecord(self,key,batchCount,dataType,transformType,direction)
+            record = struct( ...
+                "key",string(key), ...
+                "Nz",self.Nz, ...
+                "Nj",self.Nj, ...
+                "Nbatch",batchCount, ...
+                "dataType",string(dataType), ...
+                "transformType",string(transformType), ...
+                "direction",string(direction), ...
+                "implementation","matrix", ...
+                "isEligible",false, ...
+                "minimumBatchCount",0, ...
+                "maximumBatchCount",0, ...
+                "sourceIssue",0, ...
+                "sourceArtifact","", ...
+                "reason",self.emptyReason(), ...
+                "callCount",0, ...
+                "planCreationCount",0, ...
+                "planReuseCount",0);
+        end
+
+        function warnOnce(self,reason)
+            if self.hasWarnedOfFailure
+                return
+            end
+            self.hasWarnedOfFailure = true;
+            warning("WaveVortexModel:FFTWVerticalTransformUnavailable", ...
+                "An eligible FFTW vertical transform is unavailable (%s): %s Continuing with the existing dense matrix transform.", ...
+                reason.code,reason.message);
+        end
+    end
+
+    methods (Static, Access=private)
+        function services = defaultServices()
+            services = struct( ...
+                "queryCapabilities",@()FFTWBackend.capabilities(), ...
+                "constructPlan",@(sz,transformType,dataType)RealToRealTransform(sz, ...
+                    dims=1,transform=transformType,dataType=dataType,planner="measure", ...
+                    nCores=maxNumCompThreads,alignmentMode="unaligned",plannerTimeLimitSeconds=10));
+        end
+
+        function validateServices(services)
+            requiredFields = ["queryCapabilities","constructPlan"];
+            for field = requiredFields
+                if ~isfield(services,field) || ~isa(services.(field),"function_handle")
+                    error("WaveVortexModel:InvalidVerticalTransformServices","Vertical transform services must provide a function handle named %s.",field);
+                end
+            end
+        end
+
+        function validateCapabilitySchema(capabilities)
+            requiredTopLevel = ["provider","modules","features","eligibility"];
+            for field = requiredTopLevel
+                if ~isfield(capabilities,field)
+                    error("WaveVortexModel:IncompatibleVerticalCapabilitySchema","FFTW capabilities are missing %s.",field);
+                end
+            end
+            if ~isfield(capabilities.modules,"r2r") || ~isfield(capabilities.features,"dct1") || ...
+                    ~isfield(capabilities.features,"dst1") || ~isfield(capabilities.eligibility,"realToReal")
+                error("WaveVortexModel:IncompatibleVerticalCapabilitySchema","FFTW capabilities do not contain the required real-to-real records.");
+            end
+        end
+
+        function reason = reason(code,message)
+            reason = struct("code",string(code),"identifier","","message",string(message));
+        end
+
+        function reason = exceptionReason(code,exception)
+            reason = WVVerticalTransformConstantStratification.reason(code,exception.message);
+            reason.identifier = string(exception.identifier);
+        end
+
+        function reason = emptyReason()
+            reason = struct("code","","identifier","","message","");
+        end
+
+        function records = emptyDispatchRecords()
+            records = repmat(struct( ...
+                "key","","Nz",0,"Nj",0,"Nbatch",0,"dataType","", ...
+                "transformType","","direction","","implementation","", ...
+                "isEligible",false,"minimumBatchCount",0,"maximumBatchCount",0, ...
+                "sourceIssue",0,"sourceArtifact","","reason",WVVerticalTransformConstantStratification.emptyReason(), ...
+                "callCount",0,"planCreationCount",0,"planReuseCount",0),0,1);
+        end
+    end
+end

--- a/FastTransforms/WVVerticalTransformConstantStratification.m
+++ b/FastTransforms/WVVerticalTransformConstantStratification.m
@@ -229,6 +229,14 @@ classdef (Sealed) WVVerticalTransformConstantStratification < handle
         end
 
         function delete(self)
+            % Delete every cached FFTW plan idempotently.
+            %
+            % The strategy retains no array-sized MATLAB work buffers. Plan
+            % deletion releases the native FFTW plans owned by the cached
+            % `RealToRealTransform` objects.
+            %
+            % - Topic: Developer internals
+            % - Developer: true
             if isempty(self.planCache) || self.planCache.Count == 0
                 return
             end
@@ -326,12 +334,12 @@ classdef (Sealed) WVVerticalTransformConstantStratification < handle
             end
 
             try
-                capabilities = self.capabilities;
-                if string(capabilities.provider.id) ~= "matlab-bundled"
+                capabilityRecord = self.capabilities;
+                if string(capabilityRecord.provider.id) ~= "matlab-bundled"
                     record.reason = self.reason("provider-mismatch","The active FFTW provider is not matlab-bundled.");
                     return
                 end
-                if ~capabilities.modules.r2r.identityValidated
+                if ~capabilityRecord.modules.r2r.identityValidated
                     record.reason = self.reason("r2r-library-identity-failed","The r2r module did not validate its loaded FFTW library.");
                     return
                 end
@@ -339,7 +347,7 @@ classdef (Sealed) WVVerticalTransformConstantStratification < handle
                 if transformType == "sine"
                     featureName = "dst1";
                 end
-                feature = capabilities.features.(featureName);
+                feature = capabilityRecord.features.(featureName);
                 if ~feature.isAvailable
                     record.reason = self.reason("vertical-feature-unavailable","The requested FFTW real-to-real feature is unavailable.");
                     return
@@ -348,7 +356,7 @@ classdef (Sealed) WVVerticalTransformConstantStratification < handle
                     record.reason = self.reason("vertical-self-test-failed","The FFTW real-to-real self-test exceeded relative error 1e-12.");
                     return
                 end
-                eligibility = capabilities.eligibility.realToReal;
+                eligibility = capabilityRecord.eligibility.realToReal;
                 if string(eligibility.schemaVersion) ~= self.eligibilitySchema
                     error("WaveVortexModel:IncompatibleR2REligibility","Expected issue43-v1 real-to-real eligibility records.");
                 end

--- a/UnitTests/Support/MockWVVerticalR2RPlan.m
+++ b/UnitTests/Support/MockWVVerticalR2RPlan.m
@@ -1,0 +1,67 @@
+classdef MockWVVerticalR2RPlan < handle
+    properties (SetAccess=private)
+        realSize (1,2) double
+        transformType (1,1) string
+        dataType (1,1) string
+        forwardCallCount (1,1) double = 0
+        inverseCallCount (1,1) double = 0
+    end
+
+    properties
+        failForward (1,1) logical = false
+        failInverse (1,1) logical = false
+    end
+
+    properties (Access=private)
+        owner
+        deletionRecorded (1,1) logical = false
+    end
+
+    methods
+        function self = MockWVVerticalR2RPlan(sz,transformType,dataType,owner)
+            self.realSize = sz;
+            self.transformType = transformType;
+            self.dataType = dataType;
+            self.owner = owner;
+        end
+
+        function coefficients = transformForward(self,values)
+            self.forwardCallCount = self.forwardCallCount+1;
+            if self.failForward
+                error("WaveVortexModel:InjectedVerticalForwardFailure","Injected vertical forward failure.");
+            end
+            if self.transformType == "cosine"
+                matrix = WVGeometryDoublyPeriodicStratifiedConstant.CosineTransformForwardMatrix(self.realSize(1));
+            else
+                matrix = WVGeometryDoublyPeriodicStratifiedConstant.SineTransformForwardMatrix(self.realSize(1));
+            end
+            coefficients = matrix*values;
+        end
+
+        function values = transformBack(self,coefficients)
+            self.inverseCallCount = self.inverseCallCount+1;
+            if self.failInverse
+                error("WaveVortexModel:InjectedVerticalInverseFailure","Injected vertical inverse failure.");
+            end
+            if self.transformType == "cosine"
+                matrix = WVGeometryDoublyPeriodicStratifiedConstant.CosineTransformBackMatrix(self.realSize(1));
+            else
+                matrix = WVGeometryDoublyPeriodicStratifiedConstant.SineTransformBackMatrix(self.realSize(1));
+            end
+            values = matrix*coefficients;
+            if self.transformType == "sine"
+                values([1 end],:) = 0;
+            end
+        end
+
+        function delete(self)
+            if self.deletionRecorded
+                return
+            end
+            self.deletionRecorded = true;
+            if ~isempty(self.owner) && isvalid(self.owner)
+                self.owner.notePlanDeletion();
+            end
+        end
+    end
+end

--- a/UnitTests/Support/MockWVVerticalTransformServices.m
+++ b/UnitTests/Support/MockWVVerticalTransformServices.m
@@ -1,0 +1,50 @@
+classdef MockWVVerticalTransformServices < handle
+    properties
+        capabilities (1,1) struct = struct()
+        queryException = []
+        planException = []
+        failForward (1,1) logical = false
+        failInverse (1,1) logical = false
+        queryCount (1,1) double = 0
+        planConstructionCount (1,1) double = 0
+        planDeletionCount (1,1) double = 0
+        constructedPlans cell = {}
+    end
+
+    methods
+        function self = MockWVVerticalTransformServices(capabilities)
+            if nargin > 0
+                self.capabilities = capabilities;
+            end
+        end
+
+        function services = serviceRecord(self)
+            services = struct( ...
+                "queryCapabilities",@()self.queryCapabilities(), ...
+                "constructPlan",@(sz,transformType,dataType)self.constructPlan(sz,transformType,dataType));
+        end
+
+        function capabilities = queryCapabilities(self)
+            self.queryCount = self.queryCount+1;
+            if ~isempty(self.queryException)
+                throw(self.queryException);
+            end
+            capabilities = self.capabilities;
+        end
+
+        function plan = constructPlan(self,sz,transformType,dataType)
+            self.planConstructionCount = self.planConstructionCount+1;
+            if ~isempty(self.planException)
+                throw(self.planException);
+            end
+            plan = MockWVVerticalR2RPlan(sz,transformType,dataType,self);
+            plan.failForward = self.failForward;
+            plan.failInverse = self.failInverse;
+            self.constructedPlans{end+1} = plan;
+        end
+
+        function notePlanDeletion(self)
+            self.planDeletionCount = self.planDeletionCount+1;
+        end
+    end
+end

--- a/UnitTests/TestProductionCodeAnalyzer.m
+++ b/UnitTests/TestProductionCodeAnalyzer.m
@@ -23,7 +23,7 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
     methods (Test,TestTags="full")
         function productionInventoryIsDeterministic(testCase)
             files = testCase.productionReport.Files;
-            testCase.verifyNumElements(files,171);
+            testCase.verifyNumElements(files,172);
             testCase.verifyEqual(files,sort(unique(files)));
             testCase.verifyTrue(all(isfile(fullfile(testCase.repositoryRoot,files))));
 
@@ -33,6 +33,7 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
                 "FastTransforms/WVFourierStorageLayout.m"
                 "FastTransforms/WVFastTransformDoublyPeriodic.m"
                 "FastTransforms/@WVFastTransformDoublyPeriodicFFTW/WVFastTransformDoublyPeriodicFFTW.m"
+                "FastTransforms/WVVerticalTransformConstantStratification.m"
                 "Forcing/WVNonlinearAdvection.m"
                 "ObservingSystems/WVLagrangianParticles.m"
                 "Integrators/WVModelAdaptiveTimeStepMethods.m"
@@ -72,7 +73,7 @@ classdef TestProductionCodeAnalyzer < matlab.unittest.TestCase
         function reportContainsReleaseLocationsAndDiagnostics(testCase)
             output = evalc("analyzeProductionCode(testCase.repositoryRoot,ShouldFail=false);");
             testCase.verifySubstring(output,"MATLAB Code Analyzer: release=R");
-            testCase.verifySubstring(output,"files=171");
+            testCase.verifySubstring(output,"files=172");
             testCase.verifySubstring(output,"[AGROW, performance]");
             testCase.verifySubstring(output,"Variable appears to change size");
             testCase.verifyFalse(contains(output,testCase.repositoryRoot));

--- a/UnitTests/TestWVFastTransformDoublyPeriodicFFTW.m
+++ b/UnitTests/TestWVFastTransformDoublyPeriodicFFTW.m
@@ -19,6 +19,61 @@ classdef TestWVFastTransformDoublyPeriodicFFTW < matlab.unittest.TestCase
     end
 
     methods (Test,TestTags="optional")
+        function allVerticalOperationsRespectIssue43Dispatch(testCase)
+            Nz = 129;
+            Nj = 128;
+            Nbatch = 8320;
+            strategy = WVVerticalTransformConstantStratification.create(Nz,Nj,"fftw");
+            cleanup = onCleanup(@()delete(strategy));
+            DCT = WVGeometryDoublyPeriodicStratifiedConstant.CosineTransformForwardMatrix(Nz);
+            DCT = DCT(1:Nj,:);
+            iDCT = WVGeometryDoublyPeriodicStratifiedConstant.CosineTransformBackMatrix(Nz);
+            iDCT = iDCT(:,1:Nj);
+            DST = WVGeometryDoublyPeriodicStratifiedConstant.SineTransformForwardMatrix(Nz);
+            DST = [zeros(1,Nz); DST];
+            DST = DST(1:Nj,:);
+            iDST = WVGeometryDoublyPeriodicStratifiedConstant.SineTransformBackMatrix(Nz);
+            iDST = [zeros(Nz,1) iDST];
+            iDST = iDST(:,1:Nj);
+            rng(7330,"twister");
+
+            maximumError = 0;
+            for isComplex = [false true]
+                values = randn(Nz,Nbatch);
+                coefficients = randn(Nj,Nbatch);
+                if isComplex
+                    values = complex(values,randn(Nz,Nbatch));
+                    coefficients = complex(coefficients,randn(Nj,Nbatch));
+                end
+                operations = { ...
+                    strategy.transformForward(values,"cosine",DCT), DCT*values; ...
+                    strategy.transformBack(coefficients,"cosine",iDCT), iDCT*coefficients; ...
+                    strategy.transformForward(values,"sine",DST), DST*values; ...
+                    strategy.transformBack(coefficients,"sine",iDST), iDST*coefficients};
+                for iOperation = 1:size(operations,1)
+                    operationError = relativeError(operations{iOperation,1},operations{iOperation,2});
+                    maximumError = max(maximumError,operationError);
+                    testCase.verifyLessThanOrEqual(operationError,1e-12);
+                end
+                if isComplex
+                    testCase.verifyEqual(operations{4,1}([1 end],:),zeros(2,Nbatch,"like",operations{4,1}),AbsTol=0);
+                end
+            end
+            records = strategy.dispatchRecords();
+            testCase.verifyNumElements(records,8);
+            testCase.verifyEqual(nnz([records.isEligible]),5);
+            testCase.verifyEqual(nnz([records.implementation] == "fftw"),5);
+            testCase.verifyEqual(unique([records([records.isEligible]).minimumBatchCount]),8320);
+            matrixRecords = records(~[records.isEligible]);
+            testCase.verifyEqual(string({matrixRecords.key}),[ ...
+                "cosine|forward|real|8320" ...
+                "cosine|inverse|real|8320" ...
+                "sine|inverse|real|8320"]);
+            testCase.verifyLessThanOrEqual(maximumError,1e-12);
+            testCase.verifyEqual(strategy.cacheDiagnostics().planCount,uint64(3));
+            clear cleanup
+        end
+
         function completeConstantTransformsSelectEquivalentBackends(testCase)
             for isHydrostatic = [false true]
                 arguments = {'N0',sqrt(2e-5),'latitude',45,'isHydrostatic',isHydrostatic,'shouldAntialias',true};
@@ -27,6 +82,8 @@ classdef TestWVFastTransformDoublyPeriodicFFTW < matlab.unittest.TestCase
                 cleanup = onCleanup(@()deleteTransforms(builtin,fftw));
                 testCase.verifyEqual(builtin.fastTransform.backendIdentifier,"builtin");
                 testCase.verifyEqual(fftw.fastTransform.backendIdentifier,"fftw");
+                testCase.verifyEqual(builtin.verticalTransform.backendIdentifier,"builtin");
+                testCase.verifyEqual(fftw.verticalTransform.backendIdentifier,"fftw");
                 testCase.verifyEqual(fftw.k,builtin.k);
                 testCase.verifyEqual(fftw.l,builtin.l);
                 testCase.verifyEqual(fftw.Nkl,builtin.Nkl);

--- a/UnitTests/TestWVVerticalTransformConstantStratification.m
+++ b/UnitTests/TestWVVerticalTransformConstantStratification.m
@@ -1,0 +1,306 @@
+classdef TestWVVerticalTransformConstantStratification < matlab.unittest.TestCase
+    methods (TestClassSetup)
+        function addSupportPaths(testCase)
+            repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(fullfile(repositoryRoot,"UnitTests","Support")));
+            workspaceRoot = string(fileparts(repositoryRoot));
+            fftwTransformsRoot = fullfile(workspaceRoot,"fftw-transforms");
+            if isfolder(fftwTransformsRoot)
+                testCase.applyFixture(matlab.unittest.fixtures.PathFixture(fftwTransformsRoot));
+            end
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function classIsVisibleSealedAndGeometryPropertyIsReadOnly(testCase)
+            metadata = meta.class.fromName("WVVerticalTransformConstantStratification");
+            testCase.verifyNotEmpty(metadata);
+            testCase.verifyTrue(metadata.Sealed);
+            testCase.verifyFalse(metadata.Hidden);
+            property = metadata.PropertyList(strcmp({metadata.PropertyList.Name},"backendIdentifier"));
+            testCase.verifyEqual(string(property.SetAccess),"private");
+
+            geometryMetadata = meta.class.fromName("WVGeometryDoublyPeriodicStratifiedConstant");
+            verticalProperty = geometryMetadata.PropertyList(strcmp({geometryMetadata.PropertyList.Name},"verticalTransform"));
+            testCase.verifyEqual(string(verticalProperty.SetAccess),"private");
+        end
+
+        function builtinNeverQueriesFFTWAndUsesExactMatrices(testCase)
+            services = MockWVVerticalTransformServices(struct());
+            strategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"builtin",services.serviceRecord());
+            cleanup = onCleanup(@()delete(strategy));
+            rng(7301,"twister");
+            realValues = randn(7,4);
+            complexValues = complex(realValues,randn(7,4));
+            [DCT,iDCT,DST,iDST] = testCase.fallbackMatrices(7,5);
+
+            testCase.verifyEqual(strategy.transformForward(realValues,"cosine",DCT),DCT*realValues,AbsTol=0);
+            testCase.verifyEqual(strategy.transformForward(complexValues,"sine",DST),DST*complexValues,AbsTol=0);
+            coefficients = randn(5,4)+1i*randn(5,4);
+            testCase.verifyEqual(strategy.transformBack(coefficients,"cosine",iDCT),iDCT*coefficients,AbsTol=0);
+            testCase.verifyEqual(strategy.transformBack(coefficients,"sine",iDST),iDST*coefficients,AbsTol=0);
+            testCase.verifyEqual(services.queryCount,0);
+            testCase.verifyEqual(services.planConstructionCount,0);
+            testCase.verifyTrue(all([strategy.dispatchRecords().implementation] == "matrix"));
+            clear cleanup
+        end
+
+        function dispatchMatchesAllIssue43RecordsAndInclusiveBounds(testCase)
+            capabilities = testCase.actualIssue43Capabilities();
+            records = capabilities.eligibility.realToReal.records;
+            testCase.verifyNumElements(records,40);
+            for Nz = capabilities.eligibility.realToReal.testedNz
+                services = MockWVVerticalTransformServices(capabilities);
+                strategy = WVVerticalTransformConstantStratification.createWithServices(Nz,Nz-1,"fftw",services.serviceRecord());
+                cleanup = onCleanup(@()delete(strategy));
+                nzRecords = records([records.Nz] == Nz);
+                for expected = nzRecords'
+                    if expected.eligible
+                        minimum = expected.intervals.minimumBatchCount;
+                        maximum = expected.intervals.maximumBatchCount;
+                        atMinimum = strategy.dispatchForConfiguration(minimum,expected.dataType,expected.transformType,expected.direction);
+                        atMaximum = strategy.dispatchForConfiguration(maximum,expected.dataType,expected.transformType,expected.direction);
+                        testCase.verifyTrue(atMinimum.isEligible);
+                        testCase.verifyTrue(atMaximum.isEligible);
+                        if minimum > 1
+                            below = strategy.dispatchForConfiguration(minimum-1,expected.dataType,expected.transformType,expected.direction);
+                            testCase.verifyFalse(below.isEligible);
+                            testCase.verifyEqual(below.reason.code,"batch-outside-eligibility");
+                        end
+                        above = strategy.dispatchForConfiguration(maximum+1,expected.dataType,expected.transformType,expected.direction);
+                        testCase.verifyFalse(above.isEligible);
+                        testCase.verifyEqual(above.reason.code,"batch-outside-eligibility");
+                    else
+                        rejected = strategy.dispatchForConfiguration(8320,expected.dataType,expected.transformType,expected.direction);
+                        testCase.verifyFalse(rejected.isEligible);
+                        testCase.verifyEqual(rejected.reason.code,"eligibility-record-ineligible");
+                    end
+                end
+                clear cleanup
+            end
+        end
+
+        function realAndComplexDCTDSTUseExactTruncationAndPadding(testCase)
+            capabilities = testCase.smallEligibleCapabilities(7,1,16);
+            services = MockWVVerticalTransformServices(capabilities);
+            strategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",services.serviceRecord());
+            cleanup = onCleanup(@()delete(strategy));
+            [DCT,iDCT,DST,iDST] = testCase.fallbackMatrices(7,5);
+            rng(7302,"twister");
+
+            for isComplex = [false true]
+                values = randn(7,4);
+                coefficients = randn(5,4);
+                if isComplex
+                    values = complex(values,randn(7,4));
+                    coefficients = complex(coefficients,randn(5,4));
+                end
+                cosineForward = strategy.transformForward(values,"cosine",DCT);
+                sineForward = strategy.transformForward(values,"sine",DST);
+                cosineBack = strategy.transformBack(coefficients,"cosine",iDCT);
+                sineBack = strategy.transformBack(coefficients,"sine",iDST);
+                testCase.verifyLessThanOrEqual(testCase.relativeError(cosineForward,DCT*values),1e-12);
+                testCase.verifyLessThanOrEqual(testCase.relativeError(sineForward,DST*values),1e-12);
+                testCase.verifyEqual(sineForward(1,:),zeros(1,4,"like",sineForward),AbsTol=0);
+                testCase.verifyLessThanOrEqual(testCase.relativeError(cosineBack,iDCT*coefficients),1e-12);
+                testCase.verifyLessThanOrEqual(testCase.relativeError(sineBack,iDST*coefficients),1e-12);
+                testCase.verifyEqual(sineBack([1 end],:),zeros(2,4,"like",sineBack),AbsTol=0);
+            end
+
+            records = strategy.dispatchRecords();
+            testCase.verifyNumElements(records,8);
+            testCase.verifyTrue(all([records.isEligible]));
+            testCase.verifyTrue(all([records.implementation] == "fftw"));
+            testCase.verifyEqual(services.planConstructionCount,4,"Forward and inverse must share each family/data-type plan.");
+            testCase.verifyEqual(sum([records.planCreationCount]),4);
+            testCase.verifyEqual(sum([records.planReuseCount]),4);
+            clear cleanup
+            testCase.verifyEqual(services.planDeletionCount,4);
+        end
+
+        function ordinaryIneligibilityFallsBackSilently(testCase)
+            capabilities = testCase.smallEligibleCapabilities(7,8,16);
+            services = MockWVVerticalTransformServices(capabilities);
+            strategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",services.serviceRecord());
+            cleanup = onCleanup(@()delete(strategy));
+            [DCT,~,~,~] = testCase.fallbackMatrices(7,5);
+            values = randn(7,4);
+            output = testCase.verifyWarningFree(@()strategy.transformForward(values,"cosine",DCT));
+            testCase.verifyEqual(output,DCT*values,AbsTol=0);
+            record = strategy.dispatchRecords();
+            testCase.verifyEqual(record.reason.code,"batch-outside-eligibility");
+            testCase.verifyEqual(services.planConstructionCount,0);
+            clear cleanup
+        end
+
+        function invalidCapabilityCriteriaRejectWithoutPlans(testCase)
+            mutations = { ...
+                @(c)setNestedTwo(c,"provider","id","native"), ...
+                @(c)setNestedThree(c,"modules","r2r","identityValidated",false), ...
+                @(c)setNestedThree(c,"features","dct1","isAvailable",false), ...
+                @(c)setNestedThree(c,"features","dct1","maximumRelativeError",1e-9)};
+            expectedCodes = ["provider-mismatch" "r2r-library-identity-failed" "vertical-feature-unavailable" "vertical-self-test-failed"];
+            for iMutation = 1:numel(mutations)
+                capabilities = mutations{iMutation}(testCase.smallEligibleCapabilities(7,1,16));
+                services = MockWVVerticalTransformServices(capabilities);
+                strategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",services.serviceRecord());
+                cleanup = onCleanup(@()delete(strategy));
+                record = strategy.dispatchForConfiguration(4,"real","cosine","forward");
+                testCase.verifyFalse(record.isEligible);
+                testCase.verifyEqual(record.reason.code,expectedCodes(iMutation));
+                testCase.verifyEqual(services.planConstructionCount,0);
+                clear cleanup
+            end
+        end
+
+        function querySchemaPlanAndExecutionFailuresWarnOnceAndRecover(testCase)
+            [DCT,~,~,~] = testCase.fallbackMatrices(7,5);
+            values = randn(7,4);
+
+            queryServices = MockWVVerticalTransformServices(struct());
+            queryServices.queryException = MException("WaveVortexModel:InjectedQueryFailure","Injected query failure.");
+            queryStrategy = [];
+            testCase.verifyWarning(@createQueryStrategy,"WaveVortexModel:FFTWVerticalTransformUnavailable");
+            queryCleanup = onCleanup(@()delete(queryStrategy));
+            testCase.verifyWarningFree(@()queryStrategy.transformForward(values,"cosine",DCT));
+            testCase.verifyEqual(queryStrategy.dispatchRecords().reason.code,"vertical-capability-query-failed");
+            clear queryCleanup
+
+            schemaCapabilities = testCase.smallEligibleCapabilities(7,1,16);
+            schemaCapabilities.eligibility.realToReal.schemaVersion = "future-schema";
+            schemaServices = MockWVVerticalTransformServices(schemaCapabilities);
+            schemaStrategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",schemaServices.serviceRecord());
+            schemaCleanup = onCleanup(@()delete(schemaStrategy));
+            testCase.verifyWarning(@()schemaStrategy.transformForward(values,"cosine",DCT),"WaveVortexModel:FFTWVerticalTransformUnavailable");
+            testCase.verifyWarningFree(@()schemaStrategy.transformForward(values,"cosine",DCT));
+            testCase.verifyEqual(schemaServices.planConstructionCount,0);
+            testCase.verifyEqual(double(schemaStrategy.cacheDiagnostics().failedConfigurationCount),1);
+            clear schemaCleanup
+
+            planServices = MockWVVerticalTransformServices(testCase.smallEligibleCapabilities(7,1,16));
+            planServices.planException = MException("WaveVortexModel:InjectedPlanFailure","Injected plan failure.");
+            planStrategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",planServices.serviceRecord());
+            planCleanup = onCleanup(@()delete(planStrategy));
+            testCase.verifyWarning(@()planStrategy.transformForward(values,"cosine",DCT),"WaveVortexModel:FFTWVerticalTransformUnavailable");
+            testCase.verifyWarningFree(@()planStrategy.transformForward(values,"cosine",DCT));
+            testCase.verifyEqual(planServices.planConstructionCount,1);
+            testCase.verifyEqual(double(planStrategy.cacheDiagnostics().failedConfigurationCount),1);
+            clear planCleanup
+
+            executionServices = MockWVVerticalTransformServices(testCase.smallEligibleCapabilities(7,1,16));
+            executionServices.failForward = true;
+            executionStrategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",executionServices.serviceRecord());
+            executionCleanup = onCleanup(@()delete(executionStrategy));
+            testCase.verifyWarning(@()executionStrategy.transformForward(values,"cosine",DCT),"WaveVortexModel:FFTWVerticalTransformUnavailable");
+            testCase.verifyWarningFree(@()executionStrategy.transformForward(values,"cosine",DCT));
+            testCase.verifyEqual(executionServices.planConstructionCount,1);
+            testCase.verifyEqual(executionServices.planDeletionCount,1);
+            testCase.verifyEqual(double(executionStrategy.cacheDiagnostics().planCount),0);
+            clear executionCleanup
+
+            function createQueryStrategy()
+                queryStrategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",queryServices.serviceRecord());
+            end
+        end
+
+        function dispatchMetadataIsStableCompleteAndJSONSafe(testCase)
+            capabilities = testCase.smallEligibleCapabilities(7,1,16);
+            services = MockWVVerticalTransformServices(capabilities);
+            strategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"fftw",services.serviceRecord());
+            cleanup = onCleanup(@()delete(strategy));
+            [DCT,iDCT,~,~] = testCase.fallbackMatrices(7,5);
+            values = randn(7,4);
+            coefficients = strategy.transformForward(values,"cosine",DCT);
+            strategy.transformBack(coefficients,"cosine",iDCT);
+            strategy.transformForward(values,"cosine",DCT);
+            records = strategy.dispatchRecords();
+            testCase.verifyEqual(string({records.direction}),["forward" "inverse"]);
+            forward = records(1);
+            testCase.verifyEqual(forward.callCount,2);
+            testCase.verifyEqual(forward.planCreationCount,1);
+            testCase.verifyEqual(forward.planReuseCount,1);
+            testCase.verifyEqual(forward.minimumBatchCount,1);
+            testCase.verifyEqual(forward.maximumBatchCount,16);
+            testCase.verifyEqual(forward.sourceIssue,43);
+            decoded = jsondecode(jsonencode(records));
+            testCase.verifyEqual(numel(decoded),2);
+            testCase.verifyEqual(string(decoded(1).implementation),"fftw");
+            clear cleanup
+        end
+
+        function invalidCanonicalShapesAreRejected(testCase)
+            services = MockWVVerticalTransformServices(struct());
+            strategy = WVVerticalTransformConstantStratification.createWithServices(7,5,"builtin",services.serviceRecord());
+            cleanup = onCleanup(@()delete(strategy));
+            [DCT,iDCT,~,~] = testCase.fallbackMatrices(7,5);
+            testCase.verifyError(@()strategy.transformForward(zeros(6,4),"cosine",DCT),"WaveVortexModel:InvalidVerticalTransformShape");
+            testCase.verifyError(@()strategy.transformForward(zeros(7,4),"cosine",zeros(4,7)),"WaveVortexModel:InvalidVerticalFallbackShape");
+            testCase.verifyError(@()strategy.transformBack(zeros(4,4),"cosine",iDCT),"WaveVortexModel:InvalidVerticalTransformShape");
+            testCase.verifyError(@()strategy.transformBack(zeros(5,4),"cosine",zeros(6,5)),"WaveVortexModel:InvalidVerticalFallbackShape");
+            clear cleanup
+        end
+    end
+
+    methods (Static, Access=private)
+        function capabilities = actualIssue43Capabilities()
+            capabilities = FFTWBackend.capabilities();
+            capabilities.provider.id = "matlab-bundled";
+            capabilities.modules.r2r.identityValidated = true;
+            capabilities.features.dct1.isAvailable = true;
+            capabilities.features.dct1.maximumRelativeError = 0;
+            capabilities.features.dst1.isAvailable = true;
+            capabilities.features.dst1.maximumRelativeError = 0;
+        end
+
+        function capabilities = smallEligibleCapabilities(Nz,minimumBatchCount,maximumBatchCount)
+            capabilities = TestWVVerticalTransformConstantStratification.actualIssue43Capabilities();
+            records = capabilities.eligibility.realToReal.records;
+            template = records(1);
+            combinations = { ...
+                "real","cosine","forward"; "real","cosine","inverse"; ...
+                "real","sine","forward"; "real","sine","inverse"; ...
+                "complex","cosine","forward"; "complex","cosine","inverse"; ...
+                "complex","sine","forward"; "complex","sine","inverse"};
+            records = repmat(template,8,1);
+            for iRecord = 1:8
+                records(iRecord).Nz = Nz;
+                records(iRecord).dataType = combinations{iRecord,1};
+                records(iRecord).transformType = combinations{iRecord,2};
+                records(iRecord).direction = combinations{iRecord,3};
+                records(iRecord).eligible = true;
+                records(iRecord).intervals = struct("minimumBatchCount",minimumBatchCount,"maximumBatchCount",maximumBatchCount);
+            end
+            capabilities.eligibility.realToReal.records = records;
+            capabilities.eligibility.realToReal.sourceIssue = 43;
+            capabilities.eligibility.realToReal.sourceArtifact = "issue43-test-artifact.json";
+        end
+
+        function [DCT,iDCT,DST,iDST] = fallbackMatrices(Nz,Nj)
+            DCT = WVGeometryDoublyPeriodicStratifiedConstant.CosineTransformForwardMatrix(Nz);
+            DCT = DCT(1:Nj,:);
+            iDCT = WVGeometryDoublyPeriodicStratifiedConstant.CosineTransformBackMatrix(Nz);
+            iDCT = iDCT(:,1:Nj);
+            DST = WVGeometryDoublyPeriodicStratifiedConstant.SineTransformForwardMatrix(Nz);
+            DST = [zeros(1,Nz); DST];
+            DST = DST(1:Nj,:);
+            iDST = WVGeometryDoublyPeriodicStratifiedConstant.SineTransformBackMatrix(Nz);
+            iDST = [zeros(Nz,1) iDST];
+            iDST = iDST(:,1:Nj);
+        end
+
+        function error = relativeError(actual,expected)
+            denominator = max(norm(expected(:),Inf),eps);
+            error = norm(actual(:)-expected(:),Inf)/denominator;
+        end
+    end
+end
+
+function output = setNestedTwo(input,first,second,value)
+input.(first).(second) = value;
+output = input;
+end
+
+function output = setNestedThree(input,first,second,third,value)
+input.(first).(second).(third) = value;
+output = input;
+end

--- a/UnitTests/TestWaveVortexBenchmark.m
+++ b/UnitTests/TestWaveVortexBenchmark.m
@@ -77,6 +77,10 @@ classdef TestWaveVortexBenchmark < matlab.unittest.TestCase
             decoded = jsondecode(fileread(fullfile(runFolder,"benchmark.json")));
             testCase.verifyEqual(string(decoded.schemaVersion),"1.0.0");
             testCase.verifyEqual(decoded.suites.cases.backends.caseScore,100);
+            testCase.verifyTrue(isfield(decoded.suites.cases.backends,"metadata"));
+            testCase.verifyTrue(isfield(decoded.suites.cases.backends.metadata,"verticalTransformDispatch"));
+            testCase.verifyNotEmpty(decoded.suites.cases.backends.metadata.verticalTransformDispatch);
+            testCase.verifyTrue(all(string({decoded.suites.cases.backends.metadata.verticalTransformDispatch.implementation}) == "matrix"));
             summary = fileread(fullfile(runFolder,"summary.md"));
             testCase.verifySubstring(summary,"## Suite scores");
             testCase.verifySubstring(summary,"## Family scores");

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/backendidentifier.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/backendidentifier.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: backendIdentifier
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 3
+mathjax: true
+---
+
+#  backendIdentifier
+
+Active model-wide transform backend, `"builtin"` or `"fftw"`.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Type
++ Class: `string`
++ Size: `(1,1)`
+
+## Discussion

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/create.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/create.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: create
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 4
+mathjax: true
+---
+
+#  create
+
+a vertical strategy for the active model backend.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Parameters
++ `Nz`  Number of physical vertical grid points.
++ `Nj`  Number of retained WV vertical modes.
++ `activeBackend`  `"builtin"` or `"fftw"`.
+
+## Returns
++ `strategy`  Configured vertical transform strategy.
+
+## Discussion
+
+Builtin construction performs no FFTW capability query. FFTW
+construction queries capabilities once and never attempts a
+build; horizontal backend construction owns the build attempt.

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/delete.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/delete.md
@@ -9,9 +9,15 @@ mathjax: true
 
 #  delete
 
-
+every cached FFTW plan idempotently.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+
+The strategy retains no array-sized MATLAB work buffers. Plan
+deletion releases the native FFTW plans owned by the cached
+`RealToRealTransform` objects.

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/delete.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/delete.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: delete
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 5
+mathjax: true
+---
+
+#  delete
+
+
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/dispatchrecords.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/dispatchrecords.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: dispatchRecords
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 6
+mathjax: true
+---
+
+#  dispatchRecords
+
+Return stable, JSON-safe records for encountered operations.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Returns
++ `records`  Configuration, implementation, eligibility,
+
+## Discussion
+
+  failure, call-count, and plan-reuse records sorted by key.

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/index.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/index.md
@@ -55,8 +55,8 @@ These items document internal implementation details and are not part of the pri
   + [`Nz`](/classes/developer-internals/wvverticaltransformconstantstratification/nz.html) Number of physical vertical grid points.
   + [`backendIdentifier`](/classes/developer-internals/wvverticaltransformconstantstratification/backendidentifier.html) Active model-wide transform backend, `"builtin"` or `"fftw"`.
   + [`create`](/classes/developer-internals/wvverticaltransformconstantstratification/create.html) a vertical strategy for the active model backend.
-+ Class internals
-  + [`delete`](/classes/developer-internals/wvverticaltransformconstantstratification/delete.html)
++ Manage vertical-transform lifecycle
+  + [`delete`](/classes/developer-internals/wvverticaltransformconstantstratification/delete.html) every cached FFTW plan idempotently.
 + Inspect vertical dispatch
   + [`dispatchRecords`](/classes/developer-internals/wvverticaltransformconstantstratification/dispatchrecords.html) Return stable, JSON-safe records for encountered operations.
 + Apply vertical transforms

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/index.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/index.md
@@ -1,0 +1,67 @@
+---
+layout: default
+title: WVVerticalTransformConstantStratification
+has_children: false
+has_toc: false
+mathjax: true
+parent: Developer internals
+grand_parent: Class documentation
+nav_order: 4
+---
+
+#  WVVerticalTransformConstantStratification
+
+Select and cache constant-stratification vertical transforms.
+
+
+---
+
+## Declaration
+
+<div class="language-matlab highlighter-rouge"><div class="highlight"><pre class="highlight"><code>classdef (Sealed) WVVerticalTransformConstantStratification < handle</code></pre></div></div>
+
+## Overview
+
+This developer-facing strategy applies normalized DCT-I and DST-I
+transforms to canonical vertical arrays shaped `[Nz,Nbatch]`. It is
+independent of horizontal Fourier storage. With the builtin backend it
+always evaluates the supplied dense matrix expression. With an active
+FFTW backend it uses only the exact issue #43 eligibility records and
+falls back to the same matrix expression everywhere else.
+
+Cosine transforms retain the first `Nj` coefficients and discard all
+excluded modes, including the Nyquist coefficient. Sine transforms add
+the WaveVortex logical `j=0` zero row around FFTW's `Nz-2` interior-mode
+representation. Scaling by `F_g`, `G_g`, `F_wg`, or `G_wg` remains the
+responsibility of the geometry.
+
+```matlab
+strategy = WVVerticalTransformConstantStratification.create(Nz,Nj,"fftw");
+coefficients = strategy.transformForward(values,"cosine",DCT);
+values = strategy.transformBack(coefficients,"cosine",iDCT);
+records = strategy.dispatchRecords();
+```
+
+
+
+
+## Topics
+
+
+## Developer Topics
+These items document internal implementation details and are not part of the primary public API.
++ Create a vertical-transform strategy
+  + [`Nj`](/classes/developer-internals/wvverticaltransformconstantstratification/nj.html) Number of retained WaveVortex vertical modes.
+  + [`Nz`](/classes/developer-internals/wvverticaltransformconstantstratification/nz.html) Number of physical vertical grid points.
+  + [`backendIdentifier`](/classes/developer-internals/wvverticaltransformconstantstratification/backendidentifier.html) Active model-wide transform backend, `"builtin"` or `"fftw"`.
+  + [`create`](/classes/developer-internals/wvverticaltransformconstantstratification/create.html) a vertical strategy for the active model backend.
++ Class internals
+  + [`delete`](/classes/developer-internals/wvverticaltransformconstantstratification/delete.html)
++ Inspect vertical dispatch
+  + [`dispatchRecords`](/classes/developer-internals/wvverticaltransformconstantstratification/dispatchrecords.html) Return stable, JSON-safe records for encountered operations.
++ Apply vertical transforms
+  + [`transformBack`](/classes/developer-internals/wvverticaltransformconstantstratification/transformback.html) Transform `[Nj,Nbatch]` coefficients to `[Nz,Nbatch]` values.
+  + [`transformForward`](/classes/developer-internals/wvverticaltransformconstantstratification/transformforward.html) Transform `[Nz,Nbatch]` values to `[Nj,Nbatch]` coefficients.
+
+
+---

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/nj.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/nj.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Nj
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 1
+mathjax: true
+---
+
+#  Nj
+
+Number of retained WaveVortex vertical modes.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Type
++ Class: `double`
++ Size: `(1,1)`
+
+## Discussion

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/nz.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/nz.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Nz
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 2
+mathjax: true
+---
+
+#  Nz
+
+Number of physical vertical grid points.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Type
++ Class: `double`
++ Size: `(1,1)`
+
+## Discussion

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/transformback.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/transformback.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: transformBack
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 7
+mathjax: true
+---
+
+#  transformBack
+
+Transform `[Nj,Nbatch]` coefficients to `[Nz,Nbatch]` values.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Parameters
++ `coefficients`  Real or complex retained coefficients.
++ `transformType`  `"cosine"` or `"sine"`.
++ `fallbackMatrix`  Normalized `[Nz,Nj]` dense matrix.
+
+## Returns
++ `values`  Reconstructed `[Nz,Nbatch]` values.
+
+## Discussion
+
+The fallback matrix must be the existing normalized WV cosine
+or sine inverse matrix with shape `[Nz,Nj]`.

--- a/docs/classes/developer-internals/wvverticaltransformconstantstratification/transformforward.md
+++ b/docs/classes/developer-internals/wvverticaltransformconstantstratification/transformforward.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: transformForward
+parent: WVVerticalTransformConstantStratification
+grand_parent: Developer internals
+nav_order: 8
+mathjax: true
+---
+
+#  transformForward
+
+Transform `[Nz,Nbatch]` values to `[Nj,Nbatch]` coefficients.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Parameters
++ `values`  Real or complex `[Nz,Nbatch]` values.
++ `transformType`  `"cosine"` or `"sine"`.
++ `fallbackMatrix`  Normalized `[Nj,Nz]` dense matrix.
+
+## Returns
++ `coefficients`  Retained `[Nj,Nbatch]` coefficients.
+
+## Discussion
+
+The fallback matrix must be the existing normalized WV cosine
+or sine forward matrix with shape `[Nj,Nz]`.

--- a/docs/classes/transforms/wvtransformconstantstratification/index.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/index.md
@@ -251,6 +251,7 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainWithFourier`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainwithfourier.html)
   + [`transformToSpatialDomainWithFourierAtPosition`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainwithfourieratposition.html)
   + [`transformWithG_wg`](/classes/transforms/wvtransformconstantstratification/transformwithg_wg.html)
+  + [`verticalTransform`](/classes/transforms/wvtransformconstantstratification/verticaltransform.html) Layout-neutral vertical DCT-I/DST-I dispatch and plan cache.
 + Nonlinear flux and forcing internals
   + [`fluxForForcing`](/classes/transforms/wvtransformconstantstratification/fluxforforcing.html)
   + [`nonlinearFluxFunction`](/classes/transforms/wvtransformconstantstratification/nonlinearfluxfunction.html)

--- a/docs/classes/transforms/wvtransformconstantstratification/verticaltransform.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/verticaltransform.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: verticalTransform
+parent: WVTransformConstantStratification
+grand_parent: Transforms
+nav_order: 243
+mathjax: true
+---
+
+#  verticalTransform
+
+Layout-neutral vertical DCT-I/DST-I dispatch and plan cache.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Discussion
+
+The strategy operates on canonical `[Nz,Nbatch]` arrays and is
+independent of horizontal Fourier storage. Call `dispatchRecords`
+on this object to inspect which operations used FFTW.

--- a/docs/classes/transforms/wvtransformconstantstratification/w.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/w.md
@@ -3,7 +3,7 @@ layout: default
 title: w
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 243
+nav_order: 244
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/wavecoefficientsattimet.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wavecoefficientsattimet.md
@@ -3,7 +3,7 @@ layout: default
 title: waveCoefficientsAtTimeT
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 245
+nav_order: 246
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/wavecomponent.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wavecomponent.md
@@ -3,7 +3,7 @@ layout: default
 title: waveComponent
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 246
+nav_order: 247
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/waveenergy.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/waveenergy.md
@@ -3,7 +3,7 @@ layout: default
 title: waveEnergy
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 247
+nav_order: 248
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/wavemodeverticalstructureatindex.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wavemodeverticalstructureatindex.md
@@ -3,7 +3,7 @@ layout: default
 title: waveModeVerticalStructureAtIndex
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 248
+nav_order: 249
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/wavevortextransformwithexplicitantialiasing.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wavevortextransformwithexplicitantialiasing.md
@@ -3,7 +3,7 @@ layout: default
 title: waveVortexTransformWithExplicitAntialiasing
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 249
+nav_order: 250
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/wmax.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wmax.md
@@ -3,7 +3,7 @@ layout: default
 title: wMax
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 244
+nav_order: 245
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/x.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/x.md
@@ -3,7 +3,7 @@ layout: default
 title: x
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 250
+nav_order: 251
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/xyzgrid.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/xyzgrid.md
@@ -3,7 +3,7 @@ layout: default
 title: xyzGrid
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 251
+nav_order: 252
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/y.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/y.md
@@ -3,7 +3,7 @@ layout: default
 title: y
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 252
+nav_order: 253
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/z.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/z.md
@@ -3,7 +3,7 @@ layout: default
 title: z
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 253
+nav_order: 254
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/z_int.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/z_int.md
@@ -3,7 +3,7 @@ layout: default
 title: z_int
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 254
+nav_order: 255
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/zeta_x.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/zeta_x.md
@@ -3,7 +3,7 @@ layout: default
 title: zeta_x
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 255
+nav_order: 256
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/zeta_y.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/zeta_y.md
@@ -3,7 +3,7 @@ layout: default
 title: zeta_y
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 256
+nav_order: 257
 mathjax: true
 ---
 

--- a/docs/classes/transforms/wvtransformconstantstratification/zeta_z.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/zeta_z.md
@@ -3,7 +3,7 @@ layout: default
 title: zeta_z
 parent: WVTransformConstantStratification
 grand_parent: Transforms
-nav_order: 257
+nav_order: 258
 mathjax: true
 ---
 

--- a/docs/developers-guide/constant-stratification-vertical-transforms.md
+++ b/docs/developers-guide/constant-stratification-vertical-transforms.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Constant-stratification vertical transforms
+parent: Developers guide
+nav_order: 9
+mathjax: true
+---
+
+# Constant-stratification vertical transforms
+
+`WVVerticalTransformConstantStratification` is the strategy boundary between the constant-stratification model and its vertical DCT-I/DST-I implementation. It receives only canonical vertical arrays, chooses a validated FFTW plan when the exact operation is eligible, and otherwise evaluates the existing dense matrix expression. It has no knowledge of horizontal dimensions or Fourier storage.
+
+## Canonical representations
+
+The strategy uses vertical-first, two-dimensional arrays:
+
+| Representation | Shape | Meaning |
+|---|---:|---|
+| Physical values | `[Nz,Nbatch]` | Values on the endpoint-inclusive vertical grid |
+| WV coefficients | `[Nj,Nbatch]` | Retained vertical modes in canonical WV order |
+| FFTW cosine coefficients | `[Nz,Nbatch]` | Complete DCT-I coefficient set |
+| FFTW sine coefficients | `[Nz-2,Nbatch]` | Interior DST-I coefficient set |
+
+`Nbatch` is whatever collection of independent columns the caller supplies. In normal WaveVortexModel use it is the canonical horizontal WV-grid count, `Nkl`; it is not derived from a full or compressed horizontal Fourier array.
+
+## Cosine truncation and padding
+
+The forward DCT-I returns `Nz` coefficients. WaveVortexModel retains rows `1:Nj`, exactly matching the existing truncated `DCT` matrix. This discards excluded high modes and the Nyquist coefficient.
+
+The inverse receives `[Nj,Nbatch]` coefficients. The strategy pads the omitted rows with exact zeros, applies the normalized inverse DCT-I, and returns `[Nz,Nbatch]` values. The FFTWTransforms class owns DCT-I endpoint and Nyquist normalization; WaveVortexModel does not renormalize the raw transform.
+
+## Sine logical zero mode
+
+FFTW's DST-I acts on the `Nz-2` physical interior values and returns `Nz-2` interior coefficients. WaveVortexModel's canonical G grid additionally carries a logical `j=0` row:
+
+1. Forward DST-I creates an exact zero first row and copies the first `Nj-1` interior coefficients below it.
+2. Inverse DST-I removes that logical row, pads omitted interior modes with zeros, and returns `Nz` physical values with exact zero endpoints.
+
+The physical input endpoints are ignored by the normalized FFTWTransforms DST-I contract, matching the existing matrix convention.
+
+## Scaling ownership
+
+The strategy performs only the normalized DCT-I or DST-I and the canonical truncation or padding described above. Modal factors such as `F_g`, `G_g`, `F_wg`, and `G_wg` remain in the geometry methods that already own them. Keeping these factors outside the strategy preserves the existing wave-vortex normalization and makes matrix and FFTW dispatch interchangeable.
+
+## Exact eligibility
+
+An active `fastTransform="fftw"` model queries FFTWTransforms capabilities once when the strategy is created. A vertical call uses FFTW only when all of the following are true:
+
+- the provider is MATLAB's bundled FFTW and the loaded real-to-real module identity is validated;
+- the relevant DCT-I or DST-I numerical self-test has relative error at most `1e-12`;
+- the capability record uses schema `issue43-v1`;
+- one record exactly matches `Nz`, real or complex data, cosine or sine family, and forward or inverse direction; and
+- `Nbatch` lies inside one of that record's inclusive tested intervals.
+
+The strategy never interpolates between `Nz` values or extrapolates beyond a measured batch interval. Ordinary ineligibility is expected and silent: the supplied matrix expression runs unchanged.
+
+## Plans, failures, and inspection
+
+Eligible plans are created lazily and cached by `Nz`, `Nbatch`, transform family, and data type. Forward and inverse operations share one `RealToRealTransform` plan when both directions are eligible. No array-sized MATLAB work buffer is cached.
+
+A capability-schema exception, plan-construction failure, or execution failure falls back to the matrix result for the current call. The affected configuration is removed from the cache and blacklisted so it is not retried. The strategy emits `WaveVortexModel:FFTWVerticalTransformUnavailable` at most once during its lifetime; routine size ineligibility emits no warning.
+
+Backend developers and benchmark tools can call `dispatchRecords()` to inspect the actual implementation, matched interval, issue #43 source record, call count, plan creation count, reuse count, and any structured fallback reason. Plan handles and mutable cache state are deliberately not exposed.
+
+```mermaid
+flowchart LR
+    A["Canonical values<br/>Nz × Nbatch"] --> B{"Exact issue43-v1<br/>record is eligible?"}
+    B -->|"yes"| C["Cached normalized<br/>DCT-I or DST-I"]
+    B -->|"no"| D["Existing dense<br/>matrix expression"]
+    C --> E["Canonical WV coefficients<br/>Nj × Nbatch"]
+    D --> E
+```

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -8,6 +8,7 @@ nav_order: 100
 
 ## [Unreleased]
 
+- Added eligibility-aware DCT-I/DST-I dispatch for constant-stratification transforms. The optional FFTW backend now reuses validated real-to-real plans only inside the exact FFTWTransforms issue #43 size and batch intervals, while every other vertical operation retains the existing dense matrix result.
 - Added `FFTWTransforms ^1.0.2` and an explicitly opt-in `fastTransform="fftw"` path for constant-stratification transforms. Backend discovery, validated local building, and safe fallback now pass through the static layout-neutral constructor on `WVFastTransformDoublyPeriodic`; builtin remains the default and persisted files do not encode machine capability.
 - Replaced vertically replicated horizontal Fourier mappings with compact two-dimensional row mappings while preserving the canonical WaveVortex coefficients. On the Apple M5 Max/R2026a reference run, complete builtin forward transforms were 1.06x–2.00x faster and inverse transforms were 1.81x–3.58x faster across the `[256 256 65]` and `[512 512 129]` gate cases with antialiasing on and off; numerical results remained equivalent within the benchmark tolerance. See the issue #70 `transform-layout-integration-v1` artifact for the machine-specific measurements.
 - Rewrote the README, homepage, installation instructions, and user guidance around the current `WVTransform` and `WVModel` workflows; completed the NetCDF conventions guide; linked the canonical wavevortexmodel.org site prominently; and adopted the Avenir-first website typography while retaining search.

--- a/tools/applyDocumentationTaxonomy.m
+++ b/tools/applyDocumentationTaxonomy.m
@@ -27,6 +27,8 @@ elseif className == "WVFastTransformDoublyPeriodic"
     isDeveloper = true;
 elseif className == "WVFastTransformDoublyPeriodicFFTW"
     [topicPath,isDeveloper] = fftwAdapterTopic(name);
+elseif className == "WVVerticalTransformConstantStratification"
+    [topicPath,isDeveloper] = verticalTransformTopic(name);
 elseif startsWith(className,"WVTransform")
     [topicPath,isDeveloper] = transformTopic(name);
 elseif className == "WVModel"
@@ -49,6 +51,19 @@ elseif contains(className,"FlowComponent") || endsWith(className,"Component")
 else
     topicPath = "Class internals";
     isDeveloper = true;
+end
+end
+
+function [topicPath,isDeveloper] = verticalTransformTopic(name)
+isDeveloper = true;
+if ismember(name,["WVVerticalTransformConstantStratification","create","Nz","Nj","backendIdentifier"])
+    topicPath = "Create a vertical-transform strategy";
+elseif ismember(name,["transformForward","transformBack"])
+    topicPath = "Apply vertical transforms";
+elseif name == "dispatchRecords"
+    topicPath = "Inspect vertical dispatch";
+else
+    topicPath = "Class internals";
 end
 end
 

--- a/tools/applyDocumentationTaxonomy.m
+++ b/tools/applyDocumentationTaxonomy.m
@@ -62,6 +62,8 @@ elseif ismember(name,["transformForward","transformBack"])
     topicPath = "Apply vertical transforms";
 elseif name == "dispatchRecords"
     topicPath = "Inspect vertical dispatch";
+elseif name == "delete"
+    topicPath = "Manage vertical-transform lifecycle";
 else
     topicPath = "Class internals";
 end

--- a/tools/generateWebsiteDocumentation.m
+++ b/tools/generateWebsiteDocumentation.m
@@ -14,7 +14,7 @@ for iFolder = 1:numel(metadata.folders)
         addpath(folder,"-begin");
     end
 end
-clear WVFourierStorageLayout WVFastTransformDoublyPeriodic WVFastTransformDoublyPeriodicFFTW
+clear WVFourierStorageLayout WVFastTransformDoublyPeriodic WVFastTransformDoublyPeriodicFFTW WVVerticalTransformConstantStratification
 
 sourceFolder = fullfile(repositoryRoot,"Documentation","WebsiteDocumentation");
 rebuildWebsiteDocumentationFromSource(sourceFolder,buildFolder);
@@ -71,6 +71,7 @@ websiteFolder = "classes/developer-internals";
 writeClassDocumentation("WVFourierStorageLayout",buildFolder,websiteFolder,parentName,classFolderName,parentName,1,{'handle'},string.empty(0,1));
 writeClassDocumentation("WVFastTransformDoublyPeriodic",buildFolder,websiteFolder,parentName,classFolderName,parentName,2,{'handle'},string.empty(0,1));
 writeClassDocumentation("WVFastTransformDoublyPeriodicFFTW",buildFolder,websiteFolder,parentName,classFolderName,parentName,3,{'handle','WVFastTransformDoublyPeriodic'},string.empty(0,1));
+writeClassDocumentation("WVVerticalTransformConstantStratification",buildFolder,websiteFolder,parentName,classFolderName,parentName,4,{'handle'},string.empty(0,1));
 clear pathCleanup
 end
 


### PR DESCRIPTION
## Summary

- add the layout-neutral `WVVerticalTransformConstantStratification` strategy
- dispatch DCT-I/DST-I per operation using exact FFTWTransforms issue #43 eligibility records
- retain existing dense matrices silently for ineligible operations and recover safely from FFTW failures
- expose stable dispatch metadata to the shared benchmark framework
- add complete developer documentation and generated API pages

The change remains isolated from `main`; this PR targets `feature/layout-neutral-fftw-backend` under the post-4.2.1 integration policy.

## Issue #43 eligibility correction

At `[Nz,Nbatch]=[129,8320]`, the encoded table marks five of eight operation combinations eligible. The optional test exercises all eight, verifies five actual FFTW dispatches, and confirms that real cosine forward/inverse and real sine inverse retain matrices.

## Verification

- `buildtool test:full`: 641 passed
- `buildtool test:optional`: 12 passed
- `buildtool analyze`: 172 files, 0 blocking findings
- `buildtool docs:check`: 1,741 files, 0 failures, no generated diff
- actual bundled FFTW DCT-I/DST-I comparison: maximum relative error `<=1e-12`

Tracks #73.
