### PR TITLE
Correct unreleased changelog summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## [Unreleased]
 
-- Retired the unsupported experimental WaveVortex FFTW backend after the fine-grained and coarse-gateway implementations missed their model-level adoption gates; removed its probe, plans, buffers, and expanded compatibility indices while retaining compact Fourier layouts, builtin performance, and backend-neutral storage/RSS diagnostics.
-- Reorganized the transform and forcing references around common user tasks, grouped physical and spectral coordinates coherently, promoted flow-component diagnostics and forcing configuration, documented the user-facing transform surface and forcing-stage contract, corrected the supplied forcing and closure declarations, units, defaults, examples, and geometry-specific behavior, kept evaluation and inherited implementation machinery in Developer Topics, and removed obsolete transform-level pseudo-radial and frequency-axis binning remnants whose maintained implementations live in `WVDiagnostics`.
-- Updated onboarding examples to demonstrate warning-free nonlinear integration by default, simplified hand-authored MATLAB examples, and corrected unsupported single-dollar mathematical markup throughout the generated website.
+- Retired the experimental FFTW backend; WaveVortexModel now uses MATLAB's builtin transforms and has no FFTWTransforms dependency.
+- Removed the obsolete expanded mappings `dftPrimaryIndex`, `dftConjugateIndex`, `wvConjugateIndex`, `indicesFromWVGridToFFTWGrid`, and `expandedLegacyMappings`; `indicesFromWVGridToDFTGrid` remains available explicitly.
+- Updated Fourier-at-position reconstruction to use compact `WVFourierStorageLayout` mappings.
+- Removed obsolete pseudo-radial and frequency-binning APIs whose maintained equivalents live in `WVDiagnostics`.
+- Added backend-neutral transform-storage accounting and fresh-process RSS benchmarks.
+- Completed and reorganized transform and forcing documentation, corrected API metadata, and improved nonlinear-integration examples.
 
 ## [4.2.1] - 2026-08-09
 

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -8,9 +8,12 @@ nav_order: 100
 
 ## [Unreleased]
 
-- Retired the unsupported experimental WaveVortex FFTW backend after the fine-grained and coarse-gateway implementations missed their model-level adoption gates; removed its probe, plans, buffers, and expanded compatibility indices while retaining compact Fourier layouts, builtin performance, and backend-neutral storage/RSS diagnostics.
-- Reorganized the transform and forcing references around common user tasks, grouped physical and spectral coordinates coherently, promoted flow-component diagnostics and forcing configuration, documented the user-facing transform surface and forcing-stage contract, corrected the supplied forcing and closure declarations, units, defaults, examples, and geometry-specific behavior, kept evaluation and inherited implementation machinery in Developer Topics, and removed obsolete transform-level pseudo-radial and frequency-axis binning remnants whose maintained implementations live in `WVDiagnostics`.
-- Updated onboarding examples to demonstrate warning-free nonlinear integration by default, simplified hand-authored MATLAB examples, and corrected unsupported single-dollar mathematical markup throughout the generated website.
+- Retired the experimental FFTW backend; WaveVortexModel now uses MATLAB's builtin transforms and has no FFTWTransforms dependency.
+- Removed the obsolete expanded mappings `dftPrimaryIndex`, `dftConjugateIndex`, `wvConjugateIndex`, `indicesFromWVGridToFFTWGrid`, and `expandedLegacyMappings`; `indicesFromWVGridToDFTGrid` remains available explicitly.
+- Updated Fourier-at-position reconstruction to use compact `WVFourierStorageLayout` mappings.
+- Removed obsolete pseudo-radial and frequency-binning APIs whose maintained equivalents live in `WVDiagnostics`.
+- Added backend-neutral transform-storage accounting and fresh-process RSS benchmarks.
+- Completed and reorganized transform and forcing documentation, corrected API metadata, and improved nonlinear-integration examples.
 
 ## [4.2.1] - 2026-08-09
 


### PR DESCRIPTION
## Summary
- accurately separate FFTW retirement, removed mapping APIs, storage diagnostics, and documentation work
- avoid repeating v4.2.1 performance claims or implying experimental prototypes shipped
- regenerate the committed version-history page

## Verification
- buildtool docs:check