### PR TITLE
Correct supplied forcing and closure documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Reorganized the transform and forcing references around common user tasks, grouped physical and spectral coordinates coherently, promoted flow-component diagnostics and forcing configuration, documented the user-facing transform surface and forcing-stage contract, kept evaluation and inherited implementation machinery in Developer Topics, and removed obsolete transform-level pseudo-radial and frequency-axis binning remnants whose maintained implementations live in `WVDiagnostics`.
+- Reorganized the transform and forcing references around common user tasks, grouped physical and spectral coordinates coherently, promoted flow-component diagnostics and forcing configuration, documented the user-facing transform surface and forcing-stage contract, corrected the supplied forcing and closure declarations, units, defaults, examples, and geometry-specific behavior, kept evaluation and inherited implementation machinery in Developer Topics, and removed obsolete transform-level pseudo-radial and frequency-axis binning remnants whose maintained implementations live in `WVDiagnostics`.
 - Updated onboarding examples to demonstrate warning-free nonlinear integration by default, simplified hand-authored MATLAB examples, and corrected unsupported single-dollar mathematical markup throughout the generated website.
 
 ## [4.2.1] - 2026-08-09

--- a/Documentation/WebsiteDocumentation/users-guide/adding-forcing.md
+++ b/Documentation/WebsiteDocumentation/users-guide/adding-forcing.md
@@ -10,11 +10,13 @@ mathjax: true
 
 `WVModel` advances a transform with nonlinear advection by default. External tendencies and closures enter through `WVForcing` objects, while analytical linear evolution is available when nonlinear interactions should be omitted.
 
+The [Forcing reference](/classes/forcing/) summarizes the supplied physical and spectral tendencies. The [Closures reference](/classes/forcing/closures/) compares the available small-scale closures and their principal controls.
+
 ## Quick start
 
 By default, a `WVTransform` is initialized with exactly one forcing term: nonlinear advection. Initialize a transform, then call `summarizeForcing` to list its right-hand-side terms:
 ```matlab
-wvt = WVTransformHydrostatic([800e3, 800e3, 4000],[64, 64, 65], N2=@(z) (3*2*pi/3600)^2*exp(2*z/1300),latitude=30);
+wvt = WVTransformHydrostatic([800e3,800e3,4000],[64,64,65],N2Function=@(z)(3*2*pi/3600)^2*exp(2*z/1300),latitude=30);
 wvt.summarizeForcing
 ```
 
@@ -45,7 +47,10 @@ The model now includes nonlinear advection and adaptive damping when it advances
 model = WVModel(wvt);
 model.integrateToTime(wvt.inertialPeriod);
 ```
-and it would include both nonlinear advection and small scale adaptive damping.
+
+`WVModel` now advances the transform with both nonlinear advection and small-scale adaptive damping.
+
+Prescribed forcings and closures use the same registration mechanism. For example, `WVFixedAmplitudeForcing` can hold selected wave-vortex coefficients at specified values, while traditional horizontal and vertical damping apply fixed viscosity or diffusivity. The class reference documents each forcing's supported geometry, configuration, and diagnostic scales.
 
 
 ## The equations of motion

--- a/Forcing/WVAdaptiveDamping.m
+++ b/Forcing/WVAdaptiveDamping.m
@@ -1,10 +1,10 @@
 classdef WVAdaptiveDamping < WVForcing
-    % Adaptive small-scale damping
+    % Adapt small-scale spectral damping to the current flow speed.
     %
-    % This damping operator is a linear closure that dynamically changes
-    % its amplitude to keep the Reynolds number at the grid scale equal to
-    % one. This closure is ideal for a spin-up problem where the amplitude
-    % of the flow is changing.
+    % This closure rebuilds its spectral shape when the transform's effective
+    % resolution changes and scales its coefficient tendency by the current
+    % maximum horizontal speed. It is useful when the flow amplitude evolves
+    % substantially, such as during spin-up.
     % 
     % This closure has a number of noteworthy features:
     %
@@ -43,11 +43,10 @@ classdef WVAdaptiveDamping < WVForcing
     %
     % where $$U$$ is the maximum fluid velocity.
     %
-    % ### Usage
-    %
-    % Assuming there is a WVTransform instance wvt, to add this forcing,
+    % ### Example
     %
     % ```matlab
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
     % wvt.addForcing(WVAdaptiveDamping(wvt));
     % ```
     %
@@ -68,32 +67,45 @@ classdef WVAdaptiveDamping < WVForcing
     %
     % - Declaration: WVAdaptiveDamping < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % spectral matrix that multiplies Ap,Am,A0 to damp
+        % Unit-speed spectral damping operator in inverse meters.
+        %
+        % This array has `wvt.spectralMatrixSize`. The actual coefficient
+        % damping rate is `wvt.uvMax*damp` in inverse seconds.
         %
         % - Topic: Properties
         damp
 
-        % wavenumber at which the significant scale damping starts.
+        % Estimated horizontal wavenumber for significant damping.
+        %
+        % Units are radians per meter. The filter is already nonzero below
+        % this estimate; use `k_no_damp` for the exact zero-damping cutoff.
         %
         % - Topic: Properties
         k_damp
 
-        % wavenumber below which there is zero damping
+        % Horizontal wavenumber below which damping is exactly zero.
+        %
+        % Units are radians per meter.
         %
         % - Topic: Properties
         k_no_damp
         
-        % wavenumber at which the significant scale damping starts.
+        % Estimated vertical mode number for significant damping.
+        %
+        % This value is dimensionless. The filter is already nonzero below
+        % this estimate; use `j_no_damp` for the exact zero-damping cutoff.
         %
         % - Topic: Properties
         j_damp
 
-        % wavenumber below which there is zero damping
+        % Vertical mode number below which damping is exactly zero.
+        %
+        % This value is dimensionless.
         %
         % - Topic: Properties
         j_no_damp
 
-        % effective resolution used in the damping calculation
+        % Effective horizontal resolution used to construct `damp`, in meters.
         %
         % - Topic: Properties
         assumedEffectiveHorizontalGridResolution = Inf;
@@ -113,12 +125,12 @@ classdef WVAdaptiveDamping < WVForcing
 
     methods
         function self = WVAdaptiveDamping(wvt)
-            % initialize the WVAdaptiveDamping
+            % Create adaptive spectral damping for a transform.
             %
             % - Topic: Initialization
-            % - Declaration: damp = WVAdaptiveDamping(wvt)
-            % - Parameter wvt: a WVTransform instance
-            % - Returns self: a WVAdaptiveDamping instance
+            % - Declaration: self = WVAdaptiveDamping(wvt)
+            % - Parameter wvt: transform that owns and evaluates the closure
+            % - Returns self: adaptive-damping closure owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
             end
@@ -135,12 +147,11 @@ classdef WVAdaptiveDamping < WVForcing
         end
 
         function buildDampingOperator(self)
-            % Builds the damping operator
+            % Build the unit-speed spectral damping operator.
             %
             % - Topic: Internal
             % - Declaration: buildDampingOperator(self)
-            % - Parameter self: an instance of WVAdaptiveViscosity
-            % - Returns: None
+            % - Parameter self: adaptive-damping instance to update
             arguments
                 self WVAdaptiveDamping {mustBeNonempty}
             end
@@ -162,13 +173,18 @@ classdef WVAdaptiveDamping < WVForcing
         end
 
         function [Qkl,Qj,kl_cutoff, kl_damp, j_cutoff, j_damp] = spectralVanishingViscosityFilter(self, kl_max, j_max)
-            % Builds the spectral vanishing viscosity operator
+            % Build horizontal and vertical spectral-vanishing filters.
             %
             % - Topic: Internal
-            % - Declaration: spectralVanishingViscosityFilter(self, options)
-            % - Parameter self: an instance of WVAdaptiveViscosity
-            % - Parameter options: struct with field shouldAssumeAntialiasing
-            % - Returns: Qkl, Qj, kl_cutoff, kl_damp
+            % - Declaration: [Qkl,Qj,kl_cutoff,kl_damp,j_cutoff,j_damp] = spectralVanishingViscosityFilter(kl_max,j_max)
+            % - Parameter kl_max: maximum resolved horizontal wavenumber in radians per meter
+            % - Parameter j_max: maximum resolved vertical-mode number
+            % - Returns Qkl: horizontal filter on the spectral grid
+            % - Returns Qj: vertical filter on the spectral grid
+            % - Returns kl_cutoff: exact horizontal zero-damping cutoff in radians per meter
+            % - Returns kl_damp: estimated horizontal significant-damping wavenumber in radians per meter
+            % - Returns j_cutoff: exact vertical zero-damping cutoff
+            % - Returns j_damp: estimated vertical significant-damping mode
             arguments
                 self WVAdaptiveDamping {mustBeNonempty}
                 kl_max
@@ -206,7 +222,7 @@ classdef WVAdaptiveDamping < WVForcing
         %     % Builds the spectral vanishing viscosity operator
         %     %
         %     % - Declaration: spectralVanishingViscosityFilter(self, options)
-        %     % - Parameter self: an instance of WVAdaptiveViscosity
+        %     % - Parameter self: an instance of WVAdaptiveDamping
         %     % - Parameter options: struct with field shouldAssumeAntialiasing
         %     % - Returns: Qkl, Qj, kl_cutoff, kl_damp
         %     arguments
@@ -252,12 +268,16 @@ classdef WVAdaptiveDamping < WVForcing
         % end
         % 
         function dampingTimeScale = dampingTimeScale(self)
-            % Computes the minimum damping time scale
+            % Return the inverse maximum unit-speed damping coefficient.
+            %
+            % Despite the historical method name, this value has units of
+            % meters because `damp` has units of inverse meters. For a
+            % nonzero flow, divide this value by `wvt.uvMax` to obtain the
+            % shortest instantaneous e-folding time in seconds.
             %
             % - Topic: Properties
-            % - Declaration: dampingTimeScale(self)
-            % - Parameter self: an instance of WVAdaptiveViscosity
-            % - Returns: dampingTimeScale
+            % - Declaration: dampingTimeScale = dampingTimeScale()
+            % - Returns dampingTimeScale: inverse maximum absolute entry of `damp`, in meters
             arguments
                 self WVAdaptiveDamping {mustBeNonempty}
             end
@@ -265,15 +285,16 @@ classdef WVAdaptiveDamping < WVForcing
         end
         
         function [Fp, Fm, F0] = addSpectralForcing(self, wvt, Fp, Fm, F0)
-            % Adds spectral forcing
+            % Add adaptive damping to wave-vortex coefficient tendencies.
             %
             % - Declaration: addSpectralForcing(self, wvt, Fp, Fm, F0)
-            % - Parameter self: an instance of WVAdaptiveViscosity
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter Fp: positive frequency forcing
-            % - Parameter Fm: negative frequency forcing
-            % - Parameter F0: zero frequency forcing
-            % - Returns: Fp, Fm, F0
+            % - Parameter wvt: transform evaluating the forcing
+            % - Parameter Fp: accumulated `Ap` tendency
+            % - Parameter Fm: accumulated `Am` tendency
+            % - Parameter F0: accumulated `A0` tendency
+            % - Returns Fp: damped `Ap` tendency
+            % - Returns Fm: damped `Am` tendency
+            % - Returns F0: damped `A0` tendency
             arguments
                 self WVAdaptiveDamping {mustBeNonempty}
                 wvt WVTransform {mustBeNonempty}
@@ -288,13 +309,12 @@ classdef WVAdaptiveDamping < WVForcing
         end
 
         function F0 = addPotentialVorticitySpectralForcing(self, wvt, F0)
-            % Adds potential vorticity spectral forcing
+            % Add adaptive damping to the QGPV coefficient tendency.
             %
             % - Declaration: addPotentialVorticitySpectralForcing(self, wvt, F0)
-            % - Parameter self: an instance of WVAdaptiveViscosity
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter F0: zero frequency forcing
-            % - Returns: F0
+            % - Parameter wvt: QG transform evaluating the forcing
+            % - Parameter F0: accumulated `A0` tendency
+            % - Returns F0: damped `A0` tendency
             arguments
                 self WVAdaptiveDamping {mustBeNonempty}
                 wvt WVTransform {mustBeNonempty}
@@ -304,12 +324,11 @@ classdef WVAdaptiveDamping < WVForcing
         end
 
         function force = forcingWithResolutionOfTransform(self, wvtX2)
-            % Creates a forcing with the resolution of the transform
+            % Create equivalent adaptive damping for another resolution.
             %
             % - Declaration: forcingWithResolutionOfTransform(self, wvtX2)
-            % - Parameter self: an instance of WVAdaptiveViscosity
-            % - Parameter wvtX2: a WVTransform instance with doubled resolution
-            % - Returns: force
+            % - Parameter wvtX2: compatible transform at the target resolution
+            % - Returns force: adaptive damping owned by `wvtX2`
             arguments
                 self WVAdaptiveDamping {mustBeNonempty}
                 wvtX2 WVTransform {mustBeNonempty}

--- a/Forcing/WVAntialiasing.m
+++ b/Forcing/WVAntialiasing.m
@@ -1,28 +1,24 @@
 classdef WVAntialiasing < WVForcing
-    % Antialiasing filter
+    % Apply explicit spectral antialias filtering for diagnostics.
     %
-    % This forcing removes (sets to zero) energy in the largest 1/3 modes
-    % to prevent quadratic aliasing. This is the correct de-aliasing for
-    % the horizontal fourier modes, but is not exactly correct for the
-    % vertical modes in variable stratification. You can thus manually set
-    % `Nj`, otherwise it will default to `options.Nj = floor(2*wvt.Nj/3);`.
+    % This closure removes coefficient tendencies in aliased modes and sets
+    % those coefficients to zero after every integration step. The
+    % horizontal mask uses the transform's quadratic-aliasing rule. Vertical
+    % modes with `j >= Nj` are discarded; `Nj` defaults to
+    % `floor(2*wvt.Nj/3)`.
     %
-    % **Very important** You should almost never use this forcing, as
-    % de-aliasing is built-in at the transform level and enabled by
-    % default. For performance reasons is far more optimal to simply never
-    % compute the de-aliased modes. The purpose of this forcing to allow
-    % direct measurement of the effect of the de-aliasing on energy and
-    % potential enstrophy. It is quite slow and thus we recommend it be
-    % used for diagnostic purposes only.
+    % Transform-level antialiasing is enabled by default and is more
+    % efficient because discarded modes are never computed. Explicit
+    % antialiasing is intended for measuring the filter's effect on energy
+    % and potential enstrophy. Construct the transform with
+    % `shouldAntialias=false` before adding this closure. It is compatible
+    % with wave-bearing and QG transforms.
     %
-    % ### Usage
-    %
-    % This is likely to change in the future, but at the moment several of
-    % the transforms have a function that will make a new transform in the
-    % identical state, but with the antialiasing filter explicitly added.
+    % ### Example
     %
     % ```matlab
-    % wvtAA = wvt.waveVortexTransformWithExplicitAntialiasing();
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true,shouldAntialias=false);
+    % wvt.addForcing(WVAntialiasing(wvt));
     % ```
     %
     % - Topic: Create the forcing
@@ -34,7 +30,7 @@ classdef WVAntialiasing < WVForcing
     % - Topic: Forcing internals
     % - Declaration: WVAntialiasing < [WVForcing](/classes/forcing/wvforcing/)
     properties (GetAccess=public, SetAccess=protected)
-        % number of retained vertical modes used to construct the filter
+        % Number of retained vertical modes.
         %
         % This value is preserved when the forcing is converted to another
         % resolution or restored from an annotated NetCDF file.
@@ -42,7 +38,10 @@ classdef WVAntialiasing < WVForcing
         % - Topic: Properties
         Nj
 
-        % spectral matrix that multiplies Ap,Am,A0 to zero out the aliased modes
+        % Logical-shape spectral mask of discarded coefficients.
+        %
+        % This array has `wvt.spectralMatrixSize`; nonzero entries are
+        % removed from coefficient tendencies and amplitudes.
         %
         % - Topic: Properties
         M
@@ -50,12 +49,15 @@ classdef WVAntialiasing < WVForcing
 
     methods
         function self = WVAntialiasing(wvt,options)
-            % initialize the WVAntialiasing
+            % Create explicit antialias filtering for a transform.
             %
-            % - Declaration: nlFlux = WVNonlinearFlux(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter Nj: (optional) number of retained vertical modes. Modes with `j >= Nj` are set to zero. Defaults to `floor(2*wvt.Nj/3)`.
-            % - Returns self: a WVAntialiasing instance
+            % The transform must have been constructed with
+            % `shouldAntialias=false`.
+            %
+            % - Declaration: self = WVAntialiasing(wvt,options)
+            % - Parameter wvt: transform that owns and evaluates the closure
+            % - Parameter Nj: optional number of retained vertical modes; modes with `j >= Nj` are discarded; default `floor(2*wvt.Nj/3)`
+            % - Returns self: explicit-antialiasing closure owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.Nj
@@ -77,7 +79,7 @@ classdef WVAntialiasing < WVForcing
         end
 
         function effectiveHorizontalGridResolution = effectiveHorizontalGridResolution(self)
-            %returns the effective grid resolution in meters
+            % Return the shortest fully retained horizontal wavelength.
             %
             % The effective grid resolution is the highest fully resolved
             % wavelength in the model. This value takes into account
@@ -85,8 +87,8 @@ classdef WVAntialiasing < WVForcing
             % operators.
             %
             % - Topic: Properties
-            % - Declaration: flag = effectiveHorizontalGridResolution(other)
-            % - Returns effectiveHorizontalGridResolution: double
+            % - Declaration: effectiveHorizontalGridResolution = effectiveHorizontalGridResolution()
+            % - Returns effectiveHorizontalGridResolution: effective horizontal resolution in meters
             arguments
                 self WVAntialiasing
             end
@@ -94,16 +96,14 @@ classdef WVAntialiasing < WVForcing
         end
 
         function j_max = effectiveJMax(self)
-            %returns the effective highest vertical mode
+            % Return the highest retained vertical-mode number.
             %
-            % The effective highest vertical modeis the highest fully resolved
-            % mode in the model. This value takes into account
-            % anti-aliasing, and is thus appropriate for setting damping
-            % operators.
+            % This dimensionless value accounts for the explicit vertical
+            % mask and is appropriate when constructing damping operators.
             %
             % - Topic: Properties
-            % - Declaration: flag = effectiveJMax(other)
-            % - Returns effectiveJMax: double
+            % - Declaration: j_max = effectiveJMax()
+            % - Returns j_max: highest retained vertical-mode number
             arguments
                 self WVAntialiasing
             end

--- a/Forcing/WVBottomFrictionLinear.m
+++ b/Forcing/WVBottomFrictionLinear.m
@@ -1,18 +1,27 @@
 classdef WVBottomFrictionLinear < WVForcing
-    % Linear bottom friction
+    % Apply linear drag at the bottom boundary.
     %
-    % Applies linear bottom friction to the flow, i.e., $$\frac{du}{dt} = -r \cdot u(x,y,-D)$$. The parameter $$r$$ has units of $$s^{-1}$$ and thus can be set as an inverse time scale.
+    % The parameter $$r$$ is an inverse time scale in $$\mathrm{s^{-1}}$$.
+    % For a three-dimensional transform, the bottom tendency is scaled by
+    % the bottom quadrature weight `z_int(1)` so its vertically integrated
+    % effect does not change with vertical resolution:
     %
-    % The linear bottom friction is scaled such that we actually apply, $$\frac{du}{dt} = -\frac{L_z}{dz} r \cdot u(x,y,-D)$$ and the volume integrated effect of friction remains the same regardless of resolution. $$L_z$$ is the total domain depth and $$dz$$ is the spacing at the bottom grid point.
+    % $$
+    % r_\mathrm{scaled}=\frac{L_z}{z_\mathrm{int}(1)}r.
+    % $$
     %
-    % To compare with quadratic bottom friction where $$\frac{du}{dt} = -\frac{C_d}{dz} \lvert \mathbf{u} \rvert $$, note that $$- \frac{L_z}{dz} r = -\frac{C_d}{dz} \lvert \mathbf{u} \rvert$$ and you will find a characteristic velocity $$\lvert\mathbf{u}\rvert$$ of about 10 cm/s for $$C_d=0.002$$.
+    % A barotropic transform has no vertical quadrature and uses
+    % $$r_\mathrm{scaled}=r$$.
+    %
+    % Comparing this with quadratic drag gives the characteristic relation
+    % $$L_z r=C_d\lvert\mathbf{u}\rvert$$.
     %
     % For both nonhydrostatic and hydrostatic transforms linear bottom drag
     %
     % $$
     % \begin{align}
-    % \mathcal{S}_u &= -\frac{L_z}{dz} r \cdot u(x,y,-D) \\
-    % \mathcal{S}_v &= -\frac{L_z}{dz} r \cdot v(x,y,-D)  \\
+    % \mathcal{S}_u &= -r_\mathrm{scaled} u(x,y,-D) \\
+    % \mathcal{S}_v &= -r_\mathrm{scaled} v(x,y,-D)  \\
     % \mathcal{S}_w &= 0 \\
     % \mathcal{S}_\eta &= 0
     % \end{align}
@@ -22,18 +31,17 @@ classdef WVBottomFrictionLinear < WVForcing
     %
     % $$
     % \begin{align}
-    % \mathcal{S}_\textrm{qgpv} &= -\frac{L_z}{dz} r \cdot \zeta(x,y,-D)
+    % \mathcal{S}_\mathrm{qgpv} &= -r_\mathrm{scaled}\zeta(x,y,-D)
     % \end{align}
     % $$
     %
     % where $$\zeta = \partial_x v - \partial_y u$$.
     %
-    % ### Usage
-    %
-    % Assuming there is a WVTransform instance wvt, to add this forcing,
+    % ### Example
     %
     % ```matlab
-    % wvt.addForcing(WVBottomFrictionLinear(r=1/(200*86400)));
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+    % wvt.addForcing(WVBottomFrictionLinear(wvt,r=1/(200*86400)));
     % ```
     %
     % - Topic: Create the forcing
@@ -45,12 +53,18 @@ classdef WVBottomFrictionLinear < WVForcing
     %
     % - Declaration: WVBottomFrictionLinear < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % bottom friction, $$s^{-1}$$
+        % Configured linear drag rate in $$\mathrm{s^{-1}}$$.
+        %
+        % The constructor default is `1/(200*86400)`, corresponding to a
+        % 200-day time scale.
         %
         % - Topic: Properties
         r
 
-        % scaled bottom friction, $$\frac{Lz}{dz} r$$ with units $$s^{-1}$$
+        % Drag rate applied at the bottom grid point in $$\mathrm{s^{-1}}$$.
+        %
+        % This is `r*Lz/z_int(1)` for a three-dimensional transform and
+        % `r` for a barotropic transform.
         %
         % - Topic: Properties
         r_scaled
@@ -58,7 +72,7 @@ classdef WVBottomFrictionLinear < WVForcing
 
     methods
         function self = WVBottomFrictionLinear(wvt,options)
-            % initialize the WVBottomFrictionLinear
+            % Create linear bottom friction for a transform.
             %
             % See the [WVBottomFrictionLinear overview](/classes/forcing/wvbottomfrictionlinear/)
             % for the governing equations, resolution scaling, comparison
@@ -66,9 +80,9 @@ classdef WVBottomFrictionLinear < WVForcing
             %
             % - Topic: Initialization
             % - Declaration: self = WVBottomFrictionLinear(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter r: (optional) linear bottom friction, try 1/(200*86400)
-            % - Returns frictionalForce: a WVBottomFrictionLinear instance
+            % - Parameter wvt: transform that owns and evaluates the forcing
+            % - Parameter r: optional drag rate in inverse seconds; default `1/(200*86400)`
+            % - Returns self: linear bottom-friction forcing owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.r (1,1) double {mustBeNonnegative} = 1/(200*86400) % linear bottom friction, try 1/(200*86400) https://www.nemo-ocean.eu/doc/node70.html

--- a/Forcing/WVBottomFrictionQuadratic.m
+++ b/Forcing/WVBottomFrictionQuadratic.m
@@ -1,11 +1,16 @@
 classdef WVBottomFrictionQuadratic < WVForcing
-    % Quadratic bottom friction
+    % Apply quadratic drag at the bottom boundary.
     %
-    % Applies quadratic bottom friction to the flow, i.e., $$\frac{du}{dt} = -\frac{Cd}{dz}\lvert \mathbf{u} \rvert\mathbf{u}(x,y,-D)$$. Cd is unitless, and dz is (approximately) the size of the grid spacing at the bottom boundary.
+    % The dimensionless drag coefficient $$C_d$$ is divided by the bottom
+    % quadrature weight for a three-dimensional transform:
     %
-    % To compare with linear bottom friction where $$\frac{du}{dt} = -r \cdot u(x,y,-D)$$, note that $$- \frac{L_z}{dz} r = -\frac{C_d}{dz} \lvert \mathbf{u} \rvert$$ and you will find a characteristic velocity $$\lvert \mathbf{u} \rvert$$ of about 11.5 cm/s for Cd=0.002 and r=1/(200 days). If $$C_d=0.001$$, then the damping time scale has to double to 1/(400 days) for and equivalent characteristic velocity.
+    % $$
+    % c_d=\frac{C_d}{z_\mathrm{int}(1)}.
+    % $$
     %
-    % For barotropic QG we want the scaling to work out similarly, but now have $$-r = -\frac{C_d}{D}\lvert \mathbf{u} \rvert$$ where $$D$$ works out to be $$L_z$$. Thus, we will scale the barotropic QG quadratic bottom drag by 4000 m, to match typical oceanic scales.
+    % Barotropic QG uses a fixed 4000 m reference depth,
+    % $$c_d=C_d/(4000\,\mathrm{m})$$. Comparing quadratic and linear drag
+    % gives the characteristic relation $$L_z r=C_d\lvert\mathbf{u}\rvert$$.
     %
     % Using the notation that
     %
@@ -13,12 +18,13 @@ classdef WVBottomFrictionQuadratic < WVForcing
     % |\mathbf{u}(x,y,-D)| = \sqrt{u^2(x,y,-D) + v^2(x,y,-D)}
     % $$
     %
-    % is the magnitude of the total velocity at the bottom boundary, both nonhydrostatic and hydrostatic transforms linear bottom drag have the form
+    % is the magnitude of the total velocity at the bottom boundary. For
+    % hydrostatic and nonhydrostatic transforms,
     %
     % $$
     % \begin{align}
-    % \mathcal{S}_u &= -\frac{C_d}{dz} |\mathbf{u}(x,y,-D)| u(x,y,-D) \\
-    % \mathcal{S}_v &= -\frac{C_d}{dz} |\mathbf{u}(x,y,-D)| v(x,y,-D)  \\
+    % \mathcal{S}_u &= -c_d |\mathbf{u}(x,y,-D)| u(x,y,-D) \\
+    % \mathcal{S}_v &= -c_d |\mathbf{u}(x,y,-D)| v(x,y,-D)  \\
     % \mathcal{S}_w &= 0 \\
     % \mathcal{S}_\eta &= 0
     % \end{align}
@@ -28,16 +34,15 @@ classdef WVBottomFrictionQuadratic < WVForcing
     %
     % $$
     % \begin{align}
-    % \mathcal{S}_\textrm{qgpv} &= -\frac{C_dd}{dz} \left( \frac{\partial}{\partial x} \left( |\mathbf{u}(x,y,-D)| v(x,y,-D) \right) - \frac{\partial}{\partial y} \left( |\mathbf{u}(x,y,-D)| u(x,y,-D) \right) \right)
+    % \mathcal{S}_\mathrm{qgpv} &= -c_d \left[ \partial_x \left( |\mathbf{u}|v \right) - \partial_y \left( |\mathbf{u}|u \right) \right]_{z=-D}
     % \end{align}
     % $$
     %
-    % ### Usage
-    %
-    % Assuming there is a WVTransform instance wvt, to add this forcing,
+    % ### Example
     %
     % ```matlab
-    % wvt.addForcing(WVBottomFrictionQuadratic(Cd=0.001));
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+    % wvt.addForcing(WVBottomFrictionQuadratic(wvt,Cd=0.001));
     % ```
     %
     %
@@ -50,12 +55,17 @@ classdef WVBottomFrictionQuadratic < WVForcing
     %
     % - Declaration: WVBottomFrictionQuadratic < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % non-dimensional quadratic drag coefficient
+        % Configured dimensionless quadratic drag coefficient.
+        %
+        % The constructor default is `1e-3`.
         %
         % - Topic: Properties
         Cd
 
-        % $$\frac{Cd}{dz}$$ scaled quadratic drag coefficient with units $$m^{-1}$$
+        % Drag coefficient applied at the bottom in $$\mathrm{m^{-1}}$$.
+        %
+        % This is `Cd/z_int(1)` for a three-dimensional transform and
+        % `Cd/4000` for a barotropic transform.
         %
         % - Topic: Properties
         cd
@@ -63,7 +73,7 @@ classdef WVBottomFrictionQuadratic < WVForcing
 
     methods
         function self = WVBottomFrictionQuadratic(wvt,options)
-            % initialize the WVBottomFrictionQuadratic
+            % Create quadratic bottom friction for a transform.
             %
             % See the [WVBottomFrictionQuadratic overview](/classes/forcing/wvbottomfrictionquadratic/)
             % for the governing equations, geometry-dependent scaling,
@@ -71,9 +81,9 @@ classdef WVBottomFrictionQuadratic < WVForcing
             %
             % - Topic: Initialization
             % - Declaration: self = WVBottomFrictionQuadratic(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter Cd: (optional) non-dimensional quadratic damping coefficient. Default is 0.001
-            % - Returns frictionalForce: a WVBottomFrictionQuadratic instance
+            % - Parameter wvt: transform that owns and evaluates the forcing
+            % - Parameter Cd: optional dimensionless drag coefficient; default `1e-3`
+            % - Returns self: quadratic bottom-friction forcing owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.Cd (1,1) double {mustBeNonnegative} = 1e-3 % https://www.nemo-ocean.eu/doc/node70.html

--- a/Forcing/WVFixedAmplitudeForcing.m
+++ b/Forcing/WVFixedAmplitudeForcing.m
@@ -1,7 +1,8 @@
 classdef WVFixedAmplitudeForcing < WVForcing
-    % Fixed amplitude forcing at the natural frequency of each mode
+    % Hold selected wave-vortex coefficients at prescribed amplitudes.
     %
-    % The fixed-amplitude forcing maintains the amplitude of the wave or geostrophic features, while allowing energy and enstrophy to flux from the feature.
+    % The forcing maintains selected wave or geostrophic coefficients while
+    % recording the tendency that must be cancelled to maintain them.
     %
     % As a simple example, one can set an internal wave mode with amplitude 1 cm/s, and that mode will continue to oscillate and maintain its amplitude. The wave will participate in all the nonlinear dynamics, but its amplitude will be maintained/restored at each time step.
     %
@@ -12,7 +13,12 @@ classdef WVFixedAmplitudeForcing < WVForcing
     % \frac{\partial}{\partial t} A^{klj} = \sum_i F_i^{klj}
     % $$
     %
-    % where $$F_i$$ are the different forces applied. The transform computes the spatial forcing (which includes nonlinear advection), the spectral forcing, followed by the spectral amplitude forcing. The `WVFixedAmplitudeForcing` is a spectral amplitude forcing and is thus comptued last. This forcing thus simply adds back the flux the from the spatial and spectral forcing, so that $$\frac{\partial}{\partial t} A^{klj} =0$$ for the modes in question.
+    % where $$F_i$$ are the contributions from the registered forcing
+    % objects. The transform evaluates physical-space forcing, spectral
+    % forcing, and then spectral-amplitude forcing. This forcing is evaluated
+    % last: it zeros the tendency at selected indices and restores the
+    % prescribed coefficient values after the integration step, giving
+    % $$\partial_t A^{k\ell j}=0$$ for those modes.
     %
     % In practice, of course, we simply restore the amplitudes to their desired value at the last step, e.g.,
     %
@@ -23,26 +29,22 @@ classdef WVFixedAmplitudeForcing < WVForcing
     % ### Notes
     %
     % - This approach is commonly used in forced-dissipative turbulence to maintain some fixed forcing.
-    % - Every mode that is used in `WVFixedAmplitudeForcing` essentially removes a degree-of-freedom from the model, as that mode is no longer free to fully evolve. Thus when you pass the forcing wave-vortex coefficients, e.g. `A0`, it does not fix the amplitude of coefficients that are small to avoid removing degrees-of-freedom.
-    % - One must also be careful not to forcing in the damping region. If you have some sort of small scale damping enabled, you probably do not want to be forcing at those smallest scales.
+    % - Every fixed mode removes a degree of freedom because it no longer
+    % evolves freely. The setter methods therefore ignore coefficients below
+    % $$10^{-6}$$ times the largest supplied magnitude unless an explicit
+    % mask is provided.
+    % - Avoid selecting modes in a closure's damping range. When
+    % `WVAdaptiveDamping` is registered, the setter methods automatically
+    % remove requested modes with $$K_h>k_\mathrm{damp}$$.
     %
-    % ### Usage
-    %
-    % To setup a geostrophic mean flow,
+    % ### Example
     %
     % ```matlab
-    % % initialize a transform
-    % wvt = WVTransformHydrostatic([Lx, Ly, Lz], [Nx, Ny, Nz], N2=@(z) N0*N0*exp(2*z/L_gm),latitude=33);
-    %
-    % % set a geostrophic mode, with no flow at the bottom boundary
-    % wvt.setGeostrophicModes(k=0,l=5,j=1,phi=0,u=u0);
-    % wvt.setGeostrophicModes(k=0,l=5,j=0,phi=0,u=max(max(wvt.u(:,:,1))));
-    %
-    % % pass the vortex coefficients to the forcing
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+    % wvt.setGeostrophicModes(kMode=1,lMode=0,j=1,u=0.01);
     % force = WVFixedAmplitudeForcing(wvt,name="geostrophic-mean-flow");
     % force.setGeostrophicForcingCoefficients(wvt.A0);
     % wvt.addForcing(force);
-    %
     % ```
     %
     % In practice you can initialize the flow in any way you want with any arbitrary structure, and then pass those coefficients to the forcing. The `WVFixedAmplitudeForcing` looks for coefficients that are small and ignores those.
@@ -57,32 +59,47 @@ classdef WVFixedAmplitudeForcing < WVForcing
     %
     % - Declaration: WVFixedAmplitudeForcing < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % indices of modes in the `A0` matrix to fix
+        % Linear indices of the selected `A0` coefficients.
+        %
+        % This column vector is empty by default and has one entry for each
+        % value in `A0bar`.
         %
         % - Topic: Properties
         A0_indices (:,1) uint64 = []
 
-        % indices of modes in the `Ap` matrix to fix
+        % Linear indices of the selected `Ap` coefficients.
+        %
+        % This column vector is empty by default and has one entry for each
+        % value in `Apbar`.
         %
         % - Topic: Properties
         Ap_indices (:,1) uint64 = []
 
-        % indices of modes in the `Am` matrix to fix
+        % Linear indices of the selected `Am` coefficients.
+        %
+        % This column vector is empty by default and has one entry for each
+        % value in `Ambar`.
         %
         % - Topic: Properties
         Am_indices (:,1) uint64 = []
 
-        % amplitudes of the fixed modes in the `A0` matrix
+        % Prescribed `A0` values in $$\mathrm{m^2\,s^{-1}}$$.
+        %
+        % Values correspond element-by-element to `A0_indices`.
         %
         % - Topic: Properties
         A0bar (:,1) double = []
 
-        % amplitudes of the fixed modes in the `Ap` matrix
+        % Prescribed `Ap` values in $$\mathrm{m\,s^{-1}}$$.
+        %
+        % Values correspond element-by-element to `Ap_indices`.
         %
         % - Topic: Properties
         Apbar (:,1) double = []
 
-        % amplitudes of the fixed modes in the `Am` matrix
+        % Prescribed `Am` values in $$\mathrm{m\,s^{-1}}$$.
+        %
+        % Values correspond element-by-element to `Am_indices`.
         %
         % - Topic: Properties
         Ambar (:,1) double = []
@@ -90,10 +107,12 @@ classdef WVFixedAmplitudeForcing < WVForcing
 
     methods
         function self = WVFixedAmplitudeForcing(wvt,options)
-            % initialize the WVFixedAmplitudeForcing
+            % Create fixed-amplitude forcing for selected coefficients.
             %
-            % You must pass the instance of the WVTransform to be used and
-            % you must also specify a unique name for the forcing.
+            % Supply a unique registry name. Coefficients may be selected
+            % directly with paired value/index column vectors, or later with
+            % `setWaveForcingCoefficients` and
+            % `setGeostrophicForcingCoefficients`.
             %
             % See the [WVFixedAmplitudeForcing overview](/classes/forcing/wvfixedamplitudeforcing/)
             % for the tendency and restoration behavior, modeling cautions,
@@ -101,15 +120,15 @@ classdef WVFixedAmplitudeForcing < WVForcing
             %
             % - Topic: Initialization
             % - Declaration: self = WVFixedAmplitudeForcing(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter name: (required) name of this forcing
-            % - Parameter Apbar: (optional) amplitude of Ap matrix to fix
-            % - Parameter Ambar: (optional) amplitude of Am matrix to fix
-            % - Parameter A0bar: (optional) amplitude of A0 matrix to fix
-            % - Parameter Ap_indices: (optional) index of coefficient in Ap matrix to fix
-            % - Parameter Am_indices: (optional) index of coefficient in Am matrix to fix
-            % - Parameter A0_indices: (optional) index of coefficient in A0 matrix to fix
-            % - Returns self: a WVFixedAmplitudeForcing instance
+            % - Parameter wvt: transform that owns and evaluates the forcing
+            % - Parameter name: required unique forcing-registry name
+            % - Parameter Apbar: optional column of prescribed `Ap` values; default empty
+            % - Parameter Ambar: optional column of prescribed `Am` values; default empty
+            % - Parameter A0bar: optional column of prescribed `A0` values; default empty
+            % - Parameter Ap_indices: optional column of corresponding `Ap` linear indices; default empty
+            % - Parameter Am_indices: optional column of corresponding `Am` linear indices; default empty
+            % - Parameter A0_indices: optional column of corresponding `A0` linear indices; default empty
+            % - Returns self: fixed-amplitude forcing owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.name {mustBeText}
@@ -138,17 +157,19 @@ classdef WVFixedAmplitudeForcing < WVForcing
             end
         end
         function setWaveForcingCoefficients(self,Apbar,Ambar,options)
-            % set the amplitude to fix for the wave part of the flow
+            % Select positive- and negative-frequency coefficients to fix.
             %
-            % This function will automatically remove modes set in the
-            % damping region of the WVAdaptiveDamping forcing, if present.
+            % Without explicit masks, coefficients whose magnitude is at
+            % least $$10^{-6}$$ times the largest supplied magnitude are
+            % selected. If adaptive damping is registered, selected modes
+            % above its horizontal `k_damp` threshold are removed.
             %
             % - Topic: Setting the forcing
-            % - Declaration:  setWaveForcingCoefficients(Apbar,Ambar,options)
-            % - Parameter Apbar: Ap fixed amplitude
-            % - Parameter Ambar: Am fixed amplitude
-            % - Parameter MAp: (optional) forcing mask, Ap. 1s at the forced modes, 0s at the unforced modes. Default is MAp = abs(Apbar) > 1e-6*max(abs(Apbar(:)))
-            % - Parameter MAm: (optional) forcing mask, Am. 1s at the forced modes, 0s at the unforced modes. Default is MAm = abs(Ambar) > 1e-6*max(abs(Ambar(:)))
+            % - Declaration: setWaveForcingCoefficients(Apbar,Ambar,options)
+            % - Parameter Apbar: `Ap` values on the transform spectral grid
+            % - Parameter Ambar: `Am` values on the transform spectral grid
+            % - Parameter MAp: optional logical `Ap` selection mask; default `abs(Apbar) > 1e-6*max(abs(Apbar(:)))`
+            % - Parameter MAm: optional logical `Am` selection mask; default `abs(Ambar) > 1e-6*max(abs(Ambar(:)))`
             arguments
                 self WVFixedAmplitudeForcing {mustBeNonempty}
                 Apbar (:,:) double {mustBeNonempty}
@@ -179,15 +200,17 @@ classdef WVFixedAmplitudeForcing < WVForcing
         end
 
         function setGeostrophicForcingCoefficients(self,A0bar,options)
-            % set amplitude to fix for the geostrophic part of the flow
+            % Select zero-frequency coefficients to fix.
             %
-            % This function will automatically remove modes set in the
-            % damping region of the WVAdaptiveDamping forcing, if present.
+            % Without an explicit mask, coefficients whose magnitude is at
+            % least $$10^{-6}$$ times the largest supplied magnitude are
+            % selected. If adaptive damping is registered, selected modes
+            % above its horizontal `k_damp` threshold are removed.
             %
             % - Topic: Setting the forcing
             % - Declaration: setGeostrophicForcingCoefficients(A0bar,options)
-            % - Parameter A0bar: A0 fixed amplitude
-            % - Parameter MA0: (optional) forcing mask, A0. 1s at the forced modes, 0s at the unforced modes. Default is MA0 = abs(A0bar) > 1e-6*max(abs(A0bar(:)))
+            % - Parameter A0bar: `A0` values on the transform spectral grid
+            % - Parameter MA0: optional logical `A0` selection mask; default `abs(A0bar) > 1e-6*max(abs(A0bar(:)))`
             arguments
                 self WVFixedAmplitudeForcing {mustBeNonempty}
                 A0bar (:,:) double {mustBeNonempty}
@@ -212,13 +235,31 @@ classdef WVFixedAmplitudeForcing < WVForcing
         end
 
         function [model_spectrum, r] = setNarrowBandGeostrophicForcing(self, options)
-            % sets a narrow waveband of geostrophic forcing for forced-dissipative modeling
+            % Initialize and fix a narrow band of geostrophic coefficients.
             %
-            % to be moved to a subclass
+            % This legacy helper optionally initializes `wvt.A0`, constructs
+            % a radial geostrophic spectrum, selects the band centered on
+            % `k_f` at vertical mode `j_f`, and passes that selection to
+            % `setGeostrophicForcingCoefficients`. It mutates both the
+            % transform and this forcing. Its eventual replacement is
+            % tracked by [Issue #2](https://github.com/JeffreyEarly/wave-vortex-model/issues/2).
+            %
+            % `model_spectrum` is assigned only when `initialPV` is
+            % `"narrow-band"` or `"full-spectrum"`. The returned `r` is
+            % assigned only when `r` is omitted and computed from `k_r`.
+            % Callers should therefore treat both outputs as conditional
+            % legacy diagnostics.
             %
             % - Topic: Setting the forcing
-            % - Declaration: setNarrowBandGeostrophicForcing(options)
-            % - Parameter r: A0 fixed amplitude
+            % - Declaration: [model_spectrum,r] = setNarrowBandGeostrophicForcing(options)
+            % - Parameter r: optional large-scale damping rate in inverse seconds; when supplied, determines `k_r`
+            % - Parameter k_r: optional arrest wavenumber in radians per meter; default `2*dk`
+            % - Parameter k_f: optional forcing-band center in radians per meter; default `20*dk`
+            % - Parameter j_f: optional forced vertical-mode number; default `1`
+            % - Parameter u_rms: optional target surface root-mean-square speed in meters per second; default `0.2`
+            % - Parameter initialPV: optional initialization choice `"none"`, `"narrow-band"`, or `"full-spectrum"`; default `"narrow-band"`
+            % - Returns model_spectrum: conditional radial spectrum function used for initialization
+            % - Returns r: conditional damping-rate estimate computed when `r` is omitted
             arguments
                 self WVFixedAmplitudeForcing {mustBeNonempty}
                 options.r (1,1) double

--- a/Forcing/WVHorizontalDamping.m
+++ b/Forcing/WVHorizontalDamping.m
@@ -1,11 +1,13 @@
 classdef WVHorizontalDamping < WVForcing
-    % Horizontal laplacian damping with viscosity and diffusivity
+    % Apply horizontal Laplacian viscosity and diffusivity.
     %
     % The damping is a simple horizontal Laplacian, designed to mimic the
     % [HorizontalScalarDiffusivity in
     % Oceananigans](https://clima.github.io/OceananigansDocumentation/stable/appendix/library/#Oceananigans.TurbulenceClosures.HorizontalScalarDiffusivity)
-    % to allow for direct comparison between the models. This is intended to be used in combination with WVVerticalScalarDiffusivity. In
-    % general, you should be using the
+    % to allow direct comparison between the models. It applies to
+    % wave-bearing three-dimensional transforms and is intended for use with
+    % [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/).
+    % For an automatically scaled closure, use
     % [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
     % 
     % The specific form of the forcing is given by 
@@ -19,25 +21,24 @@ classdef WVHorizontalDamping < WVForcing
     % \end{align}
     % $$
     %
-    % which is just your standard Laplacian viscosity, $$\nu$$, and diffusivity, $$\kappa$$, in
-    % the horizontal. This should be combined with
-    % [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) for a complete closure. For help
-    % choosing appropriate values, see the notes in
+    % These are horizontal Laplacian viscosity, $$\nu$$, and diffusivity,
+    % $$\kappa$$. Combine this closure with
+    % [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) to
+    % damp vertical gradients as well. For guidance on automatically scaled
+    % coefficients, see
     % [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
     %
-    % ### Usage
-    %
-    % Assuming there is a WVTransform instance wvt, to add this forcing,
+    % ### Example
     %
     % ```matlab
-    % wvt.addForcing(WVHorizontalDamping(wvt,nu=1e-4, kappa=1e-6));
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+    % wvt.addForcing(WVHorizontalDamping(wvt,nu=1e-4,kappa=1e-6));
     % ```
     %
     %
     % ### Notes
     %
-    % This is currently implemented in the spatial domain and is
-    % thus highly un-optimized.
+    % This closure is evaluated in the spatial domain.
     %
     % The configured viscosity and diffusivity are preserved when the
     % forcing is copied to a transform with a different resolution.
@@ -50,12 +51,16 @@ classdef WVHorizontalDamping < WVForcing
     %
     % - Declaration: WVHorizontalDamping < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % horizontal viscosity
+        % Horizontal momentum viscosity in $$\mathrm{m^2\,s^{-1}}$$.
+        %
+        % The constructor default is `1e-4`.
         %
         % - Topic: Properties
         nu
 
-        % horizontal diffusivity
+        % Horizontal displacement diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
+        %
+        % The constructor default is `1e-6`.
         %
         % - Topic: Properties
         kappa
@@ -63,14 +68,14 @@ classdef WVHorizontalDamping < WVForcing
 
     methods
         function self = WVHorizontalDamping(wvt,options)
-            % initialize the WVHorizontalDamping
+            % Create horizontal Laplacian damping for a transform.
             %
             % - Topic: Initialization
             % - Declaration: self = WVHorizontalDamping(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter nu: horizontal viscosity, default $$1 \cdot 10^{-4} \textrm{m}^2/\textrm{s}$$
-            % - Parameter kappa: horizontal diffusivity, default $$1 \cdot 10^{-6} \textrm{m}^2/\textrm{s}$$
-            % - Returns self: a WVHorizontalDamping instance
+            % - Parameter wvt: wave-bearing three-dimensional transform that owns the closure
+            % - Parameter nu: optional horizontal viscosity in square meters per second; default `1e-4`
+            % - Parameter kappa: optional horizontal diffusivity in square meters per second; default `1e-6`
+            % - Returns self: horizontal-damping closure owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.nu = 1e-4
@@ -101,12 +106,11 @@ classdef WVHorizontalDamping < WVForcing
         end
 
         function force = forcingWithResolutionOfTransform(self, wvtX2)
-            % Creates a forcing with the resolution of the transform
+            % Create equivalent horizontal damping for another resolution.
             %
             % - Declaration: forcingWithResolutionOfTransform(self, wvtX2)
-            % - Parameter self: an instance of WVHorizontalDamping
-            % - Parameter wvtX2: a WVTransform instance with doubled resolution
-            % - Returns: force
+            % - Parameter wvtX2: compatible transform at the target resolution
+            % - Returns force: horizontal damping owned by `wvtX2`
             arguments
                 self WVHorizontalDamping {mustBeNonempty}
                 wvtX2 WVTransform {mustBeNonempty}

--- a/Forcing/WVNonlinearAdvection.m
+++ b/Forcing/WVNonlinearAdvection.m
@@ -1,9 +1,9 @@
 classdef WVNonlinearAdvection < WVForcing
-    % The advective flux, $$\mathbf{u}\cdot \nabla \mathbf{u}$$ and $$\mathbf{u}\cdot \nabla \eta$$
+    % Add nonlinear advection to the model equations.
     %
-    % The nonlinear advection forcing adds the nonlinear terms to the momentum and thermodynamic equation.
-    %
-    % The nonlinear terms are all computed in the spatial domain.
+    % The nonlinear terms are evaluated in physical space and added to the
+    % momentum, thermodynamic, or quasigeostrophic potential-vorticity
+    % (QGPV) equation appropriate to the transform.
     %
     % For nonhydrostatic transforms,
     %
@@ -30,15 +30,25 @@ classdef WVNonlinearAdvection < WVForcing
     %
     % $$
     % \begin{align}
-    % \mathcal{S}_\textrm{qgpv} &= - \left( u \partial_x q + v \partial_y q \right)
+    % \mathcal{S}_\mathrm{qgpv} &= - \left( u \partial_x q + v \partial_y q \right)
     % \end{align}
     % $$
     %
-    % where $$q$$ is the qgpv.
+    % where $$q$$ is QGPV.
     %
     % ### Notes
     %
-    % This is the only forcing added to the transforms by default. You must explicitly remove it if you want to consider linear flows.
+    % Every supported transform installs this forcing by default. A
+    % nonlinear `WVModel` evaluates it automatically. Analytical linear
+    % evolution does not evaluate nonlinear forcing, so the object does not
+    % need to be removed when using linear evolution.
+    %
+    % ### Example
+    %
+    % ```matlab
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+    % nonlinearAdvection = wvt.forcingWithName("nonlinear advection");
+    % ```
     %
     % - Topic: Create the forcing
     % - Topic: Implement forcing evaluation
@@ -48,7 +58,10 @@ classdef WVNonlinearAdvection < WVForcing
     %
     % - Declaration: WVNonlinearAdvection < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % variable stratification factor
+        % Precomputed vertical logarithmic stratification gradient.
+        %
+        % This Internal array is zero for constant stratification and has
+        % units of inverse meters for variable stratification.
         %
         % - Topic: Properties
         dLnN2 = 0
@@ -56,16 +69,16 @@ classdef WVNonlinearAdvection < WVForcing
 
     methods
         function self = WVNonlinearAdvection(wvt)
-            % initialize the WVNonlinearAdvection nonlinear flux
+            % Create nonlinear advection for a transform.
             %
             % See the [WVNonlinearAdvection overview](/classes/forcing/wvnonlinearadvection/)
-            % for the hydrostatic, nonhydrostatic, and quasigeostrophic
-            % equations and its role as the default forcing.
+            % for the hydrostatic, nonhydrostatic, and QGPV equations and
+            % its role as the default forcing.
             %
             % - Topic: Initialization
-            % - Declaration: self = WVNonlinearAdvection(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Returns self: a WVNonlinearAdvection instance
+            % - Declaration: self = WVNonlinearAdvection(wvt)
+            % - Parameter wvt: transform that owns and evaluates the forcing
+            % - Returns self: nonlinear-advection forcing owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
             end

--- a/Forcing/WVThermalDamping.m
+++ b/Forcing/WVThermalDamping.m
@@ -1,15 +1,26 @@
 classdef WVThermalDamping < WVForcing
-    % Thermal damping
+    % Apply large-scale thermal damping to QGPV.
     %
-    % Applies thermal damping to the flow, i.e., $$\frac{dq}{dt} = \alpha \lambda^2 \psi$$.
+    % For each deformation scale $$L_r$$, the implementation adds
     %
-    % This is as defined in Scott and Dritschel, but it can be shown that
-    % it is basically just a vertical diffusivity.
+    % $$
+    % \mathcal{S}_q=\frac{\alpha}{L_r^2}\psi.
+    % $$
+    %
+    % This follows the large-scale thermal-damping formulation considered
+    % by [Scott and Dritschel](https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/halting-scale-and-energy-equilibration-in-twodimensional-quasigeostrophic-turbulence/BD0CAFC9019691ADC9B18A95D15445F9).
     %
     % ### Notes
     %
-    % This is only implemented for quasigeostrophic flows. Specifically, it
-    % requires `WVForcingType("PVSpatial")`.
+    % This forcing is compatible only with stratified and barotropic QG
+    % transforms through their physical-space QGPV forcing stage.
+    %
+    % ### Example
+    %
+    % ```matlab
+    % wvt = WVTransformBarotropicQG([40e3,30e3],[8,6],h=0.8,latitude=45);
+    % wvt.addForcing(WVThermalDamping(wvt,alpha=1/(200*86400)));
+    % ```
     %
     % - Topic: Create the forcing
     % - Topic: Inspect forcing configuration
@@ -19,12 +30,17 @@ classdef WVThermalDamping < WVForcing
     % - Topic: Forcing persistence
     % - Declaration: WVThermalDamping < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % damping parameter, units of $$s^{-1}$$
+        % Configured thermal-damping rate in $$\mathrm{s^{-1}}$$.
+        %
+        % The constructor default is `1/(200*86400)`.
         %
         % - Topic: Properties
         alpha
 
-        % scaled damping parameter, units of $$s^{-1} m^{-2}$$
+        % Deformation-scaled damping coefficient in $$\mathrm{s^{-1}\,m^{-2}}$$.
+        %
+        % This is `alpha/wvt.Lr2` and has the shape required by the QG
+        % streamfunction field.
         %
         % - Topic: Properties
         alpha_scaled
@@ -32,13 +48,13 @@ classdef WVThermalDamping < WVForcing
 
     methods
         function self = WVThermalDamping(wvt,options)
-            % initialize the WVThermalDamping
+            % Create thermal damping for a QG transform.
             %
             % - Topic: Initialization
             % - Declaration: self = WVThermalDamping(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter alpha: (optional) damping time scale, default 1/(200*86400)
-            % - Returns self: a WVThermalDamping instance
+            % - Parameter wvt: stratified or barotropic QG transform that owns the forcing
+            % - Parameter alpha: optional damping rate in inverse seconds; default `1/(200*86400)`
+            % - Returns self: thermal-damping forcing owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.alpha (1,1) double {mustBeNonnegative} = 1/(200*86400)

--- a/Forcing/WVVerticalDamping.m
+++ b/Forcing/WVVerticalDamping.m
@@ -1,10 +1,12 @@
 classdef WVVerticalDamping < WVForcing
-    % Vertical viscosity and diffusivity
+    % Apply vertical Laplacian viscosity and diffusivity.
     %
     % The damping is designed to mimic the VerticalScalarDiffusivity in
     % Oceananigans to allow for direct comparison between the models. This
-    % is intended be used in combination with
-    % WVHorizontalDamping. In general, you should be using the
+    % applies to wave-bearing three-dimensional transforms and is intended
+    % for use with
+    % [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/).
+    % For an automatically scaled closure, use
     % [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
     % 
     % The specific form of the forcing is given by 
@@ -18,24 +20,24 @@ classdef WVVerticalDamping < WVForcing
     % \end{align}
     % $$
     %
-    % with viscosity, $$\nu$$, and diffusivity, $$\kappa$$. This should be combined with
-    % [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/) for a complete closure. For help
-    % choosing appropriate values, see the notes in
+    % Here $$\nu$$ is the vertical viscosity and $$\kappa$$ is the vertical
+    % diffusivity. Combine this closure with
+    % [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/)
+    % to damp horizontal gradients as well. For guidance on automatically
+    % scaled coefficients, see
     % [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
     %
-    % ### Usage
-    %
-    % Assuming there is a WVTransform instance wvt, to add this forcing,
+    % ### Example
     %
     % ```matlab
-    % wvt.addForcing(WVVerticalDamping(wvt,nu=5e-4, kappa=1e-6));
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+    % wvt.addForcing(WVVerticalDamping(wvt,nu=5e-4,kappa=1e-6));
     % ```
     %
     %
     % ### Notes
     %
-    % This is currently implemented in the spatial domain and is
-    % thus highly un-optimized.
+    % This closure is evaluated in the spatial domain.
     %
     % For constant stratification, $$\partial_z \ln N^2=0$$ and the
     % stratification-gradient correction vanishes. The configured viscosity
@@ -51,17 +53,24 @@ classdef WVVerticalDamping < WVForcing
     %
     % - Declaration: WVVerticalDamping < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % vertical viscosity
+        % Vertical momentum viscosity in $$\mathrm{m^2\,s^{-1}}$$.
+        %
+        % The constructor default is `5e-4`.
         %
         % - Topic: Properties
         nu
 
-        % vertical diffusivity
+        % Vertical displacement diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
+        %
+        % The constructor default is `1e-6`.
         %
         % - Topic: Properties
         kappa
 
-        % variable stratification factor
+        % Precomputed vertical logarithmic stratification gradient.
+        %
+        % This Internal array is zero for constant stratification and has
+        % units of inverse meters for variable stratification.
         %
         % - Topic: Properties
         dLnN2 = 0
@@ -69,14 +78,14 @@ classdef WVVerticalDamping < WVForcing
 
     methods
         function self = WVVerticalDamping(wvt,options)
-            % initialize the WVVerticalDamping
+            % Create vertical Laplacian damping for a transform.
             %
             % - Topic: Initialization
             % - Declaration: self = WVVerticalDamping(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter nu: vertical viscosity, default $$5 \cdot 10^{-4} \textrm{m}^2/\textrm{s}$$
-            % - Parameter kappa: vertical diffusivity, default $$1 \cdot 10^{-6} \textrm{m}^2/\textrm{s}$$
-            % - Returns self: a WVVerticalDamping instance
+            % - Parameter wvt: wave-bearing three-dimensional transform that owns the closure
+            % - Parameter nu: optional vertical viscosity in square meters per second; default `5e-4`
+            % - Parameter kappa: optional vertical diffusivity in square meters per second; default `1e-6`
+            % - Returns self: vertical-damping closure owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.nu = 5e-4
@@ -110,12 +119,11 @@ classdef WVVerticalDamping < WVForcing
         end
 
         function force = forcingWithResolutionOfTransform(self, wvtX2)
-            % Creates a forcing with the resolution of the transform
+            % Create equivalent vertical damping for another resolution.
             %
             % - Declaration: forcingWithResolutionOfTransform(self, wvtX2)
-            % - Parameter self: an instance of WVVerticalDamping
-            % - Parameter wvtX2: a WVTransform instance with doubled resolution
-            % - Returns: force
+            % - Parameter wvtX2: compatible transform at the target resolution
+            % - Returns force: vertical damping owned by `wvtX2`
             arguments
                 self WVVerticalDamping {mustBeNonempty}
                 wvtX2 WVTransform {mustBeNonempty}

--- a/Forcing/WVVerticalDiffusivity.m
+++ b/Forcing/WVVerticalDiffusivity.m
@@ -1,5 +1,5 @@
 classdef WVVerticalDiffusivity < WVForcing
-    % Vertical diffusivty
+    % Apply vertical diffusivity to the thermodynamic field.
     %
     % This forcing applies a vertical diffusivity with fixed $$\kappa_z$$
     % to the thermodynamic equation.
@@ -15,23 +15,24 @@ classdef WVVerticalDiffusivity < WVForcing
     % \end{align}
     % $$
     %
-    % Upon initialization you can set `shouldForceMeanDensityAnomaly` to
-    % `false` and the $$\frac{\partial}{\partial z} \ln N^2$$ term will be
-    % neglected.
+    % Set `shouldForceMeanDensityAnomaly=false` to omit the
+    % $$\partial_z\ln N^2$$ correction for variable stratification. This
+    % option has no effect for constant stratification because the gradient
+    % is zero.
     %
-    % ### Usage
-    %
-    % Assuming there is a WVTransform instance wvt, to add this forcing,
+    % ### Example
     %
     % ```matlab
-    % wvt.addForcing(WVVerticalDiffusivity(wvt, kappa_z=1e-6));
+    % wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+    % wvt.addForcing(WVVerticalDiffusivity(wvt,kappa_z=1e-6));
     % ```
     %
     % ### Notes
     %
     % This is currently implemented in the spatial domain. It applies to
-    % three-dimensional wave and stratified-QG transforms, but not to a
-    % barotropic transform because that geometry has no vertical structure.
+    % wave-bearing three-dimensional transforms and has a separate QGPV
+    % pathway for stratified QG. It is not compatible with barotropic QG,
+    % which has no vertical structure.
     %
     % - Topic: Create the forcing
     % - Topic: Inspect forcing configuration
@@ -42,17 +43,26 @@ classdef WVVerticalDiffusivity < WVForcing
     %
     % - Declaration: WVVerticalDiffusivity < [WVForcing](/classes/forcing/wvforcing/)
     properties
-        % vertical diffusivity, $$m^2s^{-1}$$
+        % Configured vertical diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
+        %
+        % The constructor default is `1e-5`.
         %
         % - Topic: Properties
         kappa_z
 
-        % whether to include the $$\frac{\partial}{\partial z} \ln N^2$$ term
+        % Whether to include the variable-stratification correction.
+        %
+        % The default is `true`. This controls the precomputed
+        % $$\partial_z\ln N^2$$ term used by the wave-bearing pathway.
         %
         % - Topic: Properties
         shouldForceMeanDensityAnomaly
 
-        % precomputed dLnN2 term
+        % Precomputed vertical logarithmic stratification gradient.
+        %
+        % This Internal value is zero when the correction is disabled or
+        % stratification is constant, and otherwise has units of inverse
+        % meters.
         %
         % - Topic: Properties
         dLnN2 = 0
@@ -60,14 +70,14 @@ classdef WVVerticalDiffusivity < WVForcing
 
     methods
         function self = WVVerticalDiffusivity(wvt,options)
-            % initialize the WVVerticalDiffusivity
+            % Create vertical diffusivity for a three-dimensional transform.
             %
             % - Topic: Initialization
             % - Declaration: self = WVVerticalDiffusivity(wvt,options)
-            % - Parameter wvt: a WVTransform instance
-            % - Parameter kappa_z: (optional) vertical diffusivity, $$m^2s^{-1}$$. Default values 1e-5
-            % - Parameter shouldForceMeanDensityAnomaly: (optional) whether to include the $$\frac{\partial}{\partial z} \ln N^2$$ term. Default `true`.
-            % - Returns self: a WVVerticalDiffusivity instance
+            % - Parameter wvt: wave-bearing or stratified-QG transform that owns the forcing
+            % - Parameter kappa_z: optional vertical diffusivity in square meters per second; default `1e-5`
+            % - Parameter shouldForceMeanDensityAnomaly: optional variable-stratification correction flag; default `true`
+            % - Returns self: vertical-diffusivity forcing owned by `wvt`
             arguments
                 wvt WVTransform {mustBeNonempty}
                 options.kappa_z double = 1e-5
@@ -102,12 +112,11 @@ classdef WVVerticalDiffusivity < WVForcing
         end
 
         function force = forcingWithResolutionOfTransform(self, wvtX2)
-            % Creates a forcing with the resolution of the transform
+            % Create equivalent vertical diffusivity for another resolution.
             %
             % - Declaration: forcingWithResolutionOfTransform(self, wvtX2)
-            % - Parameter self: an instance of WVAdaptiveViscosity
-            % - Parameter wvtX2: a WVTransform instance with doubled resolution
-            % - Returns: force
+            % - Parameter wvtX2: compatible transform at the target resolution
+            % - Returns force: vertical diffusivity owned by `wvtX2`
             arguments
                 self WVVerticalDiffusivity {mustBeNonempty}
                 wvtX2 WVTransform {mustBeNonempty}

--- a/UnitTests/TestCoreAPIDocumentation.m
+++ b/UnitTests/TestCoreAPIDocumentation.m
@@ -584,37 +584,39 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
         function forcingDetailedDescriptionsRemainOnClassPages(testCase)
             expectations = {
                 "wvbottomfrictionlinear", [
-                    "volume integrated effect of friction remains the same regardless of resolution"
-                    "To compare with quadratic bottom friction"
+                    "bottom quadrature weight"
+                    "r_\mathrm{scaled}"
+                    "Comparing this with quadratic drag"
                     "For both nonhydrostatic and hydrostatic transforms"
                     "and for quasigeostrophic transforms"
-                    "### Usage"
-                    "wvt.addForcing(WVBottomFrictionLinear(r=1/(200*86400)))"
+                    "### Example"
+                    "wvt.addForcing(WVBottomFrictionLinear(wvt,r=1/(200*86400)))"
                     ]
                 "wvbottomfrictionquadratic", [
-                    "To compare with linear bottom friction"
-                    "For barotropic QG"
-                    "both nonhydrostatic and hydrostatic transforms"
+                    "quadrature weight"
+                    "4000 m reference depth"
+                    "Comparing quadratic and linear drag"
+                    "hydrostatic and nonhydrostatic transforms"
                     "and for quasigeostrophic transforms"
-                    "### Usage"
-                    "wvt.addForcing(WVBottomFrictionQuadratic(Cd=0.001))"
+                    "### Example"
+                    "wvt.addForcing(WVBottomFrictionQuadratic(wvt,Cd=0.001))"
                     ]
                 "wvfixedamplitudeforcing", [
                     "participate in all the nonlinear dynamics"
-                    "spectral amplitude forcing"
-                    "restore the amplitudes to their desired value"
-                    "removes a degree-of-freedom from the model"
-                    "small scale damping enabled"
-                    "### Usage"
+                    "spectral-amplitude forcing"
+                    "prescribed coefficient values"
+                    "removes a degree of freedom"
+                    "closure's damping range"
+                    "### Example"
                     ]
                 "wvnonlinearadvection", [
-                    "For nonhydrostatic transforms"
-                    "for hydrostatic transforms"
-                    "and for quasigeostrophic transforms"
+                    "nonhydrostatic transforms"
+                    "hydrostatic transforms"
+                    "quasigeostrophic transforms"
                     "\mathcal{S}_w"
                     "\mathcal{S}_\eta"
-                    "\mathcal{S}_\textrm{qgpv}"
-                    "only forcing added to the transforms by default"
+                    "\mathcal{S}_\mathrm{qgpv}"
+                    "installs this forcing by default"
                     ]
                 };
             for iExpectation = 1:size(expectations,1)

--- a/UnitTests/TestForcingDocumentation.m
+++ b/UnitTests/TestForcingDocumentation.m
@@ -1,0 +1,191 @@
+classdef TestForcingDocumentation < matlab.unittest.TestCase
+    properties
+        repositoryRoot (1,1) string
+    end
+
+    methods (TestMethodSetup)
+        function locateRepository(testCase)
+            testCase.repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+        end
+    end
+
+    methods (Test, TestTags="full")
+        function suppliedForcingPagesDescribeCurrentContracts(testCase)
+            expectations = {
+                "wvnonlinearadvection", false, "self = WVNonlinearAdvection(wvt)", ["installs this forcing by default" "using linear evolution"]
+                "wvfixedamplitudeforcing", false, "self = WVFixedAmplitudeForcing(wvt,options)", ["`Apbar`" "`A0_indices`" "10^{-6}"]
+                "wvbottomfrictionlinear", false, "self = WVBottomFrictionLinear(wvt,options)", ["`r`" "inverse seconds" "200-day"]
+                "wvbottomfrictionquadratic", false, "self = WVBottomFrictionQuadratic(wvt,options)", ["`Cd`" "dimensionless" "4000"]
+                "wvadaptivedamping", true, "self = WVAdaptiveDamping(wvt)", ["wvt.uvMax*damp" "k_no_damp" "significant damping"]
+                "wvhorizontaldamping", true, "self = WVHorizontalDamping(wvt,options)", ["`nu`" "`kappa`" "square meters per second"]
+                "wvverticaldamping", true, "self = WVVerticalDamping(wvt,options)", ["`nu`" "`kappa`" "square meters per second"]
+                "wvverticaldiffusivity", true, "self = WVVerticalDiffusivity(wvt,options)", ["`kappa_z`" "`shouldForceMeanDensityAnomaly`" "barotropic QG"]
+                "wvantialiasing", true, "self = WVAntialiasing(wvt,options)", ["`Nj`" "shouldAntialias=false" "discarded"]
+                "wvthermaldamping", true, "self = WVThermalDamping(wvt,options)", ["`alpha`" "alpha/wvt.Lr2" "Scott and Dritschel"]
+                };
+
+            for iExpectation = 1:size(expectations,1)
+                folder = expectations{iExpectation,1};
+                isClosure = expectations{iExpectation,2};
+                constructorDeclaration = expectations{iExpectation,3};
+                requiredText = expectations{iExpectation,4};
+                overview = testCase.generatedPage(folder,"index.md",isClosure);
+                constructor = testCase.generatedPage(folder,folder + ".md",isClosure);
+                reference = testCase.generatedClassReference(folder,isClosure);
+                testCase.verifySubstring(overview,"### Example",folder + " lacks an example.");
+                testCase.verifySubstring(constructor,constructorDeclaration,folder + " has the wrong constructor declaration.");
+                for token = requiredText
+                    testCase.verifySubstring(reference,token,folder + " lacks " + token + ".");
+                end
+            end
+        end
+
+        function documentationContainsNoKnownCopiedDefects(testCase)
+            generatedRoot = fullfile(testCase.repositoryRoot,"docs","classes","forcing");
+            pages = dir(fullfile(generatedRoot,"**","*.md"));
+            forbidden = [
+                "WVNonlinearFlux"
+                "WVAdaptiveViscosity"
+                "WVVerticalScalarDiffusivity"
+                "WaveVortexTranform"
+                "comptued"
+                "diffusivty"
+                "C_dd"
+                "WVNonlinearAdvection(wvt,options)"
+                ];
+            for iPage = 1:numel(pages)
+                page = string(fileread(fullfile(pages(iPage).folder,pages(iPage).name)));
+                for token = forbidden'
+                    testCase.verifyFalse(contains(page,token),pages(iPage).name + " contains obsolete text " + token + ".");
+                end
+            end
+        end
+
+        function publishedExamplesExecute(testCase)
+            classes = [
+                "WVNonlinearAdvection"
+                "WVFixedAmplitudeForcing"
+                "WVBottomFrictionLinear"
+                "WVBottomFrictionQuadratic"
+                "WVAdaptiveDamping"
+                "WVHorizontalDamping"
+                "WVVerticalDamping"
+                "WVVerticalDiffusivity"
+                "WVAntialiasing"
+                "WVThermalDamping"
+                ];
+            for className = classes'
+                sourcePath = fullfile(testCase.repositoryRoot,"Forcing",className + ".m");
+                code = testCase.exampleCodeFromSource(sourcePath);
+                testCase.assertNotEmpty(code,className + " has no executable example.");
+                testCase.verifyWarningFree(@()testCase.evaluateExample(code),className + " example emitted a warning.");
+            end
+        end
+
+        function documentedDerivedQuantitiesMatchImplementation(testCase)
+            Lxyz = [40e3 30e3 2e3];
+            Nxyz = [8 6 5];
+            wvt = WVTransformConstantStratification(Lxyz,Nxyz,N0=5.2e-3,latitude=45,isHydrostatic=true,shouldAntialias=false);
+
+            linear = WVBottomFrictionLinear(wvt,r=2e-7);
+            testCase.verifyEqual(linear.r_scaled,linear.r*wvt.Lz/wvt.z_int(1),RelTol=10*eps);
+
+            quadratic = WVBottomFrictionQuadratic(wvt,Cd=2e-3);
+            testCase.verifyEqual(quadratic.cd,quadratic.Cd/wvt.z_int(1),RelTol=10*eps);
+
+            horizontal = WVHorizontalDamping(wvt);
+            testCase.verifyEqual(horizontal.nu,1e-4);
+            testCase.verifyEqual(horizontal.kappa,1e-6);
+
+            vertical = WVVerticalDamping(wvt);
+            testCase.verifyEqual(vertical.nu,5e-4);
+            testCase.verifyEqual(vertical.kappa,1e-6);
+
+            diffusivity = WVVerticalDiffusivity(wvt);
+            testCase.verifyEqual(diffusivity.kappa_z,1e-5);
+            testCase.verifyTrue(diffusivity.shouldForceMeanDensityAnomaly);
+
+            adaptive = WVAdaptiveDamping(wvt);
+            testCase.verifySize(adaptive.damp,wvt.spectralMatrixSize);
+            testCase.verifyLessThan(adaptive.k_no_damp,adaptive.k_damp);
+            testCase.verifyLessThan(adaptive.j_no_damp,adaptive.j_damp);
+            testCase.verifyEqual(adaptive.dampingTimeScale(),1/max(abs(adaptive.damp),[],"all"),RelTol=10*eps);
+
+            antialias = WVAntialiasing(wvt);
+            testCase.verifyEqual(antialias.Nj,floor(2*wvt.Nj/3));
+            testCase.verifySize(antialias.M,wvt.spectralMatrixSize);
+            testCase.verifyEqual(antialias.effectiveJMax(),antialias.Nj-1);
+
+            qg = WVTransformBarotropicQG(Lxyz(1:2),Nxyz(1:2),h=0.8,latitude=45,shouldAntialias=false);
+            qgLinear = WVBottomFrictionLinear(qg,r=2e-7);
+            qgQuadratic = WVBottomFrictionQuadratic(qg,Cd=2e-3);
+            thermal = WVThermalDamping(qg,alpha=3e-8);
+            testCase.verifyEqual(qgLinear.r_scaled,qgLinear.r);
+            testCase.verifyEqual(qgQuadratic.cd,qgQuadratic.Cd/4000,RelTol=10*eps);
+            testCase.verifyEqual(thermal.alpha_scaled,thermal.alpha./qg.Lr2,RelTol=10*eps);
+        end
+
+        function fixedAmplitudeHelperDocumentsCurrentBehavior(testCase)
+            page = testCase.generatedPage("wvfixedamplitudeforcing","setnarrowbandgeostrophicforcing.md",false);
+            required = [
+                "`k_f`"
+                "`j_f`"
+                "`k_r`"
+                "`u_rms`"
+                "`initialPV`"
+                "`r`"
+                "narrow-band"
+                "full-spectrum"
+                "github.com/JeffreyEarly/wave-vortex-model/issues/2"
+                ];
+            for token = required'
+                testCase.verifySubstring(page,token);
+            end
+
+            wvt = WVTransformConstantStratification([40e3 30e3 2e3],[8 6 5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+            forcing = WVFixedAmplitudeForcing(wvt,name="selected-geostrophic-mode");
+            A0bar = zeros(wvt.spectralMatrixSize);
+            selectedIndex = find(wvt.geostrophicComponent.maskA0,1);
+            A0bar(selectedIndex) = 1;
+            forcing.setGeostrophicForcingCoefficients(A0bar);
+            testCase.verifyEqual(forcing.A0_indices,uint64(selectedIndex));
+            testCase.verifyEqual(forcing.A0bar,1);
+        end
+    end
+
+    methods (Access=private)
+        function page = generatedPage(testCase,folder,filename,isClosure)
+            root = fullfile(testCase.repositoryRoot,"docs","classes","forcing");
+            if isClosure
+                root = fullfile(root,"closures");
+            end
+            page = string(fileread(fullfile(root,folder,filename)));
+        end
+
+        function reference = generatedClassReference(testCase,folder,isClosure)
+            root = fullfile(testCase.repositoryRoot,"docs","classes","forcing");
+            if isClosure
+                root = fullfile(root,"closures");
+            end
+            pages = dir(fullfile(root,folder,"*.md"));
+            reference = "";
+            for iPage = 1:numel(pages)
+                reference = reference + newline + string(fileread(fullfile(pages(iPage).folder,pages(iPage).name)));
+            end
+        end
+
+        function code = exampleCodeFromSource(~,sourcePath)
+            source = fileread(sourcePath);
+            match = regexp(source,'(?s)% ### Example.*?% ```matlab\s*(?<code>.*?)\s*% ```','names','once');
+            if isempty(match)
+                code = "";
+                return
+            end
+            code = string(regexprep(match.code,'(?m)^\s*% ?',''));
+        end
+
+        function evaluateExample(~,code)
+            evalc(char(code));
+        end
+    end
+end

--- a/docs/classes/forcing/closures/wvadaptivedamping/assumedeffectivehorizontalgridresolution.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/assumedeffectivehorizontalgridresolution.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  assumedEffectiveHorizontalGridResolution
 
-effective resolution used in the damping calculation
+Effective horizontal resolution used to construct `damp`, in meters.
 
 
 ---

--- a/docs/classes/forcing/closures/wvadaptivedamping/builddampingoperator.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/builddampingoperator.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  buildDampingOperator
 
-Builds the damping operator
+Build the unit-speed spectral damping operator.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -21,8 +21,6 @@ Builds the damping operator
  buildDampingOperator(self)
 ```
 ## Parameters
-+ `self`  an instance of WVAdaptiveViscosity
++ `self`  adaptive-damping instance to update
 
 ## Discussion
-
-- Returns: None

--- a/docs/classes/forcing/closures/wvadaptivedamping/damp.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/damp.md
@@ -9,9 +9,12 @@ mathjax: true
 
 #  damp
 
-spectral matrix that multiplies Ap,Am,A0 to damp
+Unit-speed spectral damping operator in inverse meters.
 
 
 ---
 
 ## Discussion
+
+This array has `wvt.spectralMatrixSize`. The actual coefficient
+damping rate is `wvt.uvMax*damp` in inverse seconds.

--- a/docs/classes/forcing/closures/wvadaptivedamping/dampingtimescale.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/dampingtimescale.md
@@ -9,18 +9,21 @@ mathjax: true
 
 #  dampingTimeScale
 
-Computes the minimum damping time scale
+Return the inverse maximum unit-speed damping coefficient.
 
 
 ---
 
 ## Declaration
 ```matlab
- dampingTimeScale(self)
+ dampingTimeScale = dampingTimeScale()
 ```
-## Parameters
-+ `self`  an instance of WVAdaptiveViscosity
+## Returns
++ `dampingTimeScale`  inverse maximum absolute entry of `damp`, in meters
 
 ## Discussion
 
-- Returns: dampingTimeScale
+Despite the historical method name, this value has units of
+meters because `damp` has units of inverse meters. For a
+nonzero flow, divide this value by `wvt.uvMax` to obtain the
+shortest instantaneous e-folding time in seconds.

--- a/docs/classes/forcing/closures/wvadaptivedamping/index.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/index.md
@@ -11,7 +11,7 @@ nav_order: 1
 
 #  WVAdaptiveDamping
 
-Adaptive small-scale damping
+Adapt small-scale spectral damping to the current flow speed.
 
 
 ---
@@ -22,10 +22,10 @@ Adaptive small-scale damping
 
 ## Overview
 
-This damping operator is a linear closure that dynamically changes
-its amplitude to keep the Reynolds number at the grid scale equal to
-one. This closure is ideal for a spin-up problem where the amplitude
-of the flow is changing.
+This closure rebuilds its spectral shape when the transform's effective
+resolution changes and scales its coefficient tendency by the current
+maximum horizontal speed. It is useful when the flow amplitude evolves
+substantially, such as during spin-up.
 
 This closure has a number of noteworthy features:
 
@@ -64,11 +64,10 @@ $$
 
 where $$U$$ is the maximum fluid velocity.
 
-### Usage
-
-Assuming there is a WVTransform instance wvt, to add this forcing,
+### Example
 
 ```matlab
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
 wvt.addForcing(WVAdaptiveDamping(wvt));
 ```
 
@@ -84,15 +83,15 @@ So arguably they're under-damped in a non-hydrostatic simulation.
 
 ## Topics
 + Create the forcing
-  + [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/wvadaptivedamping.html) initialize the WVAdaptiveDamping
+  + [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/wvadaptivedamping.html) Create adaptive spectral damping for a transform.
 + Inspect forcing or damping scales
-  + [`k_no_damp`](/classes/forcing/closures/wvadaptivedamping/k_no_damp.html) wavenumber below which there is zero damping
-  + [`k_damp`](/classes/forcing/closures/wvadaptivedamping/k_damp.html) wavenumber at which the significant scale damping starts.
-  + [`j_no_damp`](/classes/forcing/closures/wvadaptivedamping/j_no_damp.html) wavenumber below which there is zero damping
-  + [`j_damp`](/classes/forcing/closures/wvadaptivedamping/j_damp.html) wavenumber at which the significant scale damping starts.
-  + [`assumedEffectiveHorizontalGridResolution`](/classes/forcing/closures/wvadaptivedamping/assumedeffectivehorizontalgridresolution.html) effective resolution used in the damping calculation
-  + [`dampingTimeScale`](/classes/forcing/closures/wvadaptivedamping/dampingtimescale.html) Computes the minimum damping time scale
-  + [`damp`](/classes/forcing/closures/wvadaptivedamping/damp.html) spectral matrix that multiplies Ap,Am,A0 to damp
+  + [`k_no_damp`](/classes/forcing/closures/wvadaptivedamping/k_no_damp.html) Horizontal wavenumber below which damping is exactly zero.
+  + [`k_damp`](/classes/forcing/closures/wvadaptivedamping/k_damp.html) Estimated horizontal wavenumber for significant damping.
+  + [`j_no_damp`](/classes/forcing/closures/wvadaptivedamping/j_no_damp.html) Vertical mode number below which damping is exactly zero.
+  + [`j_damp`](/classes/forcing/closures/wvadaptivedamping/j_damp.html) Estimated vertical mode number for significant damping.
+  + [`assumedEffectiveHorizontalGridResolution`](/classes/forcing/closures/wvadaptivedamping/assumedeffectivehorizontalgridresolution.html) Effective horizontal resolution used to construct `damp`, in meters.
+  + [`dampingTimeScale`](/classes/forcing/closures/wvadaptivedamping/dampingtimescale.html) Return the inverse maximum unit-speed damping coefficient.
+  + [`damp`](/classes/forcing/closures/wvadaptivedamping/damp.html) Unit-speed spectral damping operator in inverse meters.
 
 
 ## Developer Topics
@@ -100,8 +99,8 @@ These items document internal implementation details and are not part of the pri
 + Forcing persistence
   + [`classRequiredPropertyNames`](/classes/forcing/closures/wvadaptivedamping/classrequiredpropertynames.html) Returns the required property names for the class
 + Forcing internals
-  + [`buildDampingOperator`](/classes/forcing/closures/wvadaptivedamping/builddampingoperator.html) Builds the damping operator
-  + [`spectralVanishingViscosityFilter`](/classes/forcing/closures/wvadaptivedamping/spectralvanishingviscosityfilter.html) Builds the spectral vanishing viscosity operator
+  + [`buildDampingOperator`](/classes/forcing/closures/wvadaptivedamping/builddampingoperator.html) Build the unit-speed spectral damping operator.
+  + [`spectralVanishingViscosityFilter`](/classes/forcing/closures/wvadaptivedamping/spectralvanishingviscosityfilter.html) Build horizontal and vertical spectral-vanishing filters.
 
 
 ---

--- a/docs/classes/forcing/closures/wvadaptivedamping/j_damp.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/j_damp.md
@@ -9,9 +9,12 @@ mathjax: true
 
 #  j_damp
 
-wavenumber at which the significant scale damping starts.
+Estimated vertical mode number for significant damping.
 
 
 ---
 
 ## Discussion
+
+This value is dimensionless. The filter is already nonzero below
+this estimate; use `j_no_damp` for the exact zero-damping cutoff.

--- a/docs/classes/forcing/closures/wvadaptivedamping/j_no_damp.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/j_no_damp.md
@@ -9,9 +9,11 @@ mathjax: true
 
 #  j_no_damp
 
-wavenumber below which there is zero damping
+Vertical mode number below which damping is exactly zero.
 
 
 ---
 
 ## Discussion
+
+This value is dimensionless.

--- a/docs/classes/forcing/closures/wvadaptivedamping/k_damp.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/k_damp.md
@@ -9,9 +9,12 @@ mathjax: true
 
 #  k_damp
 
-wavenumber at which the significant scale damping starts.
+Estimated horizontal wavenumber for significant damping.
 
 
 ---
 
 ## Discussion
+
+Units are radians per meter. The filter is already nonzero below
+this estimate; use `k_no_damp` for the exact zero-damping cutoff.

--- a/docs/classes/forcing/closures/wvadaptivedamping/k_no_damp.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/k_no_damp.md
@@ -9,9 +9,11 @@ mathjax: true
 
 #  k_no_damp
 
-wavenumber below which there is zero damping
+Horizontal wavenumber below which damping is exactly zero.
 
 
 ---
 
 ## Discussion
+
+Units are radians per meter.

--- a/docs/classes/forcing/closures/wvadaptivedamping/spectralvanishingviscosityfilter.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/spectralvanishingviscosityfilter.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  spectralVanishingViscosityFilter
 
-Builds the spectral vanishing viscosity operator
+Build horizontal and vertical spectral-vanishing filters.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -18,12 +18,18 @@ Builds the spectral vanishing viscosity operator
 
 ## Declaration
 ```matlab
- spectralVanishingViscosityFilter(self, options)
+ [Qkl,Qj,kl_cutoff,kl_damp,j_cutoff,j_damp] = spectralVanishingViscosityFilter(kl_max,j_max)
 ```
 ## Parameters
-+ `self`  an instance of WVAdaptiveViscosity
-+ `options`  struct with field shouldAssumeAntialiasing
++ `kl_max`  maximum resolved horizontal wavenumber in radians per meter
++ `j_max`  maximum resolved vertical-mode number
+
+## Returns
++ `Qkl`  horizontal filter on the spectral grid
++ `Qj`  vertical filter on the spectral grid
++ `kl_cutoff`  exact horizontal zero-damping cutoff in radians per meter
++ `kl_damp`  estimated horizontal significant-damping wavenumber in radians per meter
++ `j_cutoff`  exact vertical zero-damping cutoff
++ `j_damp`  estimated vertical significant-damping mode
 
 ## Discussion
-
-- Returns: Qkl, Qj, kl_cutoff, kl_damp

--- a/docs/classes/forcing/closures/wvadaptivedamping/wvadaptivedamping.md
+++ b/docs/classes/forcing/closures/wvadaptivedamping/wvadaptivedamping.md
@@ -9,19 +9,19 @@ mathjax: true
 
 #  WVAdaptiveDamping
 
-initialize the WVAdaptiveDamping
+Create adaptive spectral damping for a transform.
 
 
 ---
 
 ## Declaration
 ```matlab
- damp = WVAdaptiveDamping(wvt)
+ self = WVAdaptiveDamping(wvt)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
++ `wvt`  transform that owns and evaluates the closure
 
 ## Returns
-+ `self`  a WVAdaptiveDamping instance
++ `self`  adaptive-damping closure owned by `wvt`
 
 ## Discussion

--- a/docs/classes/forcing/closures/wvantialiasing/effectivehorizontalgridresolution.md
+++ b/docs/classes/forcing/closures/wvantialiasing/effectivehorizontalgridresolution.md
@@ -9,17 +9,17 @@ mathjax: true
 
 #  effectiveHorizontalGridResolution
 
-returns the effective grid resolution in meters
+Return the shortest fully retained horizontal wavelength.
 
 
 ---
 
 ## Declaration
 ```matlab
- flag = effectiveHorizontalGridResolution(other)
+ effectiveHorizontalGridResolution = effectiveHorizontalGridResolution()
 ```
 ## Returns
-+ `effectiveHorizontalGridResolution`  double
++ `effectiveHorizontalGridResolution`  effective horizontal resolution in meters
 
 ## Discussion
 

--- a/docs/classes/forcing/closures/wvantialiasing/effectivejmax.md
+++ b/docs/classes/forcing/closures/wvantialiasing/effectivejmax.md
@@ -9,21 +9,19 @@ mathjax: true
 
 #  effectiveJMax
 
-returns the effective highest vertical mode
+Return the highest retained vertical-mode number.
 
 
 ---
 
 ## Declaration
 ```matlab
- flag = effectiveJMax(other)
+ j_max = effectiveJMax()
 ```
 ## Returns
-+ `effectiveJMax`  double
++ `j_max`  highest retained vertical-mode number
 
 ## Discussion
 
-The effective highest vertical modeis the highest fully resolved
-mode in the model. This value takes into account
-anti-aliasing, and is thus appropriate for setting damping
-operators.
+This dimensionless value accounts for the explicit vertical
+mask and is appropriate when constructing damping operators.

--- a/docs/classes/forcing/closures/wvantialiasing/index.md
+++ b/docs/classes/forcing/closures/wvantialiasing/index.md
@@ -11,7 +11,7 @@ nav_order: 6
 
 #  WVAntialiasing
 
-Antialiasing filter
+Apply explicit spectral antialias filtering for diagnostics.
 
 
 ---
@@ -22,28 +22,24 @@ Antialiasing filter
 
 ## Overview
 
-This forcing removes (sets to zero) energy in the largest 1/3 modes
-to prevent quadratic aliasing. This is the correct de-aliasing for
-the horizontal fourier modes, but is not exactly correct for the
-vertical modes in variable stratification. You can thus manually set
-`Nj`, otherwise it will default to `options.Nj = floor(2*wvt.Nj/3);`.
+This closure removes coefficient tendencies in aliased modes and sets
+those coefficients to zero after every integration step. The
+horizontal mask uses the transform's quadratic-aliasing rule. Vertical
+modes with `j >= Nj` are discarded; `Nj` defaults to
+`floor(2*wvt.Nj/3)`.
 
-**Very important** You should almost never use this forcing, as
-de-aliasing is built-in at the transform level and enabled by
-default. For performance reasons is far more optimal to simply never
-compute the de-aliased modes. The purpose of this forcing to allow
-direct measurement of the effect of the de-aliasing on energy and
-potential enstrophy. It is quite slow and thus we recommend it be
-used for diagnostic purposes only.
+Transform-level antialiasing is enabled by default and is more
+efficient because discarded modes are never computed. Explicit
+antialiasing is intended for measuring the filter's effect on energy
+and potential enstrophy. Construct the transform with
+`shouldAntialias=false` before adding this closure. It is compatible
+with wave-bearing and QG transforms.
 
-### Usage
-
-This is likely to change in the future, but at the moment several of
-the transforms have a function that will make a new transform in the
-identical state, but with the antialiasing filter explicitly added.
+### Example
 
 ```matlab
-wvtAA = wvt.waveVortexTransformWithExplicitAntialiasing();
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true,shouldAntialias=false);
+wvt.addForcing(WVAntialiasing(wvt));
 ```
 
 
@@ -51,12 +47,12 @@ wvtAA = wvt.waveVortexTransformWithExplicitAntialiasing();
 
 ## Topics
 + Create the forcing
-  + [`WVAntialiasing`](/classes/forcing/closures/wvantialiasing/wvantialiasing.html) initialize the WVAntialiasing
+  + [`WVAntialiasing`](/classes/forcing/closures/wvantialiasing/wvantialiasing.html) Create explicit antialias filtering for a transform.
 + Inspect forcing configuration
-  + [`Nj`](/classes/forcing/closures/wvantialiasing/nj.html) number of retained vertical modes used to construct the filter
+  + [`Nj`](/classes/forcing/closures/wvantialiasing/nj.html) Number of retained vertical modes.
 + Inspect forcing or damping scales
-  + [`effectiveHorizontalGridResolution`](/classes/forcing/closures/wvantialiasing/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
-  + [`effectiveJMax`](/classes/forcing/closures/wvantialiasing/effectivejmax.html) returns the effective highest vertical mode
+  + [`effectiveHorizontalGridResolution`](/classes/forcing/closures/wvantialiasing/effectivehorizontalgridresolution.html) Return the shortest fully retained horizontal wavelength.
+  + [`effectiveJMax`](/classes/forcing/closures/wvantialiasing/effectivejmax.html) Return the highest retained vertical-mode number.
 
 
 ## Developer Topics
@@ -64,7 +60,7 @@ These items document internal implementation details and are not part of the pri
 + Forcing persistence
   + [`classRequiredPropertyNames`](/classes/forcing/closures/wvantialiasing/classrequiredpropertynames.html) Returns the required property names for the class
 + Forcing internals
-  + [`M`](/classes/forcing/closures/wvantialiasing/m.html) spectral matrix that multiplies Ap,Am,A0 to zero out the aliased modes
+  + [`M`](/classes/forcing/closures/wvantialiasing/m.html) Logical-shape spectral mask of discarded coefficients.
 
 
 ---

--- a/docs/classes/forcing/closures/wvantialiasing/m.md
+++ b/docs/classes/forcing/closures/wvantialiasing/m.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  M
 
-spectral matrix that multiplies Ap,Am,A0 to zero out the aliased modes
+Logical-shape spectral mask of discarded coefficients.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,3 +17,6 @@ spectral matrix that multiplies Ap,Am,A0 to zero out the aliased modes
 ---
 
 ## Discussion
+
+This array has `wvt.spectralMatrixSize`; nonzero entries are
+removed from coefficient tendencies and amplitudes.

--- a/docs/classes/forcing/closures/wvantialiasing/nj.md
+++ b/docs/classes/forcing/closures/wvantialiasing/nj.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Nj
 
-number of retained vertical modes used to construct the filter
+Number of retained vertical modes.
 
 
 ---

--- a/docs/classes/forcing/closures/wvantialiasing/wvantialiasing.md
+++ b/docs/classes/forcing/closures/wvantialiasing/wvantialiasing.md
@@ -9,20 +9,23 @@ mathjax: true
 
 #  WVAntialiasing
 
-initialize the WVAntialiasing
+Create explicit antialias filtering for a transform.
 
 
 ---
 
 ## Declaration
 ```matlab
- nlFlux = WVNonlinearFlux(wvt,options)
+ self = WVAntialiasing(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `Nj`  (optional) number of retained vertical modes. Modes with `j >= Nj` are set to zero. Defaults to `floor(2*wvt.Nj/3)`.
++ `wvt`  transform that owns and evaluates the closure
++ `Nj`  optional number of retained vertical modes; modes with `j >= Nj` are discarded; default `floor(2*wvt.Nj/3)`
 
 ## Returns
-+ `self`  a WVAntialiasing instance
++ `self`  explicit-antialiasing closure owned by `wvt`
 
 ## Discussion
+
+The transform must have been constructed with
+`shouldAntialias=false`.

--- a/docs/classes/forcing/closures/wvhorizontaldamping/index.md
+++ b/docs/classes/forcing/closures/wvhorizontaldamping/index.md
@@ -11,7 +11,7 @@ nav_order: 3
 
 #  WVHorizontalDamping
 
-Horizontal laplacian damping with viscosity and diffusivity
+Apply horizontal Laplacian viscosity and diffusivity.
 
 
 ---
@@ -25,8 +25,10 @@ Horizontal laplacian damping with viscosity and diffusivity
 The damping is a simple horizontal Laplacian, designed to mimic the
 [HorizontalScalarDiffusivity in
 Oceananigans](https://clima.github.io/OceananigansDocumentation/stable/appendix/library/#Oceananigans.TurbulenceClosures.HorizontalScalarDiffusivity)
-to allow for direct comparison between the models. This is intended to be used in combination with WVVerticalScalarDiffusivity. In
-general, you should be using the
+to allow direct comparison between the models. It applies to
+wave-bearing three-dimensional transforms and is intended for use with
+[`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/).
+For an automatically scaled closure, use
 [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
 
 The specific form of the forcing is given by
@@ -40,24 +42,23 @@ $$
 \end{align}
 $$
 
-which is just your standard Laplacian viscosity, $$\nu$$, and diffusivity, $$\kappa$$, in
-the horizontal. This should be combined with
-[`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) for a complete closure. For help
-choosing appropriate values, see the notes in
+These are horizontal Laplacian viscosity, $$\nu$$, and diffusivity,
+$$\kappa$$. Combine this closure with
+[`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) to
+damp vertical gradients as well. For guidance on automatically scaled
+coefficients, see
 [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
 
-### Usage
-
-Assuming there is a WVTransform instance wvt, to add this forcing,
+### Example
 
 ```matlab
-wvt.addForcing(WVHorizontalDamping(wvt,nu=1e-4, kappa=1e-6));
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+wvt.addForcing(WVHorizontalDamping(wvt,nu=1e-4,kappa=1e-6));
 ```
 
 ### Notes
 
-This is currently implemented in the spatial domain and is
-thus highly un-optimized.
+This closure is evaluated in the spatial domain.
 
 The configured viscosity and diffusivity are preserved when the
 forcing is copied to a transform with a different resolution.
@@ -67,10 +68,10 @@ forcing is copied to a transform with a different resolution.
 
 ## Topics
 + Create the forcing
-  + [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/wvhorizontaldamping.html) initialize the WVHorizontalDamping
+  + [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/wvhorizontaldamping.html) Create horizontal Laplacian damping for a transform.
 + Inspect forcing configuration
-  + [`nu`](/classes/forcing/closures/wvhorizontaldamping/nu.html) horizontal viscosity
-  + [`kappa`](/classes/forcing/closures/wvhorizontaldamping/kappa.html) horizontal diffusivity
+  + [`nu`](/classes/forcing/closures/wvhorizontaldamping/nu.html) Horizontal momentum viscosity in $$\mathrm{m^2\,s^{-1}}$$.
+  + [`kappa`](/classes/forcing/closures/wvhorizontaldamping/kappa.html) Horizontal displacement diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ## Developer Topics

--- a/docs/classes/forcing/closures/wvhorizontaldamping/kappa.md
+++ b/docs/classes/forcing/closures/wvhorizontaldamping/kappa.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  kappa
 
-horizontal diffusivity
+Horizontal displacement diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ---
@@ -18,3 +18,5 @@ horizontal diffusivity
 Real valued property with no dimensions and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+
+The constructor default is `1e-6`.

--- a/docs/classes/forcing/closures/wvhorizontaldamping/nu.md
+++ b/docs/classes/forcing/closures/wvhorizontaldamping/nu.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  nu
 
-horizontal viscosity
+Horizontal momentum viscosity in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ---
@@ -18,3 +18,5 @@ horizontal viscosity
 Real valued property with no dimensions and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+
+The constructor default is `1e-4`.

--- a/docs/classes/forcing/closures/wvhorizontaldamping/wvhorizontaldamping.md
+++ b/docs/classes/forcing/closures/wvhorizontaldamping/wvhorizontaldamping.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVHorizontalDamping
 
-initialize the WVHorizontalDamping
+Create horizontal Laplacian damping for a transform.
 
 
 ---
@@ -19,11 +19,11 @@ initialize the WVHorizontalDamping
  self = WVHorizontalDamping(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `nu`  horizontal viscosity, default $$1 \cdot 10^{-4} \textrm{m}^2/\textrm{s}$$
-+ `kappa`  horizontal diffusivity, default $$1 \cdot 10^{-6} \textrm{m}^2/\textrm{s}$$
++ `wvt`  wave-bearing three-dimensional transform that owns the closure
++ `nu`  optional horizontal viscosity in square meters per second; default `1e-4`
++ `kappa`  optional horizontal diffusivity in square meters per second; default `1e-6`
 
 ## Returns
-+ `self`  a WVHorizontalDamping instance
++ `self`  horizontal-damping closure owned by `wvt`
 
 ## Discussion

--- a/docs/classes/forcing/closures/wvthermaldamping/alpha.md
+++ b/docs/classes/forcing/closures/wvthermaldamping/alpha.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  alpha
 
-damping parameter, units of $$s^{-1}$$
+Configured thermal-damping rate in $$\mathrm{s^{-1}}$$.
 
 
 ---
@@ -18,3 +18,5 @@ damping parameter, units of $$s^{-1}$$
 Real valued property with no dimensions and units of $$s^{-1}$$.
 
 ## Discussion
+
+The constructor default is `1/(200*86400)`.

--- a/docs/classes/forcing/closures/wvthermaldamping/alpha_scaled.md
+++ b/docs/classes/forcing/closures/wvthermaldamping/alpha_scaled.md
@@ -9,9 +9,12 @@ mathjax: true
 
 #  alpha_scaled
 
-scaled damping parameter, units of $$s^{-1} m^{-2}$$
+Deformation-scaled damping coefficient in $$\mathrm{s^{-1}\,m^{-2}}$$.
 
 
 ---
 
 ## Discussion
+
+This is `alpha/wvt.Lr2` and has the shape required by the QG
+streamfunction field.

--- a/docs/classes/forcing/closures/wvthermaldamping/index.md
+++ b/docs/classes/forcing/closures/wvthermaldamping/index.md
@@ -11,7 +11,7 @@ nav_order: 5
 
 #  WVThermalDamping
 
-Thermal damping
+Apply large-scale thermal damping to QGPV.
 
 
 ---
@@ -22,26 +22,37 @@ Thermal damping
 
 ## Overview
 
-Applies thermal damping to the flow, i.e., $$\frac{dq}{dt} = \alpha \lambda^2 \psi$$.
+For each deformation scale $$L_r$$, the implementation adds
 
-This is as defined in Scott and Dritschel, but it can be shown that
-it is basically just a vertical diffusivity.
+$$
+\mathcal{S}_q=\frac{\alpha}{L_r^2}\psi.
+$$
+
+This follows the large-scale thermal-damping formulation considered
+by [Scott and Dritschel](https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/halting-scale-and-energy-equilibration-in-twodimensional-quasigeostrophic-turbulence/BD0CAFC9019691ADC9B18A95D15445F9).
 
 ### Notes
 
-This is only implemented for quasigeostrophic flows. Specifically, it
-requires `WVForcingType("PVSpatial")`.
+This forcing is compatible only with stratified and barotropic QG
+transforms through their physical-space QGPV forcing stage.
+
+### Example
+
+```matlab
+wvt = WVTransformBarotropicQG([40e3,30e3],[8,6],h=0.8,latitude=45);
+wvt.addForcing(WVThermalDamping(wvt,alpha=1/(200*86400)));
+```
 
 
 
 
 ## Topics
 + Create the forcing
-  + [`WVThermalDamping`](/classes/forcing/closures/wvthermaldamping/wvthermaldamping.html) initialize the WVThermalDamping
+  + [`WVThermalDamping`](/classes/forcing/closures/wvthermaldamping/wvthermaldamping.html) Create thermal damping for a QG transform.
 + Inspect forcing configuration
-  + [`alpha`](/classes/forcing/closures/wvthermaldamping/alpha.html) damping parameter, units of $$s^{-1}$$
+  + [`alpha`](/classes/forcing/closures/wvthermaldamping/alpha.html) Configured thermal-damping rate in $$\mathrm{s^{-1}}$$.
 + Inspect forcing or damping scales
-  + [`alpha_scaled`](/classes/forcing/closures/wvthermaldamping/alpha_scaled.html) scaled damping parameter, units of $$s^{-1} m^{-2}$$
+  + [`alpha_scaled`](/classes/forcing/closures/wvthermaldamping/alpha_scaled.html) Deformation-scaled damping coefficient in $$\mathrm{s^{-1}\,m^{-2}}$$.
 
 
 ## Developer Topics

--- a/docs/classes/forcing/closures/wvthermaldamping/wvthermaldamping.md
+++ b/docs/classes/forcing/closures/wvthermaldamping/wvthermaldamping.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVThermalDamping
 
-initialize the WVThermalDamping
+Create thermal damping for a QG transform.
 
 
 ---
@@ -19,10 +19,10 @@ initialize the WVThermalDamping
  self = WVThermalDamping(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `alpha`  (optional) damping time scale, default 1/(200*86400)
++ `wvt`  stratified or barotropic QG transform that owns the forcing
++ `alpha`  optional damping rate in inverse seconds; default `1/(200*86400)`
 
 ## Returns
-+ `self`  a WVThermalDamping instance
++ `self`  thermal-damping forcing owned by `wvt`
 
 ## Discussion

--- a/docs/classes/forcing/closures/wvverticaldamping/dlnn2.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/dlnn2.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dLnN2
 
-variable stratification factor
+Precomputed vertical logarithmic stratification gradient.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,3 +17,6 @@ variable stratification factor
 ---
 
 ## Discussion
+
+This Internal array is zero for constant stratification and has
+units of inverse meters for variable stratification.

--- a/docs/classes/forcing/closures/wvverticaldamping/index.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/index.md
@@ -11,7 +11,7 @@ nav_order: 4
 
 #  WVVerticalDamping
 
-Vertical viscosity and diffusivity
+Apply vertical Laplacian viscosity and diffusivity.
 
 
 ---
@@ -24,8 +24,10 @@ Vertical viscosity and diffusivity
 
 The damping is designed to mimic the VerticalScalarDiffusivity in
 Oceananigans to allow for direct comparison between the models. This
-is intended be used in combination with
-WVHorizontalDamping. In general, you should be using the
+applies to wave-bearing three-dimensional transforms and is intended
+for use with
+[`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/).
+For an automatically scaled closure, use
 [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
 
 The specific form of the forcing is given by
@@ -39,23 +41,23 @@ $$
 \end{align}
 $$
 
-with viscosity, $$\nu$$, and diffusivity, $$\kappa$$. This should be combined with
-[`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/) for a complete closure. For help
-choosing appropriate values, see the notes in
+Here $$\nu$$ is the vertical viscosity and $$\kappa$$ is the vertical
+diffusivity. Combine this closure with
+[`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/)
+to damp horizontal gradients as well. For guidance on automatically
+scaled coefficients, see
 [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/).
 
-### Usage
-
-Assuming there is a WVTransform instance wvt, to add this forcing,
+### Example
 
 ```matlab
-wvt.addForcing(WVVerticalDamping(wvt,nu=5e-4, kappa=1e-6));
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+wvt.addForcing(WVVerticalDamping(wvt,nu=5e-4,kappa=1e-6));
 ```
 
 ### Notes
 
-This is currently implemented in the spatial domain and is
-thus highly un-optimized.
+This closure is evaluated in the spatial domain.
 
 For constant stratification, $$\partial_z \ln N^2=0$$ and the
 stratification-gradient correction vanishes. The configured viscosity
@@ -67,10 +69,10 @@ transform with a different resolution.
 
 ## Topics
 + Create the forcing
-  + [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/wvverticaldamping.html) initialize the WVVerticalDamping
+  + [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/wvverticaldamping.html) Create vertical Laplacian damping for a transform.
 + Inspect forcing configuration
-  + [`nu`](/classes/forcing/closures/wvverticaldamping/nu.html) vertical viscosity
-  + [`kappa`](/classes/forcing/closures/wvverticaldamping/kappa.html) vertical diffusivity
+  + [`nu`](/classes/forcing/closures/wvverticaldamping/nu.html) Vertical momentum viscosity in $$\mathrm{m^2\,s^{-1}}$$.
+  + [`kappa`](/classes/forcing/closures/wvverticaldamping/kappa.html) Vertical displacement diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ## Developer Topics
@@ -78,7 +80,7 @@ These items document internal implementation details and are not part of the pri
 + Forcing persistence
   + [`classRequiredPropertyNames`](/classes/forcing/closures/wvverticaldamping/classrequiredpropertynames.html) Returns the required property names for the class
 + Forcing internals
-  + [`dLnN2`](/classes/forcing/closures/wvverticaldamping/dlnn2.html) variable stratification factor
+  + [`dLnN2`](/classes/forcing/closures/wvverticaldamping/dlnn2.html) Precomputed vertical logarithmic stratification gradient.
 
 
 ---

--- a/docs/classes/forcing/closures/wvverticaldamping/kappa.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/kappa.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  kappa
 
-vertical diffusivity
+Vertical displacement diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ---
@@ -18,3 +18,5 @@ vertical diffusivity
 Real valued property with no dimensions and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+
+The constructor default is `1e-6`.

--- a/docs/classes/forcing/closures/wvverticaldamping/nu.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/nu.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  nu
 
-vertical viscosity
+Vertical momentum viscosity in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ---
@@ -18,3 +18,5 @@ vertical viscosity
 Real valued property with no dimensions and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+
+The constructor default is `5e-4`.

--- a/docs/classes/forcing/closures/wvverticaldamping/wvverticaldamping.md
+++ b/docs/classes/forcing/closures/wvverticaldamping/wvverticaldamping.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVVerticalDamping
 
-initialize the WVVerticalDamping
+Create vertical Laplacian damping for a transform.
 
 
 ---
@@ -19,11 +19,11 @@ initialize the WVVerticalDamping
  self = WVVerticalDamping(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `nu`  vertical viscosity, default $$5 \cdot 10^{-4} \textrm{m}^2/\textrm{s}$$
-+ `kappa`  vertical diffusivity, default $$1 \cdot 10^{-6} \textrm{m}^2/\textrm{s}$$
++ `wvt`  wave-bearing three-dimensional transform that owns the closure
++ `nu`  optional vertical viscosity in square meters per second; default `5e-4`
++ `kappa`  optional vertical diffusivity in square meters per second; default `1e-6`
 
 ## Returns
-+ `self`  a WVVerticalDamping instance
++ `self`  vertical-damping closure owned by `wvt`
 
 ## Discussion

--- a/docs/classes/forcing/closures/wvverticaldiffusivity/dlnn2.md
+++ b/docs/classes/forcing/closures/wvverticaldiffusivity/dlnn2.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dLnN2
 
-precomputed dLnN2 term
+Precomputed vertical logarithmic stratification gradient.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,3 +17,7 @@ precomputed dLnN2 term
 ---
 
 ## Discussion
+
+This Internal value is zero when the correction is disabled or
+stratification is constant, and otherwise has units of inverse
+meters.

--- a/docs/classes/forcing/closures/wvverticaldiffusivity/index.md
+++ b/docs/classes/forcing/closures/wvverticaldiffusivity/index.md
@@ -11,7 +11,7 @@ nav_order: 2
 
 #  WVVerticalDiffusivity
 
-Vertical diffusivty
+Apply vertical diffusivity to the thermodynamic field.
 
 
 ---
@@ -36,33 +36,34 @@ $$
 \end{align}
 $$
 
-Upon initialization you can set `shouldForceMeanDensityAnomaly` to
-`false` and the $$\frac{\partial}{\partial z} \ln N^2$$ term will be
-neglected.
+Set `shouldForceMeanDensityAnomaly=false` to omit the
+$$\partial_z\ln N^2$$ correction for variable stratification. This
+option has no effect for constant stratification because the gradient
+is zero.
 
-### Usage
-
-Assuming there is a WVTransform instance wvt, to add this forcing,
+### Example
 
 ```matlab
-wvt.addForcing(WVVerticalDiffusivity(wvt, kappa_z=1e-6));
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+wvt.addForcing(WVVerticalDiffusivity(wvt,kappa_z=1e-6));
 ```
 
 ### Notes
 
 This is currently implemented in the spatial domain. It applies to
-three-dimensional wave and stratified-QG transforms, but not to a
-barotropic transform because that geometry has no vertical structure.
+wave-bearing three-dimensional transforms and has a separate QGPV
+pathway for stratified QG. It is not compatible with barotropic QG,
+which has no vertical structure.
 
 
 
 
 ## Topics
 + Create the forcing
-  + [`WVVerticalDiffusivity`](/classes/forcing/closures/wvverticaldiffusivity/wvverticaldiffusivity.html) initialize the WVVerticalDiffusivity
+  + [`WVVerticalDiffusivity`](/classes/forcing/closures/wvverticaldiffusivity/wvverticaldiffusivity.html) Create vertical diffusivity for a three-dimensional transform.
 + Inspect forcing configuration
-  + [`kappa_z`](/classes/forcing/closures/wvverticaldiffusivity/kappa_z.html) vertical diffusivity, $$m^2s^{-1}$$
-  + [`shouldForceMeanDensityAnomaly`](/classes/forcing/closures/wvverticaldiffusivity/shouldforcemeandensityanomaly.html) whether to include the $$\frac{\partial}{\partial z} \ln N^2$$ term
+  + [`kappa_z`](/classes/forcing/closures/wvverticaldiffusivity/kappa_z.html) Configured vertical diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
+  + [`shouldForceMeanDensityAnomaly`](/classes/forcing/closures/wvverticaldiffusivity/shouldforcemeandensityanomaly.html) Whether to include the variable-stratification correction.
 
 
 ## Developer Topics
@@ -70,7 +71,7 @@ These items document internal implementation details and are not part of the pri
 + Forcing persistence
   + [`classRequiredPropertyNames`](/classes/forcing/closures/wvverticaldiffusivity/classrequiredpropertynames.html) Returns the required property names for the class
 + Forcing internals
-  + [`dLnN2`](/classes/forcing/closures/wvverticaldiffusivity/dlnn2.html) precomputed dLnN2 term
+  + [`dLnN2`](/classes/forcing/closures/wvverticaldiffusivity/dlnn2.html) Precomputed vertical logarithmic stratification gradient.
 
 
 ---

--- a/docs/classes/forcing/closures/wvverticaldiffusivity/kappa_z.md
+++ b/docs/classes/forcing/closures/wvverticaldiffusivity/kappa_z.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  kappa_z
 
-vertical diffusivity, $$m^2s^{-1}$$
+Configured vertical diffusivity in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ---
@@ -18,3 +18,5 @@ vertical diffusivity, $$m^2s^{-1}$$
 Real valued property with no dimensions and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+
+The constructor default is `1e-5`.

--- a/docs/classes/forcing/closures/wvverticaldiffusivity/shouldforcemeandensityanomaly.md
+++ b/docs/classes/forcing/closures/wvverticaldiffusivity/shouldforcemeandensityanomaly.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  shouldForceMeanDensityAnomaly
 
-whether to include the $$\frac{\partial}{\partial z} \ln N^2$$ term
+Whether to include the variable-stratification correction.
 
 
 ---
@@ -18,3 +18,6 @@ whether to include the $$\frac{\partial}{\partial z} \ln N^2$$ term
 Real valued property with no dimensions and units of $$bool$$.
 
 ## Discussion
+
+The default is `true`. This controls the precomputed
+$$\partial_z\ln N^2$$ term used by the wave-bearing pathway.

--- a/docs/classes/forcing/closures/wvverticaldiffusivity/wvverticaldiffusivity.md
+++ b/docs/classes/forcing/closures/wvverticaldiffusivity/wvverticaldiffusivity.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVVerticalDiffusivity
 
-initialize the WVVerticalDiffusivity
+Create vertical diffusivity for a three-dimensional transform.
 
 
 ---
@@ -19,11 +19,11 @@ initialize the WVVerticalDiffusivity
  self = WVVerticalDiffusivity(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `kappa_z`  (optional) vertical diffusivity, $$m^2s^{-1}$$. Default values 1e-5
-+ `shouldForceMeanDensityAnomaly`  (optional) whether to include the $$\frac{\partial}{\partial z} \ln N^2$$ term. Default `true`.
++ `wvt`  wave-bearing or stratified-QG transform that owns the forcing
++ `kappa_z`  optional vertical diffusivity in square meters per second; default `1e-5`
++ `shouldForceMeanDensityAnomaly`  optional variable-stratification correction flag; default `true`
 
 ## Returns
-+ `self`  a WVVerticalDiffusivity instance
++ `self`  vertical-diffusivity forcing owned by `wvt`
 
 ## Discussion

--- a/docs/classes/forcing/wvbottomfrictionlinear/index.md
+++ b/docs/classes/forcing/wvbottomfrictionlinear/index.md
@@ -11,7 +11,7 @@ nav_order: 3
 
 #  WVBottomFrictionLinear
 
-Linear bottom friction
+Apply linear drag at the bottom boundary.
 
 
 ---
@@ -22,18 +22,27 @@ Linear bottom friction
 
 ## Overview
 
-Applies linear bottom friction to the flow, i.e., $$\frac{du}{dt} = -r \cdot u(x,y,-D)$$. The parameter $$r$$ has units of $$s^{-1}$$ and thus can be set as an inverse time scale.
+The parameter $$r$$ is an inverse time scale in $$\mathrm{s^{-1}}$$.
+For a three-dimensional transform, the bottom tendency is scaled by
+the bottom quadrature weight `z_int(1)` so its vertically integrated
+effect does not change with vertical resolution:
 
-The linear bottom friction is scaled such that we actually apply, $$\frac{du}{dt} = -\frac{L_z}{dz} r \cdot u(x,y,-D)$$ and the volume integrated effect of friction remains the same regardless of resolution. $$L_z$$ is the total domain depth and $$dz$$ is the spacing at the bottom grid point.
+$$
+r_\mathrm{scaled}=\frac{L_z}{z_\mathrm{int}(1)}r.
+$$
 
-To compare with quadratic bottom friction where $$\frac{du}{dt} = -\frac{C_d}{dz} \lvert \mathbf{u} \rvert $$, note that $$- \frac{L_z}{dz} r = -\frac{C_d}{dz} \lvert \mathbf{u} \rvert$$ and you will find a characteristic velocity $$\lvert\mathbf{u}\rvert$$ of about 10 cm/s for $$C_d=0.002$$.
+A barotropic transform has no vertical quadrature and uses
+$$r_\mathrm{scaled}=r$$.
+
+Comparing this with quadratic drag gives the characteristic relation
+$$L_z r=C_d\lvert\mathbf{u}\rvert$$.
 
 For both nonhydrostatic and hydrostatic transforms linear bottom drag
 
 $$
 \begin{align}
-\mathcal{S}_u &= -\frac{L_z}{dz} r \cdot u(x,y,-D) \\
-\mathcal{S}_v &= -\frac{L_z}{dz} r \cdot v(x,y,-D)  \\
+\mathcal{S}_u &= -r_\mathrm{scaled} u(x,y,-D) \\
+\mathcal{S}_v &= -r_\mathrm{scaled} v(x,y,-D)  \\
 \mathcal{S}_w &= 0 \\
 \mathcal{S}_\eta &= 0
 \end{align}
@@ -43,18 +52,17 @@ and for quasigeostrophic transforms,
 
 $$
 \begin{align}
-\mathcal{S}_\textrm{qgpv} &= -\frac{L_z}{dz} r \cdot \zeta(x,y,-D)
+\mathcal{S}_\mathrm{qgpv} &= -r_\mathrm{scaled}\zeta(x,y,-D)
 \end{align}
 $$
 
 where $$\zeta = \partial_x v - \partial_y u$$.
 
-### Usage
-
-Assuming there is a WVTransform instance wvt, to add this forcing,
+### Example
 
 ```matlab
-wvt.addForcing(WVBottomFrictionLinear(r=1/(200*86400)));
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+wvt.addForcing(WVBottomFrictionLinear(wvt,r=1/(200*86400)));
 ```
 
 
@@ -62,11 +70,11 @@ wvt.addForcing(WVBottomFrictionLinear(r=1/(200*86400)));
 
 ## Topics
 + Create the forcing
-  + [`WVBottomFrictionLinear`](/classes/forcing/wvbottomfrictionlinear/wvbottomfrictionlinear.html) initialize the WVBottomFrictionLinear
+  + [`WVBottomFrictionLinear`](/classes/forcing/wvbottomfrictionlinear/wvbottomfrictionlinear.html) Create linear bottom friction for a transform.
 + Inspect forcing configuration
-  + [`r`](/classes/forcing/wvbottomfrictionlinear/r.html) bottom friction, $$s^{-1}$$
+  + [`r`](/classes/forcing/wvbottomfrictionlinear/r.html) Configured linear drag rate in $$\mathrm{s^{-1}}$$.
 + Inspect forcing or damping scales
-  + [`r_scaled`](/classes/forcing/wvbottomfrictionlinear/r_scaled.html) scaled bottom friction, $$\frac{Lz}{dz} r$$ with units $$s^{-1}$$
+  + [`r_scaled`](/classes/forcing/wvbottomfrictionlinear/r_scaled.html) Drag rate applied at the bottom grid point in $$\mathrm{s^{-1}}$$.
 
 
 ## Developer Topics

--- a/docs/classes/forcing/wvbottomfrictionlinear/r.md
+++ b/docs/classes/forcing/wvbottomfrictionlinear/r.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  r
 
-bottom friction, $$s^{-1}$$
+Configured linear drag rate in $$\mathrm{s^{-1}}$$.
 
 
 ---
@@ -18,3 +18,6 @@ bottom friction, $$s^{-1}$$
 Real valued property with no dimensions and units of $$s^{-1}$$.
 
 ## Discussion
+
+The constructor default is `1/(200*86400)`, corresponding to a
+200-day time scale.

--- a/docs/classes/forcing/wvbottomfrictionlinear/r_scaled.md
+++ b/docs/classes/forcing/wvbottomfrictionlinear/r_scaled.md
@@ -9,9 +9,12 @@ mathjax: true
 
 #  r_scaled
 
-scaled bottom friction, $$\frac{Lz}{dz} r$$ with units $$s^{-1}$$
+Drag rate applied at the bottom grid point in $$\mathrm{s^{-1}}$$.
 
 
 ---
 
 ## Discussion
+
+This is `r*Lz/z_int(1)` for a three-dimensional transform and
+`r` for a barotropic transform.

--- a/docs/classes/forcing/wvbottomfrictionlinear/wvbottomfrictionlinear.md
+++ b/docs/classes/forcing/wvbottomfrictionlinear/wvbottomfrictionlinear.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVBottomFrictionLinear
 
-initialize the WVBottomFrictionLinear
+Create linear bottom friction for a transform.
 
 
 ---
@@ -19,11 +19,11 @@ initialize the WVBottomFrictionLinear
  self = WVBottomFrictionLinear(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `r`  (optional) linear bottom friction, try 1/(200*86400)
++ `wvt`  transform that owns and evaluates the forcing
++ `r`  optional drag rate in inverse seconds; default `1/(200*86400)`
 
 ## Returns
-+ `frictionalForce`  a WVBottomFrictionLinear instance
++ `self`  linear bottom-friction forcing owned by `wvt`
 
 ## Discussion
 

--- a/docs/classes/forcing/wvbottomfrictionquadratic/cd.md
+++ b/docs/classes/forcing/wvbottomfrictionquadratic/cd.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Cd
 
-non-dimensional quadratic drag coefficient
+Configured dimensionless quadratic drag coefficient.
 
 
 ---
@@ -18,3 +18,5 @@ non-dimensional quadratic drag coefficient
 Real valued property with no dimensions and no units.
 
 ## Discussion
+
+The constructor default is `1e-3`.

--- a/docs/classes/forcing/wvbottomfrictionquadratic/cd_.md
+++ b/docs/classes/forcing/wvbottomfrictionquadratic/cd_.md
@@ -9,9 +9,12 @@ mathjax: true
 
 #  cd
 
-$$\frac{Cd}{dz}$$ scaled quadratic drag coefficient with units $$m^{-1}$$
+Drag coefficient applied at the bottom in $$\mathrm{m^{-1}}$$.
 
 
 ---
 
 ## Discussion
+
+This is `Cd/z_int(1)` for a three-dimensional transform and
+`Cd/4000` for a barotropic transform.

--- a/docs/classes/forcing/wvbottomfrictionquadratic/index.md
+++ b/docs/classes/forcing/wvbottomfrictionquadratic/index.md
@@ -11,7 +11,7 @@ nav_order: 4
 
 #  WVBottomFrictionQuadratic
 
-Quadratic bottom friction
+Apply quadratic drag at the bottom boundary.
 
 
 ---
@@ -22,11 +22,16 @@ Quadratic bottom friction
 
 ## Overview
 
-Applies quadratic bottom friction to the flow, i.e., $$\frac{du}{dt} = -\frac{Cd}{dz}\lvert \mathbf{u} \rvert\mathbf{u}(x,y,-D)$$. Cd is unitless, and dz is (approximately) the size of the grid spacing at the bottom boundary.
+The dimensionless drag coefficient $$C_d$$ is divided by the bottom
+quadrature weight for a three-dimensional transform:
 
-To compare with linear bottom friction where $$\frac{du}{dt} = -r \cdot u(x,y,-D)$$, note that $$- \frac{L_z}{dz} r = -\frac{C_d}{dz} \lvert \mathbf{u} \rvert$$ and you will find a characteristic velocity $$\lvert \mathbf{u} \rvert$$ of about 11.5 cm/s for Cd=0.002 and r=1/(200 days). If $$C_d=0.001$$, then the damping time scale has to double to 1/(400 days) for and equivalent characteristic velocity.
+$$
+c_d=\frac{C_d}{z_\mathrm{int}(1)}.
+$$
 
-For barotropic QG we want the scaling to work out similarly, but now have $$-r = -\frac{C_d}{D}\lvert \mathbf{u} \rvert$$ where $$D$$ works out to be $$L_z$$. Thus, we will scale the barotropic QG quadratic bottom drag by 4000 m, to match typical oceanic scales.
+Barotropic QG uses a fixed 4000 m reference depth,
+$$c_d=C_d/(4000\,\mathrm{m})$$. Comparing quadratic and linear drag
+gives the characteristic relation $$L_z r=C_d\lvert\mathbf{u}\rvert$$.
 
 Using the notation that
 
@@ -34,12 +39,13 @@ $$
 |\mathbf{u}(x,y,-D)| = \sqrt{u^2(x,y,-D) + v^2(x,y,-D)}
 $$
 
-is the magnitude of the total velocity at the bottom boundary, both nonhydrostatic and hydrostatic transforms linear bottom drag have the form
+is the magnitude of the total velocity at the bottom boundary. For
+hydrostatic and nonhydrostatic transforms,
 
 $$
 \begin{align}
-\mathcal{S}_u &= -\frac{C_d}{dz} |\mathbf{u}(x,y,-D)| u(x,y,-D) \\
-\mathcal{S}_v &= -\frac{C_d}{dz} |\mathbf{u}(x,y,-D)| v(x,y,-D)  \\
+\mathcal{S}_u &= -c_d |\mathbf{u}(x,y,-D)| u(x,y,-D) \\
+\mathcal{S}_v &= -c_d |\mathbf{u}(x,y,-D)| v(x,y,-D)  \\
 \mathcal{S}_w &= 0 \\
 \mathcal{S}_\eta &= 0
 \end{align}
@@ -49,16 +55,15 @@ and for quasigeostrophic transforms,
 
 $$
 \begin{align}
-\mathcal{S}_\textrm{qgpv} &= -\frac{C_dd}{dz} \left( \frac{\partial}{\partial x} \left( |\mathbf{u}(x,y,-D)| v(x,y,-D) \right) - \frac{\partial}{\partial y} \left( |\mathbf{u}(x,y,-D)| u(x,y,-D) \right) \right)
+\mathcal{S}_\mathrm{qgpv} &= -c_d \left[ \partial_x \left( |\mathbf{u}|v \right) - \partial_y \left( |\mathbf{u}|u \right) \right]_{z=-D}
 \end{align}
 $$
 
-### Usage
-
-Assuming there is a WVTransform instance wvt, to add this forcing,
+### Example
 
 ```matlab
-wvt.addForcing(WVBottomFrictionQuadratic(Cd=0.001));
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+wvt.addForcing(WVBottomFrictionQuadratic(wvt,Cd=0.001));
 ```
 
 
@@ -66,11 +71,11 @@ wvt.addForcing(WVBottomFrictionQuadratic(Cd=0.001));
 
 ## Topics
 + Create the forcing
-  + [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/wvbottomfrictionquadratic.html) initialize the WVBottomFrictionQuadratic
+  + [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/wvbottomfrictionquadratic.html) Create quadratic bottom friction for a transform.
 + Inspect forcing configuration
-  + [`Cd`](/classes/forcing/wvbottomfrictionquadratic/cd.html) non-dimensional quadratic drag coefficient
+  + [`Cd`](/classes/forcing/wvbottomfrictionquadratic/cd.html) Configured dimensionless quadratic drag coefficient.
 + Inspect forcing or damping scales
-  + [`cd`](/classes/forcing/wvbottomfrictionquadratic/cd_.html) $$\frac{Cd}{dz}$$ scaled quadratic drag coefficient with units $$m^{-1}$$
+  + [`cd`](/classes/forcing/wvbottomfrictionquadratic/cd_.html) Drag coefficient applied at the bottom in $$\mathrm{m^{-1}}$$.
 
 
 ## Developer Topics

--- a/docs/classes/forcing/wvbottomfrictionquadratic/wvbottomfrictionquadratic.md
+++ b/docs/classes/forcing/wvbottomfrictionquadratic/wvbottomfrictionquadratic.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVBottomFrictionQuadratic
 
-initialize the WVBottomFrictionQuadratic
+Create quadratic bottom friction for a transform.
 
 
 ---
@@ -19,11 +19,11 @@ initialize the WVBottomFrictionQuadratic
  self = WVBottomFrictionQuadratic(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `Cd`  (optional) non-dimensional quadratic damping coefficient. Default is 0.001
++ `wvt`  transform that owns and evaluates the forcing
++ `Cd`  optional dimensionless drag coefficient; default `1e-3`
 
 ## Returns
-+ `frictionalForce`  a WVBottomFrictionQuadratic instance
++ `self`  quadratic bottom-friction forcing owned by `wvt`
 
 ## Discussion
 

--- a/docs/classes/forcing/wvfixedamplitudeforcing/a0_indices.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/a0_indices.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0_indices
 
-indices of modes in the `A0` matrix to fix
+Linear indices of the selected `A0` coefficients.
 
 
 ---
@@ -19,3 +19,6 @@ indices of modes in the `A0` matrix to fix
 + Size: `(:,1)`
 
 ## Discussion
+
+This column vector is empty by default and has one entry for each
+value in `A0bar`.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/a0bar.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/a0bar.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0bar
 
-amplitudes of the fixed modes in the `A0` matrix
+Prescribed `A0` values in $$\mathrm{m^2\,s^{-1}}$$.
 
 
 ---
@@ -22,3 +22,5 @@ amplitudes of the fixed modes in the `A0` matrix
 Complex valued property with dimension $$A0_indices$$ and no units.
 
 ## Discussion
+
+Values correspond element-by-element to `A0_indices`.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/am_indices.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/am_indices.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Am_indices
 
-indices of modes in the `Am` matrix to fix
+Linear indices of the selected `Am` coefficients.
 
 
 ---
@@ -19,3 +19,6 @@ indices of modes in the `Am` matrix to fix
 + Size: `(:,1)`
 
 ## Discussion
+
+This column vector is empty by default and has one entry for each
+value in `Ambar`.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/ambar.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/ambar.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Ambar
 
-amplitudes of the fixed modes in the `Am` matrix
+Prescribed `Am` values in $$\mathrm{m\,s^{-1}}$$.
 
 
 ---
@@ -22,3 +22,5 @@ amplitudes of the fixed modes in the `Am` matrix
 Complex valued property with dimension $$Am_indices$$ and no units.
 
 ## Discussion
+
+Values correspond element-by-element to `Am_indices`.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/ap_indices.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/ap_indices.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Ap_indices
 
-indices of modes in the `Ap` matrix to fix
+Linear indices of the selected `Ap` coefficients.
 
 
 ---
@@ -19,3 +19,6 @@ indices of modes in the `Ap` matrix to fix
 + Size: `(:,1)`
 
 ## Discussion
+
+This column vector is empty by default and has one entry for each
+value in `Apbar`.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/apbar.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/apbar.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Apbar
 
-amplitudes of the fixed modes in the `Ap` matrix
+Prescribed `Ap` values in $$\mathrm{m\,s^{-1}}$$.
 
 
 ---
@@ -22,3 +22,5 @@ amplitudes of the fixed modes in the `Ap` matrix
 Complex valued property with dimension $$Ap_indices$$ and no units.
 
 ## Discussion
+
+Values correspond element-by-element to `Ap_indices`.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/index.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/index.md
@@ -11,7 +11,7 @@ nav_order: 5
 
 #  WVFixedAmplitudeForcing
 
-Fixed amplitude forcing at the natural frequency of each mode
+Hold selected wave-vortex coefficients at prescribed amplitudes.
 
 
 ---
@@ -22,7 +22,8 @@ Fixed amplitude forcing at the natural frequency of each mode
 
 ## Overview
 
-The fixed-amplitude forcing maintains the amplitude of the wave or geostrophic features, while allowing energy and enstrophy to flux from the feature.
+The forcing maintains selected wave or geostrophic coefficients while
+recording the tendency that must be cancelled to maintain them.
 
 As a simple example, one can set an internal wave mode with amplitude 1 cm/s, and that mode will continue to oscillate and maintain its amplitude. The wave will participate in all the nonlinear dynamics, but its amplitude will be maintained/restored at each time step.
 
@@ -32,7 +33,12 @@ $$
 \frac{\partial}{\partial t} A^{klj} = \sum_i F_i^{klj}
 $$
 
-where $$F_i$$ are the different forces applied. The transform computes the spatial forcing (which includes nonlinear advection), the spectral forcing, followed by the spectral amplitude forcing. The `WVFixedAmplitudeForcing` is a spectral amplitude forcing and is thus comptued last. This forcing thus simply adds back the flux the from the spatial and spectral forcing, so that $$\frac{\partial}{\partial t} A^{klj} =0$$ for the modes in question.
+where $$F_i$$ are the contributions from the registered forcing
+objects. The transform evaluates physical-space forcing, spectral
+forcing, and then spectral-amplitude forcing. This forcing is evaluated
+last: it zeros the tendency at selected indices and restores the
+prescribed coefficient values after the integration step, giving
+$$\partial_t A^{k\ell j}=0$$ for those modes.
 
 In practice, of course, we simply restore the amplitudes to their desired value at the last step, e.g.,
 
@@ -43,26 +49,22 @@ A0(self.A0_indices) = self.A0bar
 ### Notes
 
 - This approach is commonly used in forced-dissipative turbulence to maintain some fixed forcing.
-- Every mode that is used in `WVFixedAmplitudeForcing` essentially removes a degree-of-freedom from the model, as that mode is no longer free to fully evolve. Thus when you pass the forcing wave-vortex coefficients, e.g. `A0`, it does not fix the amplitude of coefficients that are small to avoid removing degrees-of-freedom.
-- One must also be careful not to forcing in the damping region. If you have some sort of small scale damping enabled, you probably do not want to be forcing at those smallest scales.
+- Every fixed mode removes a degree of freedom because it no longer
+evolves freely. The setter methods therefore ignore coefficients below
+$$10^{-6}$$ times the largest supplied magnitude unless an explicit
+mask is provided.
+- Avoid selecting modes in a closure's damping range. When
+`WVAdaptiveDamping` is registered, the setter methods automatically
+remove requested modes with $$K_h>k_\mathrm{damp}$$.
 
-### Usage
-
-To setup a geostrophic mean flow,
+### Example
 
 ```matlab
-% initialize a transform
-wvt = WVTransformHydrostatic([Lx, Ly, Lz], [Nx, Ny, Nz], N2=@(z) N0*N0*exp(2*z/L_gm),latitude=33);
-
-% set a geostrophic mode, with no flow at the bottom boundary
-wvt.setGeostrophicModes(k=0,l=5,j=1,phi=0,u=u0);
-wvt.setGeostrophicModes(k=0,l=5,j=0,phi=0,u=max(max(wvt.u(:,:,1))));
-
-% pass the vortex coefficients to the forcing
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+wvt.setGeostrophicModes(kMode=1,lMode=0,j=1,u=0.01);
 force = WVFixedAmplitudeForcing(wvt,name="geostrophic-mean-flow");
 force.setGeostrophicForcingCoefficients(wvt.A0);
 wvt.addForcing(force);
-
 ```
 
 In practice you can initialize the flow in any way you want with any arbitrary structure, and then pass those coefficients to the forcing. The `WVFixedAmplitudeForcing` looks for coefficients that are small and ignores those.
@@ -72,18 +74,18 @@ In practice you can initialize the flow in any way you want with any arbitrary s
 
 ## Topics
 + Create the forcing
-  + [`WVFixedAmplitudeForcing`](/classes/forcing/wvfixedamplitudeforcing/wvfixedamplitudeforcing.html) initialize the WVFixedAmplitudeForcing
+  + [`WVFixedAmplitudeForcing`](/classes/forcing/wvfixedamplitudeforcing/wvfixedamplitudeforcing.html) Create fixed-amplitude forcing for selected coefficients.
 + Inspect forcing configuration
-  + [`A0_indices`](/classes/forcing/wvfixedamplitudeforcing/a0_indices.html) indices of modes in the `A0` matrix to fix
-  + [`A0bar`](/classes/forcing/wvfixedamplitudeforcing/a0bar.html) amplitudes of the fixed modes in the `A0` matrix
-  + [`Ap_indices`](/classes/forcing/wvfixedamplitudeforcing/ap_indices.html) indices of modes in the `Ap` matrix to fix
-  + [`Apbar`](/classes/forcing/wvfixedamplitudeforcing/apbar.html) amplitudes of the fixed modes in the `Ap` matrix
-  + [`Am_indices`](/classes/forcing/wvfixedamplitudeforcing/am_indices.html) indices of modes in the `Am` matrix to fix
-  + [`Ambar`](/classes/forcing/wvfixedamplitudeforcing/ambar.html) amplitudes of the fixed modes in the `Am` matrix
+  + [`A0_indices`](/classes/forcing/wvfixedamplitudeforcing/a0_indices.html) Linear indices of the selected `A0` coefficients.
+  + [`A0bar`](/classes/forcing/wvfixedamplitudeforcing/a0bar.html) Prescribed `A0` values in $$\mathrm{m^2\,s^{-1}}$$.
+  + [`Ap_indices`](/classes/forcing/wvfixedamplitudeforcing/ap_indices.html) Linear indices of the selected `Ap` coefficients.
+  + [`Apbar`](/classes/forcing/wvfixedamplitudeforcing/apbar.html) Prescribed `Ap` values in $$\mathrm{m\,s^{-1}}$$.
+  + [`Am_indices`](/classes/forcing/wvfixedamplitudeforcing/am_indices.html) Linear indices of the selected `Am` coefficients.
+  + [`Ambar`](/classes/forcing/wvfixedamplitudeforcing/ambar.html) Prescribed `Am` values in $$\mathrm{m\,s^{-1}}$$.
 + Configure forcing
-  + [`setWaveForcingCoefficients`](/classes/forcing/wvfixedamplitudeforcing/setwaveforcingcoefficients.html) set the amplitude to fix for the wave part of the flow
-  + [`setGeostrophicForcingCoefficients`](/classes/forcing/wvfixedamplitudeforcing/setgeostrophicforcingcoefficients.html) set amplitude to fix for the geostrophic part of the flow
-  + [`setNarrowBandGeostrophicForcing`](/classes/forcing/wvfixedamplitudeforcing/setnarrowbandgeostrophicforcing.html) sets a narrow waveband of geostrophic forcing for forced-dissipative modeling
+  + [`setWaveForcingCoefficients`](/classes/forcing/wvfixedamplitudeforcing/setwaveforcingcoefficients.html) Select positive- and negative-frequency coefficients to fix.
+  + [`setGeostrophicForcingCoefficients`](/classes/forcing/wvfixedamplitudeforcing/setgeostrophicforcingcoefficients.html) Select zero-frequency coefficients to fix.
+  + [`setNarrowBandGeostrophicForcing`](/classes/forcing/wvfixedamplitudeforcing/setnarrowbandgeostrophicforcing.html) Initialize and fix a narrow band of geostrophic coefficients.
 
 
 ## Developer Topics

--- a/docs/classes/forcing/wvfixedamplitudeforcing/setgeostrophicforcingcoefficients.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/setgeostrophicforcingcoefficients.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  setGeostrophicForcingCoefficients
 
-set amplitude to fix for the geostrophic part of the flow
+Select zero-frequency coefficients to fix.
 
 
 ---
@@ -19,10 +19,12 @@ set amplitude to fix for the geostrophic part of the flow
  setGeostrophicForcingCoefficients(A0bar,options)
 ```
 ## Parameters
-+ `A0bar`  A0 fixed amplitude
-+ `MA0`  (optional) forcing mask, A0. 1s at the forced modes, 0s at the unforced modes. Default is MA0 = abs(A0bar) > 1e-6*max(abs(A0bar(:)))
++ `A0bar`  `A0` values on the transform spectral grid
++ `MA0`  optional logical `A0` selection mask; default `abs(A0bar) > 1e-6*max(abs(A0bar(:)))`
 
 ## Discussion
 
-This function will automatically remove modes set in the
-damping region of the WVAdaptiveDamping forcing, if present.
+Without an explicit mask, coefficients whose magnitude is at
+least $$10^{-6}$$ times the largest supplied magnitude are
+selected. If adaptive damping is registered, selected modes
+above its horizontal `k_damp` threshold are removed.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/setnarrowbandgeostrophicforcing.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/setnarrowbandgeostrophicforcing.md
@@ -9,18 +9,38 @@ mathjax: true
 
 #  setNarrowBandGeostrophicForcing
 
-sets a narrow waveband of geostrophic forcing for forced-dissipative modeling
+Initialize and fix a narrow band of geostrophic coefficients.
 
 
 ---
 
 ## Declaration
 ```matlab
- setNarrowBandGeostrophicForcing(options)
+ [model_spectrum,r] = setNarrowBandGeostrophicForcing(options)
 ```
 ## Parameters
-+ `r`  A0 fixed amplitude
++ `r`  optional large-scale damping rate in inverse seconds; when supplied, determines `k_r`
++ `k_r`  optional arrest wavenumber in radians per meter; default `2*dk`
++ `k_f`  optional forcing-band center in radians per meter; default `20*dk`
++ `j_f`  optional forced vertical-mode number; default `1`
++ `u_rms`  optional target surface root-mean-square speed in meters per second; default `0.2`
++ `initialPV`  optional initialization choice `"none"`, `"narrow-band"`, or `"full-spectrum"`; default `"narrow-band"`
+
+## Returns
++ `model_spectrum`  conditional radial spectrum function used for initialization
++ `r`  conditional damping-rate estimate computed when `r` is omitted
 
 ## Discussion
 
-to be moved to a subclass
+This legacy helper optionally initializes `wvt.A0`, constructs
+a radial geostrophic spectrum, selects the band centered on
+`k_f` at vertical mode `j_f`, and passes that selection to
+`setGeostrophicForcingCoefficients`. It mutates both the
+transform and this forcing. Its eventual replacement is
+tracked by [Issue #2](https://github.com/JeffreyEarly/wave-vortex-model/issues/2).
+
+`model_spectrum` is assigned only when `initialPV` is
+`"narrow-band"` or `"full-spectrum"`. The returned `r` is
+assigned only when `r` is omitted and computed from `k_r`.
+Callers should therefore treat both outputs as conditional
+legacy diagnostics.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/setwaveforcingcoefficients.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/setwaveforcingcoefficients.md
@@ -9,22 +9,24 @@ mathjax: true
 
 #  setWaveForcingCoefficients
 
-set the amplitude to fix for the wave part of the flow
+Select positive- and negative-frequency coefficients to fix.
 
 
 ---
 
 ## Declaration
 ```matlab
-  setWaveForcingCoefficients(Apbar,Ambar,options)
+ setWaveForcingCoefficients(Apbar,Ambar,options)
 ```
 ## Parameters
-+ `Apbar`  Ap fixed amplitude
-+ `Ambar`  Am fixed amplitude
-+ `MAp`  (optional) forcing mask, Ap. 1s at the forced modes, 0s at the unforced modes. Default is MAp = abs(Apbar) > 1e-6*max(abs(Apbar(:)))
-+ `MAm`  (optional) forcing mask, Am. 1s at the forced modes, 0s at the unforced modes. Default is MAm = abs(Ambar) > 1e-6*max(abs(Ambar(:)))
++ `Apbar`  `Ap` values on the transform spectral grid
++ `Ambar`  `Am` values on the transform spectral grid
++ `MAp`  optional logical `Ap` selection mask; default `abs(Apbar) > 1e-6*max(abs(Apbar(:)))`
++ `MAm`  optional logical `Am` selection mask; default `abs(Ambar) > 1e-6*max(abs(Ambar(:)))`
 
 ## Discussion
 
-This function will automatically remove modes set in the
-damping region of the WVAdaptiveDamping forcing, if present.
+Without explicit masks, coefficients whose magnitude is at
+least $$10^{-6}$$ times the largest supplied magnitude are
+selected. If adaptive damping is registered, selected modes
+above its horizontal `k_damp` threshold are removed.

--- a/docs/classes/forcing/wvfixedamplitudeforcing/wvfixedamplitudeforcing.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/wvfixedamplitudeforcing.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WVFixedAmplitudeForcing
 
-initialize the WVFixedAmplitudeForcing
+Create fixed-amplitude forcing for selected coefficients.
 
 
 ---
@@ -19,22 +19,24 @@ initialize the WVFixedAmplitudeForcing
  self = WVFixedAmplitudeForcing(wvt,options)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
-+ `name`  (required) name of this forcing
-+ `Apbar`  (optional) amplitude of Ap matrix to fix
-+ `Ambar`  (optional) amplitude of Am matrix to fix
-+ `A0bar`  (optional) amplitude of A0 matrix to fix
-+ `Ap_indices`  (optional) index of coefficient in Ap matrix to fix
-+ `Am_indices`  (optional) index of coefficient in Am matrix to fix
-+ `A0_indices`  (optional) index of coefficient in A0 matrix to fix
++ `wvt`  transform that owns and evaluates the forcing
++ `name`  required unique forcing-registry name
++ `Apbar`  optional column of prescribed `Ap` values; default empty
++ `Ambar`  optional column of prescribed `Am` values; default empty
++ `A0bar`  optional column of prescribed `A0` values; default empty
++ `Ap_indices`  optional column of corresponding `Ap` linear indices; default empty
++ `Am_indices`  optional column of corresponding `Am` linear indices; default empty
++ `A0_indices`  optional column of corresponding `A0` linear indices; default empty
 
 ## Returns
-+ `self`  a WVFixedAmplitudeForcing instance
++ `self`  fixed-amplitude forcing owned by `wvt`
 
 ## Discussion
 
-You must pass the instance of the WVTransform to be used and
-you must also specify a unique name for the forcing.
+Supply a unique registry name. Coefficients may be selected
+directly with paired value/index column vectors, or later with
+`setWaveForcingCoefficients` and
+`setGeostrophicForcingCoefficients`.
 
 See the [WVFixedAmplitudeForcing overview](/classes/forcing/wvfixedamplitudeforcing/)
 for the tendency and restoration behavior, modeling cautions,

--- a/docs/classes/forcing/wvnonlinearadvection/dlnn2.md
+++ b/docs/classes/forcing/wvnonlinearadvection/dlnn2.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  dLnN2
 
-variable stratification factor
+Precomputed vertical logarithmic stratification gradient.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,3 +17,6 @@ variable stratification factor
 ---
 
 ## Discussion
+
+This Internal array is zero for constant stratification and has
+units of inverse meters for variable stratification.

--- a/docs/classes/forcing/wvnonlinearadvection/index.md
+++ b/docs/classes/forcing/wvnonlinearadvection/index.md
@@ -11,7 +11,7 @@ nav_order: 2
 
 #  WVNonlinearAdvection
 
-The advective flux, $$\mathbf{u}\cdot \nabla \mathbf{u}$$ and $$\mathbf{u}\cdot \nabla \eta$$
+Add nonlinear advection to the model equations.
 
 
 ---
@@ -22,9 +22,9 @@ The advective flux, $$\mathbf{u}\cdot \nabla \mathbf{u}$$ and $$\mathbf{u}\cdot 
 
 ## Overview
 
-The nonlinear advection forcing adds the nonlinear terms to the momentum and thermodynamic equation.
-
-The nonlinear terms are all computed in the spatial domain.
+The nonlinear terms are evaluated in physical space and added to the
+momentum, thermodynamic, or quasigeostrophic potential-vorticity
+(QGPV) equation appropriate to the transform.
 
 For nonhydrostatic transforms,
 
@@ -51,22 +51,32 @@ and for quasigeostrophic transforms,
 
 $$
 \begin{align}
-\mathcal{S}_\textrm{qgpv} &= - \left( u \partial_x q + v \partial_y q \right)
+\mathcal{S}_\mathrm{qgpv} &= - \left( u \partial_x q + v \partial_y q \right)
 \end{align}
 $$
 
-where $$q$$ is the qgpv.
+where $$q$$ is QGPV.
 
 ### Notes
 
-This is the only forcing added to the transforms by default. You must explicitly remove it if you want to consider linear flows.
+Every supported transform installs this forcing by default. A
+nonlinear `WVModel` evaluates it automatically. Analytical linear
+evolution does not evaluate nonlinear forcing, so the object does not
+need to be removed when using linear evolution.
+
+### Example
+
+```matlab
+wvt = WVTransformConstantStratification([40e3,30e3,2e3],[8,6,5],N0=5.2e-3,latitude=45,isHydrostatic=true);
+nonlinearAdvection = wvt.forcingWithName("nonlinear advection");
+```
 
 
 
 
 ## Topics
 + Create the forcing
-  + [`WVNonlinearAdvection`](/classes/forcing/wvnonlinearadvection/wvnonlinearadvection.html) initialize the WVNonlinearAdvection nonlinear flux
+  + [`WVNonlinearAdvection`](/classes/forcing/wvnonlinearadvection/wvnonlinearadvection.html) Create nonlinear advection for a transform.
 
 
 ## Developer Topics
@@ -74,7 +84,7 @@ These items document internal implementation details and are not part of the pri
 + Forcing persistence
   + [`classRequiredPropertyNames`](/classes/forcing/wvnonlinearadvection/classrequiredpropertynames.html) Returns the required property names for the class
 + Forcing internals
-  + [`dLnN2`](/classes/forcing/wvnonlinearadvection/dlnn2.html) variable stratification factor
+  + [`dLnN2`](/classes/forcing/wvnonlinearadvection/dlnn2.html) Precomputed vertical logarithmic stratification gradient.
 
 
 ---

--- a/docs/classes/forcing/wvnonlinearadvection/wvnonlinearadvection.md
+++ b/docs/classes/forcing/wvnonlinearadvection/wvnonlinearadvection.md
@@ -9,23 +9,23 @@ mathjax: true
 
 #  WVNonlinearAdvection
 
-initialize the WVNonlinearAdvection nonlinear flux
+Create nonlinear advection for a transform.
 
 
 ---
 
 ## Declaration
 ```matlab
- self = WVNonlinearAdvection(wvt,options)
+ self = WVNonlinearAdvection(wvt)
 ```
 ## Parameters
-+ `wvt`  a WVTransform instance
++ `wvt`  transform that owns and evaluates the forcing
 
 ## Returns
-+ `self`  a WVNonlinearAdvection instance
++ `self`  nonlinear-advection forcing owned by `wvt`
 
 ## Discussion
 
 See the [WVNonlinearAdvection overview](/classes/forcing/wvnonlinearadvection/)
-for the hydrostatic, nonhydrostatic, and quasigeostrophic
-equations and its role as the default forcing.
+for the hydrostatic, nonhydrostatic, and QGPV equations and
+its role as the default forcing.

--- a/docs/users-guide/adding-forcing.md
+++ b/docs/users-guide/adding-forcing.md
@@ -10,11 +10,13 @@ mathjax: true
 
 `WVModel` advances a transform with nonlinear advection by default. External tendencies and closures enter through `WVForcing` objects, while analytical linear evolution is available when nonlinear interactions should be omitted.
 
+The [Forcing reference](/classes/forcing/) summarizes the supplied physical and spectral tendencies. The [Closures reference](/classes/forcing/closures/) compares the available small-scale closures and their principal controls.
+
 ## Quick start
 
 By default, a `WVTransform` is initialized with exactly one forcing term: nonlinear advection. Initialize a transform, then call `summarizeForcing` to list its right-hand-side terms:
 ```matlab
-wvt = WVTransformHydrostatic([800e3, 800e3, 4000],[64, 64, 65], N2=@(z) (3*2*pi/3600)^2*exp(2*z/1300),latitude=30);
+wvt = WVTransformHydrostatic([800e3,800e3,4000],[64,64,65],N2Function=@(z)(3*2*pi/3600)^2*exp(2*z/1300),latitude=30);
 wvt.summarizeForcing
 ```
 
@@ -45,7 +47,10 @@ The model now includes nonlinear advection and adaptive damping when it advances
 model = WVModel(wvt);
 model.integrateToTime(wvt.inertialPeriod);
 ```
-and it would include both nonlinear advection and small scale adaptive damping.
+
+`WVModel` now advances the transform with both nonlinear advection and small-scale adaptive damping.
+
+Prescribed forcings and closures use the same registration mechanism. For example, `WVFixedAmplitudeForcing` can hold selected wave-vortex coefficients at specified values, while traditional horizontal and vertical damping apply fixed viscosity or diffusivity. The class reference documents each forcing's supported geometry, configuration, and diagnostic scales.
 
 
 ## The equations of motion

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -8,7 +8,7 @@ nav_order: 100
 
 ## [Unreleased]
 
-- Reorganized the transform and forcing references around common user tasks, grouped physical and spectral coordinates coherently, promoted flow-component diagnostics and forcing configuration, documented the user-facing transform surface and forcing-stage contract, kept evaluation and inherited implementation machinery in Developer Topics, and removed obsolete transform-level pseudo-radial and frequency-axis binning remnants whose maintained implementations live in `WVDiagnostics`.
+- Reorganized the transform and forcing references around common user tasks, grouped physical and spectral coordinates coherently, promoted flow-component diagnostics and forcing configuration, documented the user-facing transform surface and forcing-stage contract, corrected the supplied forcing and closure declarations, units, defaults, examples, and geometry-specific behavior, kept evaluation and inherited implementation machinery in Developer Topics, and removed obsolete transform-level pseudo-radial and frequency-axis binning remnants whose maintained implementations live in `WVDiagnostics`.
 - Updated onboarding examples to demonstrate warning-free nonlinear integration by default, simplified hand-authored MATLAB examples, and corrected unsupported single-dollar mathematical markup throughout the generated website.
 
 ## [4.2.1] - 2026-08-09


### PR DESCRIPTION
## Summary
- correct constructors, units, defaults, examples, and geometry-specific behavior for ten supplied forcings and closures
- preserve the authored scientific explanations while removing obsolete and copied documentation
- update the adding-forcing guide and add focused executable documentation coverage

## Verification
- TestForcingDocumentation
- TestCoreAPIDocumentation
- all ten published examples execute without warnings
- buildtool docs:check twice
- buildtool analyze with 0 blocking findings
- whitespace, manifest-scope, mirror, route, and artifact checks

Smoke, full, exhaustive, and optional suites are intentionally deferred to umbrella #99 integration.

Closes #101