### PR TITLE
Refine WVTransform reference organization

### DIFF
--- a/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
+++ b/@WVGeometryDoublyPeriodic/WVGeometryDoublyPeriodic.m
@@ -99,14 +99,14 @@ classdef WVGeometryDoublyPeriodic < CAAnnotatedClass
         % - Topic: Domain attributes — WV grid
         dftConjugateIndices2D uint64
 
-        % Stored x-direction angular wavenumbers on the compact WV grid.
+        % Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
         %
         % `k` is an `Nkl`-by-1 column vector in radians per meter.
         %
         % - Topic: Domain attributes — WV grid
         k
         
-        % Stored y-direction angular wavenumbers on the compact WV grid.
+        % Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
         %
         % `l` is an `Nkl`-by-1 column vector in radians per meter.
         %

--- a/@WVGeometryDoublyPeriodicStratified/WVGeometryDoublyPeriodicStratified.m
+++ b/@WVGeometryDoublyPeriodicStratified/WVGeometryDoublyPeriodicStratified.m
@@ -139,7 +139,7 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         function Finv = get.FinvMatrix(wvt)
-            % Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+            % Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
@@ -154,7 +154,7 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         end
 
         function F = get.FMatrix(wvt)
-            % Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+            % Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.
@@ -169,7 +169,7 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         end
 
         function Ginv = get.GinvMatrix(wvt)
-            % Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+            % Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
@@ -184,7 +184,7 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         end
 
         function G = get.GMatrix(wvt)
-            % Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+            % Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.

--- a/@WVGeometryDoublyPeriodicStratified/WVGeometryDoublyPeriodicStratified.m
+++ b/@WVGeometryDoublyPeriodicStratified/WVGeometryDoublyPeriodicStratified.m
@@ -139,14 +139,14 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         function Finv = get.FinvMatrix(wvt)
-            % transformation matrix $$F^{-1}$$
+            % Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: Finv = FinvMatrix(wvt)
-            % - Returns Finv: A matrix with dimensions [Nz Nj]
+            % - Returns Finv: vertical-mode reconstruction matrix with dimensions `[Nz Nj]`
             arguments
                 wvt         WVStratification
             end
@@ -154,14 +154,14 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         end
 
         function F = get.FMatrix(wvt)
-            % transformation matrix $$F$$
+            % Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: F = FMatrix(wvt)
-            % - Returns Finv: A matrix with dimensions [Nz Nj]
+            % - Returns F: vertical-mode projection matrix with dimensions `[Nj Nz]`
             arguments
                 wvt         WVStratification
             end
@@ -169,14 +169,14 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         end
 
         function Ginv = get.GinvMatrix(wvt)
-            % transformation matrix $$G^{-1}$$
+            % Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: Ginv = GinvMatrix(wvt)
-            % - Returns Finv: A matrix with dimensions [Nz Nj]
+            % - Returns Ginv: vertical-mode reconstruction matrix with dimensions `[Nz Nj]`
             arguments
                 wvt         WVStratification
             end
@@ -184,14 +184,14 @@ classdef WVGeometryDoublyPeriodicStratified < WVGeometryDoublyPeriodic & WVStrat
         end
 
         function G = get.GMatrix(wvt)
-            % transformation matrix $$G$$
+            % Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: G = GMatrix(wvt)
-            % - Returns Ginv: A matrix with dimensions [Nz Nj]
+            % - Returns G: vertical-mode projection matrix with dimensions `[Nj Nz]`
             arguments
                 wvt         WVStratification
             end

--- a/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
@@ -161,7 +161,7 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
         end
 
         function Finv = get.FinvMatrix(wvt)
-            % Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+            % Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
@@ -177,7 +177,7 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
         end
 
         function F = get.FMatrix(wvt)
-            % Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+            % Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.
@@ -192,7 +192,7 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
             F = wvt.DCT ./ wvt.F_g(:,1);
         end
         function Ginv = get.GinvMatrix(wvt)
-            % Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+            % Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
@@ -207,7 +207,7 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
             Ginv = shiftdim(wvt.G_g(:,1),1) .* wvt.iDST;
         end
         function G = get.GMatrix(wvt)
-            % Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+            % Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.

--- a/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
+++ b/@WVGeometryDoublyPeriodicStratifiedConstant/WVGeometryDoublyPeriodicStratifiedConstant.m
@@ -161,14 +161,14 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
         end
 
         function Finv = get.FinvMatrix(wvt)
-            % transformation matrix $$F^{-1}$$
+            % Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: Finv = FinvMatrix(wvt)
-            % - Returns Finv: A matrix with dimensions [Nz Nj]
+            % - Returns Finv: vertical-mode reconstruction matrix with dimensions `[Nz Nj]`
             arguments
                 wvt         WVTransform
             end
@@ -177,14 +177,14 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
         end
 
         function F = get.FMatrix(wvt)
-            % transformation matrix $$F$$
+            % Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: F = FMatrix(wvt)
-            % - Returns Finv: A matrix with dimensions [Nz Nj]
+            % - Returns F: vertical-mode projection matrix with dimensions `[Nj Nz]`
             arguments
                 wvt         WVTransform
             end
@@ -192,14 +192,14 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
             F = wvt.DCT ./ wvt.F_g(:,1);
         end
         function Ginv = get.GinvMatrix(wvt)
-            % transformation matrix $$G^{-1}$$
+            % Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
             %
             % A matrix that transforms a vector from vertical mode space to physical
             % space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: Ginv = GinvMatrix(wvt)
-            % - Returns Finv: A matrix with dimensions [Nz Nj]
+            % - Returns Ginv: vertical-mode reconstruction matrix with dimensions `[Nz Nj]`
             arguments
                 wvt         WVTransform
             end
@@ -207,14 +207,14 @@ classdef WVGeometryDoublyPeriodicStratifiedConstant < WVGeometryDoublyPeriodic &
             Ginv = shiftdim(wvt.G_g(:,1),1) .* wvt.iDST;
         end
         function G = get.GMatrix(wvt)
-            % transformation matrix $$G$$
+            % Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
             %
             % A matrix that transforms a vector from physical
             % space to vertical mode space.
             %
             % - Topic: Operations — Transformations
             % - Declaration: G = GMatrix(wvt)
-            % - Returns Ginv: A matrix with dimensions [Nz Nj]
+            % - Returns G: vertical-mode projection matrix with dimensions `[Nj Nz]`
             arguments
                 wvt         WVTransform
             end

--- a/@WVTransform/WVTransform.m
+++ b/@WVTransform/WVTransform.m
@@ -42,11 +42,13 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
     % - Topic: Inspect the domain — Spatial grid — Resolution and shape
     % - Topic: Inspect the domain — Spatial grid — Quadrature and integration
     % - Topic: Inspect the domain — Spectral grid
-    % - Topic: Inspect the domain — Spectral grid — Axes and spacing
-    % - Topic: Inspect the domain — Spectral grid — Coordinate arrays
+    % - Topic: Inspect the domain — Spectral grid — Compact grid vectors
+    % - Topic: Inspect the domain — Spectral grid — Compact grid arrays
+    % - Topic: Inspect the domain — Spectral grid — Wavenumber spacing
     % - Topic: Inspect the domain — Spectral grid — Horizontal wavenumber geometry
     % - Topic: Inspect the domain — Spectral grid — Resolution and shape
     % - Topic: Inspect the domain — Spectral grid — Vertical modes and scaling
+    % - Topic: Inspect the domain — Spectral grid — Vertical-mode transformation matrices
     % - Topic: Inspect the domain — Transform configuration
     % - Topic: Initialize the flow
     % - Topic: Initialize the flow — General initialization
@@ -66,8 +68,10 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
     % - Topic: Evaluate physical fields — At arbitrary positions
     % - Topic: Evaluate physical fields — Isopycnal utilities
     % - Topic: Manage forcing and closures
+    % - Topic: Manage forcing and closures — Configure forcing
+    % - Topic: Manage forcing and closures — Inspect forcing and closures
+    % - Topic: Manage forcing and closures — Summarize forcing
     % - Topic: Analyze the flow
-    % - Topic: Analyze the flow — Energy and summaries
     % - Topic: Analyze the flow — Flow diagnostics
     % - Topic: Analyze the flow — Density validity
     % - Topic: Analyze the flow — Potential vorticity and enstrophy
@@ -75,11 +79,18 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
     % - Topic: Analyze the flow — Spectra — Spectral fields
     % - Topic: Analyze the flow — Spectra — Radial wavenumber
     % - Topic: Analyze the flow — Spectra — Frequency
+    % - Topic: Analyze energy
+    % - Topic: Analyze energy — Component energy
+    % - Topic: Analyze energy — Total energy
+    % - Topic: Analyze energy — Energy summaries
     % - Topic: Save transform state
     % - Topic: Convert representations
     % - Topic: Convert representations — Physical fields and coefficients
     % - Topic: Differentiate and integrate fields
     % - Topic: Inspect flow components
+    % - Topic: Inspect flow components — Primary flow components
+    % - Topic: Inspect flow components — Registered and combined components
+    % - Topic: Inspect flow components — Summarize flow components
     % - Topic: Inspect wave-vortex coefficients
     % - Topic: Inspect wave-vortex coefficients — Stored coefficients
     % - Topic: Inspect wave-vortex coefficients — Coefficients at the current time
@@ -91,6 +102,12 @@ classdef WVTransform < matlab.mixin.indexing.RedefinesDot & CAAnnotatedClass
     % - Topic: Get package information
     % - Topic: Projection and reconstruction coefficients
     % - Topic: Geometry and mode indexing
+    % - Topic: Geometry and mode indexing — Mode numbers and validity
+    % - Topic: Geometry and mode indexing — Linear-index conversion
+    % - Topic: Geometry and mode indexing — DFT and WV layout metadata
+    % - Topic: Geometry and mode indexing — Layout conversion
+    % - Topic: Geometry and mode indexing — Masks and Hermitian bookkeeping
+    % - Topic: Geometry and mode indexing — Additional geometry utilities
     % - Topic: Spectral transforms and operators
     % - Topic: Nonlinear flux and forcing internals
     % - Topic: Persistence internals

--- a/@WVTransform/detailedDescriptions/A0.md
+++ b/@WVTransform/detailedDescriptions/A0.md
@@ -1,3 +1,5 @@
+Zero-frequency wave–vortex coefficient array.
+
 `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
 
 The geostrophic solutions follow the decomposition in [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The complete basis, including the mean-density-anomaly solution, is described in the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269).

--- a/@WVTransform/detailedDescriptions/A0N.md
+++ b/@WVTransform/detailedDescriptions/A0N.md
@@ -1,3 +1,5 @@
+Projects density displacement onto $$A_0$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/@WVTransform/detailedDescriptions/A0U.md
+++ b/@WVTransform/detailedDescriptions/A0U.md
@@ -1,3 +1,5 @@
+Projects $$u$$ onto $$A_0$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/@WVTransform/detailedDescriptions/A0V.md
+++ b/@WVTransform/detailedDescriptions/A0V.md
@@ -1,3 +1,5 @@
+Projects $$v$$ onto $$A_0$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/@WVTransform/detailedDescriptions/A0Z.md
+++ b/@WVTransform/detailedDescriptions/A0Z.md
@@ -1,0 +1,3 @@
+Projects vertical vorticity onto $$A_0$$.
+
+`A0Z` maps the vertically transformed relative-vorticity state onto the zero-frequency coefficient array.

--- a/@WVTransform/detailedDescriptions/Am.md
+++ b/@WVTransform/detailedDescriptions/Am.md
@@ -1,3 +1,5 @@
+Negative-frequency wave–vortex coefficient array.
+
 `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the negative-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/@WVTransform/detailedDescriptions/AmN.md
+++ b/@WVTransform/detailedDescriptions/AmN.md
@@ -1,3 +1,5 @@
+Projects density displacement onto $$A_-$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_-$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/AmU.md
+++ b/@WVTransform/detailedDescriptions/AmU.md
@@ -1,3 +1,5 @@
+Projects $$u$$ onto $$A_-$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_-$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/AmV.md
+++ b/@WVTransform/detailedDescriptions/AmV.md
@@ -1,3 +1,5 @@
+Projects $$v$$ onto $$A_-$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_-$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/Ap.md
+++ b/@WVTransform/detailedDescriptions/Ap.md
@@ -1,3 +1,5 @@
+Positive-frequency wave–vortex coefficient array.
+
 `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the positive-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/@WVTransform/detailedDescriptions/ApN.md
+++ b/@WVTransform/detailedDescriptions/ApN.md
@@ -1,3 +1,5 @@
+Projects density displacement onto $$A_+$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_+$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/ApU.md
+++ b/@WVTransform/detailedDescriptions/ApU.md
@@ -1,3 +1,5 @@
+Projects $$u$$ onto $$A_+$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_+$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/ApV.md
+++ b/@WVTransform/detailedDescriptions/ApV.md
@@ -1,3 +1,5 @@
+Projects $$v$$ onto $$A_+$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_+$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/ApmD.md
+++ b/@WVTransform/detailedDescriptions/ApmD.md
@@ -1,0 +1,3 @@
+Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
+
+`ApmD` supplies the common divergence contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/@WVTransform/detailedDescriptions/ApmN.md
+++ b/@WVTransform/detailedDescriptions/ApmN.md
@@ -1,0 +1,3 @@
+Projects density displacement onto $$A_+$$ and $$A_-$$.
+
+`ApmN` supplies the signed density-displacement contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/@WVTransform/detailedDescriptions/FMatrix.md
+++ b/@WVTransform/detailedDescriptions/FMatrix.md
@@ -1,3 +1,3 @@
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/@WVTransform/detailedDescriptions/FMatrix.md
+++ b/@WVTransform/detailedDescriptions/FMatrix.md
@@ -1,0 +1,3 @@
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/@WVTransform/detailedDescriptions/FinvMatrix.md
+++ b/@WVTransform/detailedDescriptions/FinvMatrix.md
@@ -1,0 +1,3 @@
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+
+`FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/@WVTransform/detailedDescriptions/FinvMatrix.md
+++ b/@WVTransform/detailedDescriptions/FinvMatrix.md
@@ -1,3 +1,3 @@
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 `FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/@WVTransform/detailedDescriptions/GMatrix.md
+++ b/@WVTransform/detailedDescriptions/GMatrix.md
@@ -1,0 +1,3 @@
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/@WVTransform/detailedDescriptions/GMatrix.md
+++ b/@WVTransform/detailedDescriptions/GMatrix.md
@@ -1,3 +1,3 @@
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/@WVTransform/detailedDescriptions/GinvMatrix.md
+++ b/@WVTransform/detailedDescriptions/GinvMatrix.md
@@ -1,0 +1,3 @@
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+
+`GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/@WVTransform/detailedDescriptions/GinvMatrix.md
+++ b/@WVTransform/detailedDescriptions/GinvMatrix.md
@@ -1,3 +1,3 @@
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 `GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/@WVTransform/detailedDescriptions/NA0.md
+++ b/@WVTransform/detailedDescriptions/NA0.md
@@ -1,3 +1,5 @@
+Reconstructs density displacement from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/NAm.md
+++ b/@WVTransform/detailedDescriptions/NAm.md
@@ -1,3 +1,5 @@
+Reconstructs density displacement from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/NAp.md
+++ b/@WVTransform/detailedDescriptions/NAp.md
@@ -1,3 +1,5 @@
+Reconstructs density displacement from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/PA0.md
+++ b/@WVTransform/detailedDescriptions/PA0.md
@@ -1,0 +1,3 @@
+Reconstructs pressure height from $$A_0$$.
+
+`PA0` maps the zero-frequency coefficient array onto the pressure-height anomaly used to evaluate `pi` and pressure.

--- a/@WVTransform/detailedDescriptions/UA0.md
+++ b/@WVTransform/detailedDescriptions/UA0.md
@@ -1,3 +1,5 @@
+Reconstructs $$u$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/UAm.md
+++ b/@WVTransform/detailedDescriptions/UAm.md
@@ -1,3 +1,5 @@
+Reconstructs $$u$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/UAp.md
+++ b/@WVTransform/detailedDescriptions/UAp.md
@@ -1,3 +1,5 @@
+Reconstructs $$u$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/VA0.md
+++ b/@WVTransform/detailedDescriptions/VA0.md
@@ -1,3 +1,5 @@
+Reconstructs $$v$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/VAm.md
+++ b/@WVTransform/detailedDescriptions/VAm.md
@@ -1,3 +1,5 @@
+Reconstructs $$v$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/VAp.md
+++ b/@WVTransform/detailedDescriptions/VAp.md
@@ -1,3 +1,5 @@
+Reconstructs $$v$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/WAm.md
+++ b/@WVTransform/detailedDescriptions/WAm.md
@@ -1,3 +1,5 @@
+Reconstructs $$w$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/WAp.md
+++ b/@WVTransform/detailedDescriptions/WAp.md
@@ -1,3 +1,5 @@
+Reconstructs $$w$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/@WVTransform/detailedDescriptions/j.md
+++ b/@WVTransform/detailedDescriptions/j.md
@@ -1,4 +1,4 @@
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 `j` is an `Nj`-by-1 column vector of dimensionless nonnegative mode numbers. Three-dimensional rigid-lid transforms include the barotropic index `j=0`; wave motions occupy internal modes with `j>0`.
 

--- a/@WVTransform/detailedDescriptions/kAxis.md
+++ b/@WVTransform/detailedDescriptions/kAxis.md
@@ -1,4 +1,4 @@
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 `kAxis` is an `Nx`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dk`.
 

--- a/@WVTransform/detailedDescriptions/lAxis.md
+++ b/@WVTransform/detailedDescriptions/lAxis.md
@@ -1,4 +1,4 @@
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 `lAxis` is an `Ny`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dl`.
 

--- a/@WVTransform/detailedDescriptions/rho_bar.md
+++ b/@WVTransform/detailedDescriptions/rho_bar.md
@@ -1,0 +1,3 @@
+Current horizontally averaged density, `[Nz 1]`, in kg/m³.
+
+`rho_bar` is the horizontal mean of the density represented by the current transform state, including any mean-density-anomaly contribution.

--- a/@WVTransform/detailedDescriptions/rho_nm.md
+++ b/@WVTransform/detailedDescriptions/rho_nm.md
@@ -1,0 +1,3 @@
+Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm` is the statically rearranged no-motion profile diagnosed from the current density field while preserving its density moments.

--- a/@WVTransform/detailedDescriptions/rho_nm0.md
+++ b/@WVTransform/detailedDescriptions/rho_nm0.md
@@ -1,0 +1,3 @@
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm0` is the fixed profile supplied when constructing the transform and sampled on the vertical grid.

--- a/@WVTransform/detailedDescriptions/totalEnergy.md
+++ b/@WVTransform/detailedDescriptions/totalEnergy.md
@@ -1,4 +1,4 @@
- % - Topic: Energetics
+Total energy computed from wave-vortex coefficients.
 
 The horizontally-averaged depth-integrated energy computed from the wave-vortex coefficients
 
@@ -12,4 +12,3 @@ In code,
 App = self.Ap; Amm = self.Am; A00 = self.A0;
 energy = sum(sum(sum( self.Apm_TE_factor.*( App.*conj(App) + Amm.*conj(Amm) ) + self.A0_TE_factor.*( A00.*conj(A00) ) )));
 ```
-

--- a/@WVTransform/detailedDescriptions/totalEnergySpatiallyIntegrated.md
+++ b/@WVTransform/detailedDescriptions/totalEnergySpatiallyIntegrated.md
@@ -1,4 +1,4 @@
- % - Topic: Energetics
+Total energy computed from physical-space fields.
 
 The horizontally-averaged depth-integrated energy computed in the spatial domain is defined as,
 

--- a/@WVTransformBarotropicQG/WVTransformBarotropicQG.m
+++ b/@WVTransformBarotropicQG/WVTransformBarotropicQG.m
@@ -28,8 +28,9 @@ classdef WVTransformBarotropicQG < WVGeometryDoublyPeriodicBarotropic & WVTransf
     % - Topic: Inspect the domain — Spatial grid — Domain dimensions
     % - Topic: Inspect the domain — Spatial grid — Resolution and shape
     % - Topic: Inspect the domain — Spectral grid
-    % - Topic: Inspect the domain — Spectral grid — Axes and spacing
-    % - Topic: Inspect the domain — Spectral grid — Coordinate arrays
+    % - Topic: Inspect the domain — Spectral grid — Compact grid vectors
+    % - Topic: Inspect the domain — Spectral grid — Compact grid arrays
+    % - Topic: Inspect the domain — Spectral grid — Wavenumber spacing
     % - Topic: Inspect the domain — Spectral grid — Horizontal wavenumber geometry
     % - Topic: Inspect the domain — Spectral grid — Resolution and shape
     % - Topic: Inspect the domain — Spectral grid — Equivalent depth and deformation scale
@@ -45,18 +46,27 @@ classdef WVTransformBarotropicQG < WVGeometryDoublyPeriodicBarotropic & WVTransf
     % - Topic: Evaluate physical fields — On the model grid — Vorticity and geostrophic fields
     % - Topic: Evaluate physical fields — At arbitrary positions
     % - Topic: Manage forcing and closures
+    % - Topic: Manage forcing and closures — Configure forcing
+    % - Topic: Manage forcing and closures — Inspect forcing and closures
+    % - Topic: Manage forcing and closures — Summarize forcing
     % - Topic: Analyze the flow
-    % - Topic: Analyze the flow — Energy and summaries
     % - Topic: Analyze the flow — Flow diagnostics
     % - Topic: Analyze the flow — Potential vorticity and enstrophy
     % - Topic: Analyze the flow — Spectra
     % - Topic: Analyze the flow — Spectra — Spectral fields
     % - Topic: Analyze the flow — Spectra — Radial wavenumber
+    % - Topic: Analyze energy
+    % - Topic: Analyze energy — Component energy
+    % - Topic: Analyze energy — Total energy
+    % - Topic: Analyze energy — Energy summaries
     % - Topic: Save transform state
     % - Topic: Convert representations
     % - Topic: Convert representations — Physical fields and coefficients
     % - Topic: Differentiate and integrate fields
     % - Topic: Inspect flow components
+    % - Topic: Inspect flow components — Primary flow components
+    % - Topic: Inspect flow components — Registered and combined components
+    % - Topic: Inspect flow components — Summarize flow components
     % - Topic: Inspect wave-vortex coefficients
     % - Topic: Inspect wave-vortex coefficients — Stored coefficients
     % - Topic: Inspect wave-vortex coefficients — Coefficients at the current time
@@ -68,6 +78,12 @@ classdef WVTransformBarotropicQG < WVGeometryDoublyPeriodicBarotropic & WVTransf
     % - Topic: Get package information
     % - Topic: Projection and reconstruction coefficients
     % - Topic: Geometry and mode indexing
+    % - Topic: Geometry and mode indexing — Mode numbers and validity
+    % - Topic: Geometry and mode indexing — Linear-index conversion
+    % - Topic: Geometry and mode indexing — DFT and WV layout metadata
+    % - Topic: Geometry and mode indexing — Layout conversion
+    % - Topic: Geometry and mode indexing — Masks and Hermitian bookkeeping
+    % - Topic: Geometry and mode indexing — Additional geometry utilities
     % - Topic: Spectral transforms and operators
     % - Topic: Nonlinear flux and forcing internals
     % - Topic: Persistence internals

--- a/@WVTransformBoussinesq/WVTransformBoussinesq.m
+++ b/@WVTransformBoussinesq/WVTransformBoussinesq.m
@@ -30,11 +30,13 @@ classdef WVTransformBoussinesq < WVGeometryDoublyPeriodicStratifiedBoussinesq & 
     % - Topic: Inspect the domain — Spatial grid — Resolution and shape
     % - Topic: Inspect the domain — Spatial grid — Quadrature and integration
     % - Topic: Inspect the domain — Spectral grid
-    % - Topic: Inspect the domain — Spectral grid — Axes and spacing
-    % - Topic: Inspect the domain — Spectral grid — Coordinate arrays
+    % - Topic: Inspect the domain — Spectral grid — Compact grid vectors
+    % - Topic: Inspect the domain — Spectral grid — Compact grid arrays
+    % - Topic: Inspect the domain — Spectral grid — Wavenumber spacing
     % - Topic: Inspect the domain — Spectral grid — Horizontal wavenumber geometry
     % - Topic: Inspect the domain — Spectral grid — Resolution and shape
     % - Topic: Inspect the domain — Spectral grid — Vertical modes and scaling
+    % - Topic: Inspect the domain — Spectral grid — Vertical-mode transformation matrices
     % - Topic: Inspect the domain — Transform configuration
     % - Topic: Initialize the flow
     % - Topic: Initialize the flow — General initialization
@@ -54,8 +56,10 @@ classdef WVTransformBoussinesq < WVGeometryDoublyPeriodicStratifiedBoussinesq & 
     % - Topic: Evaluate physical fields — At arbitrary positions
     % - Topic: Evaluate physical fields — Isopycnal utilities
     % - Topic: Manage forcing and closures
+    % - Topic: Manage forcing and closures — Configure forcing
+    % - Topic: Manage forcing and closures — Inspect forcing and closures
+    % - Topic: Manage forcing and closures — Summarize forcing
     % - Topic: Analyze the flow
-    % - Topic: Analyze the flow — Energy and summaries
     % - Topic: Analyze the flow — Flow diagnostics
     % - Topic: Analyze the flow — Density validity
     % - Topic: Analyze the flow — Potential vorticity and enstrophy
@@ -63,11 +67,18 @@ classdef WVTransformBoussinesq < WVGeometryDoublyPeriodicStratifiedBoussinesq & 
     % - Topic: Analyze the flow — Spectra — Spectral fields
     % - Topic: Analyze the flow — Spectra — Radial wavenumber
     % - Topic: Analyze the flow — Spectra — Frequency
+    % - Topic: Analyze energy
+    % - Topic: Analyze energy — Component energy
+    % - Topic: Analyze energy — Total energy
+    % - Topic: Analyze energy — Energy summaries
     % - Topic: Save transform state
     % - Topic: Convert representations
     % - Topic: Convert representations — Physical fields and coefficients
     % - Topic: Differentiate and integrate fields
     % - Topic: Inspect flow components
+    % - Topic: Inspect flow components — Primary flow components
+    % - Topic: Inspect flow components — Registered and combined components
+    % - Topic: Inspect flow components — Summarize flow components
     % - Topic: Inspect wave-vortex coefficients
     % - Topic: Inspect wave-vortex coefficients — Stored coefficients
     % - Topic: Inspect wave-vortex coefficients — Coefficients at the current time
@@ -79,6 +90,12 @@ classdef WVTransformBoussinesq < WVGeometryDoublyPeriodicStratifiedBoussinesq & 
     % - Topic: Get package information
     % - Topic: Projection and reconstruction coefficients
     % - Topic: Geometry and mode indexing
+    % - Topic: Geometry and mode indexing — Mode numbers and validity
+    % - Topic: Geometry and mode indexing — Linear-index conversion
+    % - Topic: Geometry and mode indexing — DFT and WV layout metadata
+    % - Topic: Geometry and mode indexing — Layout conversion
+    % - Topic: Geometry and mode indexing — Masks and Hermitian bookkeeping
+    % - Topic: Geometry and mode indexing — Additional geometry utilities
     % - Topic: Spectral transforms and operators
     % - Topic: Nonlinear flux and forcing internals
     % - Topic: Persistence internals

--- a/@WVTransformConstantStratification/WVTransformConstantStratification.m
+++ b/@WVTransformConstantStratification/WVTransformConstantStratification.m
@@ -29,11 +29,13 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
     % - Topic: Inspect the domain — Spatial grid — Resolution and shape
     % - Topic: Inspect the domain — Spatial grid — Quadrature and integration
     % - Topic: Inspect the domain — Spectral grid
-    % - Topic: Inspect the domain — Spectral grid — Axes and spacing
-    % - Topic: Inspect the domain — Spectral grid — Coordinate arrays
+    % - Topic: Inspect the domain — Spectral grid — Compact grid vectors
+    % - Topic: Inspect the domain — Spectral grid — Compact grid arrays
+    % - Topic: Inspect the domain — Spectral grid — Wavenumber spacing
     % - Topic: Inspect the domain — Spectral grid — Horizontal wavenumber geometry
     % - Topic: Inspect the domain — Spectral grid — Resolution and shape
     % - Topic: Inspect the domain — Spectral grid — Vertical modes and scaling
+    % - Topic: Inspect the domain — Spectral grid — Vertical-mode transformation matrices
     % - Topic: Inspect the domain — Transform configuration
     % - Topic: Initialize the flow
     % - Topic: Initialize the flow — General initialization
@@ -53,8 +55,10 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
     % - Topic: Evaluate physical fields — At arbitrary positions
     % - Topic: Evaluate physical fields — Isopycnal utilities
     % - Topic: Manage forcing and closures
+    % - Topic: Manage forcing and closures — Configure forcing
+    % - Topic: Manage forcing and closures — Inspect forcing and closures
+    % - Topic: Manage forcing and closures — Summarize forcing
     % - Topic: Analyze the flow
-    % - Topic: Analyze the flow — Energy and summaries
     % - Topic: Analyze the flow — Flow diagnostics
     % - Topic: Analyze the flow — Density validity
     % - Topic: Analyze the flow — Potential vorticity and enstrophy
@@ -62,11 +66,18 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
     % - Topic: Analyze the flow — Spectra — Spectral fields
     % - Topic: Analyze the flow — Spectra — Radial wavenumber
     % - Topic: Analyze the flow — Spectra — Frequency
+    % - Topic: Analyze energy
+    % - Topic: Analyze energy — Component energy
+    % - Topic: Analyze energy — Total energy
+    % - Topic: Analyze energy — Energy summaries
     % - Topic: Save transform state
     % - Topic: Convert representations
     % - Topic: Convert representations — Physical fields and coefficients
     % - Topic: Differentiate and integrate fields
     % - Topic: Inspect flow components
+    % - Topic: Inspect flow components — Primary flow components
+    % - Topic: Inspect flow components — Registered and combined components
+    % - Topic: Inspect flow components — Summarize flow components
     % - Topic: Inspect wave-vortex coefficients
     % - Topic: Inspect wave-vortex coefficients — Stored coefficients
     % - Topic: Inspect wave-vortex coefficients — Coefficients at the current time
@@ -78,6 +89,12 @@ classdef WVTransformConstantStratification < WVGeometryDoublyPeriodicStratifiedC
     % - Topic: Get package information
     % - Topic: Projection and reconstruction coefficients
     % - Topic: Geometry and mode indexing
+    % - Topic: Geometry and mode indexing — Mode numbers and validity
+    % - Topic: Geometry and mode indexing — Linear-index conversion
+    % - Topic: Geometry and mode indexing — DFT and WV layout metadata
+    % - Topic: Geometry and mode indexing — Layout conversion
+    % - Topic: Geometry and mode indexing — Masks and Hermitian bookkeeping
+    % - Topic: Geometry and mode indexing — Additional geometry utilities
     % - Topic: Spectral transforms and operators
     % - Topic: Nonlinear flux and forcing internals
     % - Topic: Persistence internals

--- a/@WVTransformHydrostatic/WVTransformHydrostatic.m
+++ b/@WVTransformHydrostatic/WVTransformHydrostatic.m
@@ -30,11 +30,13 @@ classdef WVTransformHydrostatic < WVGeometryDoublyPeriodicStratified & WVTransfo
     % - Topic: Inspect the domain — Spatial grid — Resolution and shape
     % - Topic: Inspect the domain — Spatial grid — Quadrature and integration
     % - Topic: Inspect the domain — Spectral grid
-    % - Topic: Inspect the domain — Spectral grid — Axes and spacing
-    % - Topic: Inspect the domain — Spectral grid — Coordinate arrays
+    % - Topic: Inspect the domain — Spectral grid — Compact grid vectors
+    % - Topic: Inspect the domain — Spectral grid — Compact grid arrays
+    % - Topic: Inspect the domain — Spectral grid — Wavenumber spacing
     % - Topic: Inspect the domain — Spectral grid — Horizontal wavenumber geometry
     % - Topic: Inspect the domain — Spectral grid — Resolution and shape
     % - Topic: Inspect the domain — Spectral grid — Vertical modes and scaling
+    % - Topic: Inspect the domain — Spectral grid — Vertical-mode transformation matrices
     % - Topic: Inspect the domain — Transform configuration
     % - Topic: Initialize the flow
     % - Topic: Initialize the flow — General initialization
@@ -54,8 +56,10 @@ classdef WVTransformHydrostatic < WVGeometryDoublyPeriodicStratified & WVTransfo
     % - Topic: Evaluate physical fields — At arbitrary positions
     % - Topic: Evaluate physical fields — Isopycnal utilities
     % - Topic: Manage forcing and closures
+    % - Topic: Manage forcing and closures — Configure forcing
+    % - Topic: Manage forcing and closures — Inspect forcing and closures
+    % - Topic: Manage forcing and closures — Summarize forcing
     % - Topic: Analyze the flow
-    % - Topic: Analyze the flow — Energy and summaries
     % - Topic: Analyze the flow — Flow diagnostics
     % - Topic: Analyze the flow — Density validity
     % - Topic: Analyze the flow — Potential vorticity and enstrophy
@@ -63,11 +67,18 @@ classdef WVTransformHydrostatic < WVGeometryDoublyPeriodicStratified & WVTransfo
     % - Topic: Analyze the flow — Spectra — Spectral fields
     % - Topic: Analyze the flow — Spectra — Radial wavenumber
     % - Topic: Analyze the flow — Spectra — Frequency
+    % - Topic: Analyze energy
+    % - Topic: Analyze energy — Component energy
+    % - Topic: Analyze energy — Total energy
+    % - Topic: Analyze energy — Energy summaries
     % - Topic: Save transform state
     % - Topic: Convert representations
     % - Topic: Convert representations — Physical fields and coefficients
     % - Topic: Differentiate and integrate fields
     % - Topic: Inspect flow components
+    % - Topic: Inspect flow components — Primary flow components
+    % - Topic: Inspect flow components — Registered and combined components
+    % - Topic: Inspect flow components — Summarize flow components
     % - Topic: Inspect wave-vortex coefficients
     % - Topic: Inspect wave-vortex coefficients — Stored coefficients
     % - Topic: Inspect wave-vortex coefficients — Coefficients at the current time
@@ -79,6 +90,12 @@ classdef WVTransformHydrostatic < WVGeometryDoublyPeriodicStratified & WVTransfo
     % - Topic: Get package information
     % - Topic: Projection and reconstruction coefficients
     % - Topic: Geometry and mode indexing
+    % - Topic: Geometry and mode indexing — Mode numbers and validity
+    % - Topic: Geometry and mode indexing — Linear-index conversion
+    % - Topic: Geometry and mode indexing — DFT and WV layout metadata
+    % - Topic: Geometry and mode indexing — Layout conversion
+    % - Topic: Geometry and mode indexing — Masks and Hermitian bookkeeping
+    % - Topic: Geometry and mode indexing — Additional geometry utilities
     % - Topic: Spectral transforms and operators
     % - Topic: Nonlinear flux and forcing internals
     % - Topic: Persistence internals

--- a/@WVTransformStratifiedQG/WVTransformStratifiedQG.m
+++ b/@WVTransformStratifiedQG/WVTransformStratifiedQG.m
@@ -29,11 +29,13 @@ classdef WVTransformStratifiedQG < WVGeometryDoublyPeriodicStratified & WVTransf
     % - Topic: Inspect the domain — Spatial grid — Resolution and shape
     % - Topic: Inspect the domain — Spatial grid — Quadrature and integration
     % - Topic: Inspect the domain — Spectral grid
-    % - Topic: Inspect the domain — Spectral grid — Axes and spacing
-    % - Topic: Inspect the domain — Spectral grid — Coordinate arrays
+    % - Topic: Inspect the domain — Spectral grid — Compact grid vectors
+    % - Topic: Inspect the domain — Spectral grid — Compact grid arrays
+    % - Topic: Inspect the domain — Spectral grid — Wavenumber spacing
     % - Topic: Inspect the domain — Spectral grid — Horizontal wavenumber geometry
     % - Topic: Inspect the domain — Spectral grid — Resolution and shape
     % - Topic: Inspect the domain — Spectral grid — Vertical modes and scaling
+    % - Topic: Inspect the domain — Spectral grid — Vertical-mode transformation matrices
     % - Topic: Inspect the domain — Transform configuration
     % - Topic: Initialize the flow
     % - Topic: Initialize the flow — General initialization
@@ -48,8 +50,10 @@ classdef WVTransformStratifiedQG < WVGeometryDoublyPeriodicStratified & WVTransf
     % - Topic: Evaluate physical fields — At arbitrary positions
     % - Topic: Evaluate physical fields — Isopycnal utilities
     % - Topic: Manage forcing and closures
+    % - Topic: Manage forcing and closures — Configure forcing
+    % - Topic: Manage forcing and closures — Inspect forcing and closures
+    % - Topic: Manage forcing and closures — Summarize forcing
     % - Topic: Analyze the flow
-    % - Topic: Analyze the flow — Energy and summaries
     % - Topic: Analyze the flow — Flow diagnostics
     % - Topic: Analyze the flow — Density validity
     % - Topic: Analyze the flow — Potential vorticity and enstrophy
@@ -57,11 +61,18 @@ classdef WVTransformStratifiedQG < WVGeometryDoublyPeriodicStratified & WVTransf
     % - Topic: Analyze the flow — Spectra — Spectral fields
     % - Topic: Analyze the flow — Spectra — Radial wavenumber
     % - Topic: Analyze the flow — Spectra — Frequency
+    % - Topic: Analyze energy
+    % - Topic: Analyze energy — Component energy
+    % - Topic: Analyze energy — Total energy
+    % - Topic: Analyze energy — Energy summaries
     % - Topic: Save transform state
     % - Topic: Convert representations
     % - Topic: Convert representations — Physical fields and coefficients
     % - Topic: Differentiate and integrate fields
     % - Topic: Inspect flow components
+    % - Topic: Inspect flow components — Primary flow components
+    % - Topic: Inspect flow components — Registered and combined components
+    % - Topic: Inspect flow components — Summarize flow components
     % - Topic: Inspect wave-vortex coefficients
     % - Topic: Inspect wave-vortex coefficients — Stored coefficients
     % - Topic: Inspect wave-vortex coefficients — Coefficients at the current time
@@ -73,6 +84,12 @@ classdef WVTransformStratifiedQG < WVGeometryDoublyPeriodicStratified & WVTransf
     % - Topic: Get package information
     % - Topic: Projection and reconstruction coefficients
     % - Topic: Geometry and mode indexing
+    % - Topic: Geometry and mode indexing — Mode numbers and validity
+    % - Topic: Geometry and mode indexing — Linear-index conversion
+    % - Topic: Geometry and mode indexing — DFT and WV layout metadata
+    % - Topic: Geometry and mode indexing — Layout conversion
+    % - Topic: Geometry and mode indexing — Masks and Hermitian bookkeeping
+    % - Topic: Geometry and mode indexing — Additional geometry utilities
     % - Topic: Spectral transforms and operators
     % - Topic: Nonlinear flux and forcing internals
     % - Topic: Persistence internals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Updated Fourier-at-position reconstruction to use compact `WVFourierStorageLayout` mappings.
 - Removed obsolete pseudo-radial and frequency-binning APIs whose maintained equivalents live in `WVDiagnostics`.
 - Added backend-neutral transform-storage accounting and fresh-process RSS benchmarks.
-- Completed and reorganized transform and forcing documentation, corrected API metadata, and improved nonlinear-integration examples.
+- Completed and reorganized transform and forcing documentation, clarified spectral grids, energy, forcing, flow components, geometry indexing, density profiles, and projection/reconstruction summaries, corrected API metadata, and improved nonlinear-integration examples.
 - Verified and documented the mathematical contracts for pseudo-topographic wave generation, beta-plane QGPV advection, and vertical diffusivity, and restored the variable-stratification mean-density-anomaly source disabled by an obsolete class-name check.
 
 ## [4.2.1] - 2026-08-09

--- a/Documentation/WebsiteDocumentation/classes/forcing/closures/index.md
+++ b/Documentation/WebsiteDocumentation/classes/forcing/closures/index.md
@@ -12,14 +12,14 @@ permalink: /classes/forcing/closures
 
 Closures are `WVForcing` objects that remove variance near unresolved scales. Nonlinear integrations normally include a closure; adaptive damping is the usual starting point.
 
-| Class | Purpose | Supported transforms | Principal controls |
-| --- | --- | --- | --- |
-| [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/) | Adapt spectral damping to the instantaneous flow and effective resolution | All transform families | Computed automatically from the flow |
-| [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/) | Apply horizontal Laplacian viscosity and diffusivity | Wave-bearing three-dimensional transforms | Viscosity `nu` and diffusivity `kappa` |
-| [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) | Apply vertical Laplacian viscosity and diffusivity | Wave-bearing three-dimensional transforms | Viscosity `nu` and diffusivity `kappa` |
-| [`WVVerticalDiffusivity`](/classes/forcing/closures/wvverticaldiffusivity/) | Diffuse displacement vertically and apply its induced QGPV tendency | Three-dimensional wave and stratified-QG transforms | `kappa_z`; optional mean-density-anomaly source |
-| [`WVThermalDamping`](/classes/forcing/closures/wvthermaldamping/) | Apply the current QG thermal-damping formulation | Stratified and barotropic QG transforms | Rate `alpha` |
-| [`WVAntialiasing`](/classes/forcing/closures/wvantialiasing/) | Apply antialias filtering explicitly for diagnostics | All transform families constructed without transform-level antialiasing | Retained vertical-mode count `Nj` |
+| Class | Purpose |
+| --- | --- |
+| [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/) | Adapt spectral damping to the instantaneous flow and effective resolution |
+| [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/) | Apply horizontal Laplacian viscosity and diffusivity |
+| [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) | Apply vertical Laplacian viscosity and diffusivity |
+| [`WVVerticalDiffusivity`](/classes/forcing/closures/wvverticaldiffusivity/) | Diffuse displacement vertically and apply its induced QGPV tendency |
+| [`WVThermalDamping`](/classes/forcing/closures/wvthermaldamping/) | Apply the current QG thermal-damping formulation |
+| [`WVAntialiasing`](/classes/forcing/closures/wvantialiasing/) | Apply antialias filtering explicitly for diagnostics |
 
 Here *viscosity* $$\nu$$ acts on momentum, *diffusivity* $$\kappa$$ acts on the thermodynamic field, and *damping* is the broader term for small-scale variance removal. Transform-level antialiasing remains the efficient default; explicit `WVAntialiasing` is intended for diagnosing its effect.
 

--- a/Documentation/WebsiteDocumentation/classes/forcing/index.md
+++ b/Documentation/WebsiteDocumentation/classes/forcing/index.md
@@ -14,11 +14,11 @@ Forcing objects add physical-space tendencies, spectral tendencies, or direct co
 
 All forcing classes derive from [`WVForcing`](/classes/forcing/wvforcing/). New transforms contain nonlinear advection by default; other forcing and [closure](/classes/forcing/closures/) objects are added explicitly.
 
-| Class | Purpose | Supported transforms | Principal controls |
-| --- | --- | --- | --- |
-| [`WVNonlinearAdvection`](/classes/forcing/wvnonlinearadvection/) | Nonlinear momentum, displacement, and QGPV advection | All transform families | None; added by default |
-| [`WVBottomFrictionLinear`](/classes/forcing/wvbottomfrictionlinear/) | Linear drag at the bottom boundary | All transform families | Drag rate `r` |
-| [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/) | Quadratic drag at the bottom boundary | All transform families | Drag coefficient `Cd` |
-| [`WVFixedAmplitudeForcing`](/classes/forcing/wvfixedamplitudeforcing/) | Hold selected `Ap`, `Am`, or `A0` coefficients fixed | All transform families | Registry `name`, selected indices, and target coefficients |
-| [`WVBetaPlanePVAdvection`](/classes/forcing/wvbetaplanepvadvection/) | Add the $$-\beta v_g$$ tendency to balanced QGPV | QG transforms directly; balanced `A0` in wave-bearing transforms | No user parameter |
-| [`WVPseudoTopographicWaveGeneration`](/classes/forcing/wvpseudotopographicwavegeneration/) | Project prescribed bottom velocity onto internal-wave modes | Wave-bearing three-dimensional transforms | Topography, velocity amplitude, tidal frequency, ramp, and spectral bounds |
+| Class | Purpose |
+| --- | --- |
+| [`WVNonlinearAdvection`](/classes/forcing/wvnonlinearadvection/) | Nonlinear momentum, displacement, and QGPV advection |
+| [`WVBottomFrictionLinear`](/classes/forcing/wvbottomfrictionlinear/) | Linear drag at the bottom boundary |
+| [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/) | Quadratic drag at the bottom boundary |
+| [`WVFixedAmplitudeForcing`](/classes/forcing/wvfixedamplitudeforcing/) | Hold selected `Ap`, `Am`, or `A0` coefficients fixed |
+| [`WVBetaPlanePVAdvection`](/classes/forcing/wvbetaplanepvadvection/) | Add the $$-\beta v_g$$ tendency to balanced QGPV |
+| [`WVPseudoTopographicWaveGeneration`](/classes/forcing/wvpseudotopographicwavegeneration/) | Project prescribed bottom velocity onto internal-wave modes |

--- a/Forcing/WVFixedAmplitudeForcing.m
+++ b/Forcing/WVFixedAmplitudeForcing.m
@@ -1,8 +1,7 @@
 classdef WVFixedAmplitudeForcing < WVForcing
     % Hold selected wave-vortex coefficients at prescribed amplitudes.
     %
-    % The forcing maintains selected wave or geostrophic coefficients while
-    % recording the tendency that must be cancelled to maintain them.
+    % This forcing keeps selected wave-vortex coefficients at prescribed amplitudes while those modes continue to participate in nonlinear interactions.
     %
     % As a simple example, one can set an internal wave mode with amplitude 1 cm/s, and that mode will continue to oscillate and maintain its amplitude. The wave will participate in all the nonlinear dynamics, but its amplitude will be maintained/restored at each time step.
     %

--- a/UnitTests/TestCoreAPIDocumentation.m
+++ b/UnitTests/TestCoreAPIDocumentation.m
@@ -166,6 +166,7 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
                 "Evaluate physical fields"
                 "Manage forcing and closures"
                 "Analyze the flow"
+                "Analyze energy"
                 "Save transform state"
                 "Convert representations"
                 "Differentiate and integrate fields"
@@ -197,17 +198,112 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
             testCase.verifyTextOrder(domain,["[`x`]" "[`y`]" "[`z`]"]);
             testCase.verifyTextOrder(domain,["[`X`]" "[`Y`]" "[`Z`]" "[`xyzGrid`]"]);
             testCase.verifyTextOrder(domain,["[`z_int`]" "[`volumeIntegral`]"]);
-            testCase.verifyTextOrder(domain,["[`kAxis`]" "[`lAxis`]" "[`j`]" "[`dk`]" "[`dl`]"]);
-            testCase.verifyTextOrder(domain,["[`k`]" "[`l`]" "[`K`]" "[`L`]" "[`J`]" "[`kljGrid`]"]);
+            testCase.verifyTextOrder(domain,["[`k`]" "[`l`]" "[`j`]"]);
+            testCase.verifyTextOrder(domain,["[`K`]" "[`L`]" "[`J`]" "[`kljGrid`]"]);
+            testCase.verifyTextOrder(domain,["[`dk`]" "[`dl`]"]);
             testCase.verifyTextOrder(domain,["[`Kh`]" "[`K2`]"]);
+            testCase.verifyTextOrder(domain,["[`FMatrix`]" "[`FinvMatrix`]" "[`GMatrix`]" "[`GinvMatrix`]"]);
+            testCase.verifyFalse(any(contains(domain,["[`kAxis`]" "[`lAxis`]" "[`transformToKLAxes`]" ])));
             for name = ["f" "g" "dLnN2" "rho0" "planetaryRadius" "rotationRate"]
                 testCase.verifySubstring(domain,"[`" + name + "`]");
             end
 
-            analysis = extractBetween(page,"+ Analyze the flow","+ Save transform state");
+            barotropic = testCase.generatedTransformPage("wvtransformbarotropicqg","index.md");
+            barotropicDomain = extractBetween(barotropic,"+ Inspect the domain","+ Initialize the flow");
+            testCase.verifyTextOrder(barotropicDomain,["[`k`]" "[`l`]"]);
+            testCase.verifyTextOrder(barotropicDomain,["[`K`]" "[`L`]" "[`klGrid`]"]);
+
+            analysis = extractBetween(page,"+ Analyze the flow","+ Analyze energy");
+            testCase.verifyTextOrder(analysis,["[`kAxis`]" "[`lAxis`]" "[`transformToKLAxes`]"]);
             testCase.verifyTextOrder(analysis,["[`kRadial`]" "[`transformToRadialWavenumber`]"]);
             testCase.verifyFalse(contains(analysis,"Pseudo-radial wavenumber"));
             testCase.verifyFalse(contains(analysis,"transformToOmegaAxis"));
+        end
+
+        function transformTopicsGroupForcingEnergyAndComponents(testCase)
+            page = testCase.generatedTransformPage("wvtransformhydrostatic","index.md");
+            forcing = extractBetween(page,"+ Manage forcing and closures","+ Analyze the flow");
+            testCase.verifyTextOrder(forcing,["Configure forcing" "Inspect forcing and closures" "Summarize forcing"]);
+            testCase.verifySubstring(forcing,"[`addForcing`]");
+            testCase.verifySubstring(forcing,"[`forcingNames`]");
+            testCase.verifySubstring(forcing,"[`summarizeForcing`]");
+
+            energy = extractBetween(page,"+ Analyze energy","+ Save transform state");
+            testCase.verifyTextOrder(energy,["Component energy" "Total energy" "Energy summaries"]);
+            testCase.verifySubstring(energy,"[`totalEnergyOfFlowComponent`]");
+            testCase.verifySubstring(energy,"[`totalEnergy`]");
+            testCase.verifySubstring(energy,"[`summarizeEnergyContent`]");
+
+            components = extractBetween(page,"+ Inspect flow components","+ Inspect wave-vortex coefficients");
+            testCase.verifyTextOrder(components,["Primary flow components" "Registered and combined components" "Summarize flow components"]);
+            testCase.verifyTextOrder(components,["[`waveComponent`]" "[`inertialComponent`]" "[`geostrophicComponent`]" "[`mdaComponent`]"]);
+
+            for folder = ["wvtransformstratifiedqg" "wvtransformbarotropicqg"]
+                qgPage = testCase.generatedTransformPage(folder,"index.md");
+                qgComponents = extractBetween(qgPage,"+ Inspect flow components","+ Inspect wave-vortex coefficients");
+                testCase.verifySubstring(qgComponents,"[`geostrophicComponent`]");
+                testCase.verifyFalse(any(contains(qgComponents,["[`waveComponent`]" "[`inertialComponent`]" "[`mdaComponent`]" ])));
+            end
+        end
+
+        function transformDeveloperGeometryHasIntentionalSubtopics(testCase)
+            page = testCase.generatedTransformPage("wvtransformhydrostatic","index.md");
+            developer = extractAfter(page,"## Developer Topics");
+            geometry = extractBetween(developer,"+ Geometry and mode indexing","+ Spectral transforms and operators");
+            expectedSubtopics = [
+                "Mode numbers and validity"
+                "Linear-index conversion"
+                "DFT and WV layout metadata"
+                "Layout conversion"
+                "Masks and Hermitian bookkeeping"
+                ];
+            testCase.verifyTextOrder(geometry,expectedSubtopics);
+
+            movedMembers = ["Nk_dft" "Nl_dft" "k_dft" "l_dft" "kl" ...
+                "dftConjugateIndices2D" "dftPrimaryIndices2D" ...
+                "indicesOfFourierConjugates" "shouldExcludeConjugates" ...
+                "shouldExcludeNyquist" "isHermitian" "setConjugateToUnity"];
+            for name = movedMembers
+                testCase.verifySubstring(geometry,"[`" + name + "`]");
+            end
+
+            classInternals = extractAfter(developer,"+ Class internals");
+            for name = movedMembers
+                testCase.verifyFalse(contains(classInternals,"[`" + name + "`]"));
+            end
+        end
+
+        function transformSummariesAreConciseAndSpecific(testCase)
+            page = testCase.generatedTransformPage("wvtransformhydrostatic","index.md");
+            expectedSummaries = {
+                "Ap", "Positive-frequency wave–vortex coefficient array."
+                "Am", "Negative-frequency wave–vortex coefficient array."
+                "A0", "Zero-frequency wave–vortex coefficient array."
+                "k", "Compact `Nkl`-by-1 x-wavenumber vector in rad/m."
+                "l", "Compact `Nkl`-by-1 y-wavenumber vector in rad/m."
+                "j", "Dimensionless `Nj`-by-1 vertical-mode index vector."
+                "kAxis", "Centered `Nx`-by-1 x-wavenumber axis in rad/m."
+                "lAxis", "Centered `Ny`-by-1 y-wavenumber axis in rad/m."
+                "rho_bar", "Current horizontally averaged density, `[Nz 1]`, in kg/m³."
+                "rho_nm", "Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³."
+                "rho_nm0", "Reference no-motion density profile, `[Nz 1]`, in kg/m³."
+                "FMatrix", "Projects F-grid values onto vertical modes with shape `[Nj Nz]`."
+                "FinvMatrix", "Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`."
+                "GMatrix", "Projects G-grid values onto vertical modes with shape `[Nj Nz]`."
+                "GinvMatrix", "Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`."
+                };
+            for iExpectation = 1:size(expectedSummaries,1)
+                testCase.verifyEqual(testCase.memberSummary(page,expectedSummaries{iExpectation,1}),expectedSummaries{iExpectation,2});
+            end
+
+            coefficientNames = ["A0N" "A0U" "A0V" "A0Z" "ApmD" "ApmN" ...
+                "NA0" "NAm" "NAp" "PA0" "UA0" "UAm" "UAp" ...
+                "VA0" "VAm" "VAp" "WAm" "WAp"];
+            for name = coefficientNames
+                summary = testCase.memberSummary(page,name);
+                testCase.verifyTrue(startsWith(summary,["Projects" "Reconstructs"]),name + " has an inconsistent summary: " + summary);
+                testCase.verifyLessThanOrEqual(strlength(summary),80,name + " has an overly long topic summary.");
+            end
         end
 
         function staleTransformLevelSpectralBinningIsAbsent(testCase)
@@ -768,6 +864,13 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
             topicBlock = extractBetween(page,"## Topics","## Developer Topics");
             tokens = regexp(topicBlock,'(?m)^\+ (?<name>[^\r\n]+)$','names');
             topics = string({tokens.name})';
+        end
+
+        function summary = memberSummary(testCase,page,name)
+            lines = splitlines(page);
+            candidate = lines(startsWith(strtrim(lines),"+ [`" + name + "`]"));
+            testCase.assertNumElements(candidate,1,"Expected exactly one topic-list entry for " + name + ".");
+            summary = strtrim(regexprep(candidate,'^.*\)\s*',''));
         end
 
         function verifyTextOrder(testCase,text,tokens)

--- a/UnitTests/TestCoreAPIDocumentation.m
+++ b/UnitTests/TestCoreAPIDocumentation.m
@@ -287,10 +287,10 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
                 "rho_bar", "Current horizontally averaged density, `[Nz 1]`, in kg/m³."
                 "rho_nm", "Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³."
                 "rho_nm0", "Reference no-motion density profile, `[Nz 1]`, in kg/m³."
-                "FMatrix", "Projects F-grid values onto vertical modes with shape `[Nj Nz]`."
-                "FinvMatrix", "Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`."
-                "GMatrix", "Projects G-grid values onto vertical modes with shape `[Nj Nz]`."
-                "GinvMatrix", "Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`."
+                "FMatrix", "Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`."
+                "FinvMatrix", "Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`."
+                "GMatrix", "Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`."
+                "GinvMatrix", "Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`."
                 };
             for iExpectation = 1:size(expectedSummaries,1)
                 testCase.verifyEqual(testCase.memberSummary(page,expectedSummaries{iExpectation,1}),expectedSummaries{iExpectation,2});
@@ -671,6 +671,12 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
             for className = closureClasses
                 testCase.verifyEqual(count(closureLanding,"[`" + className + "`]"),1,className);
             end
+            testCase.verifySubstring(forcingLanding,"| Class | Purpose |");
+            testCase.verifySubstring(closureLanding,"| Class | Purpose |");
+            testCase.verifyFalse(contains(forcingLanding,"Supported transforms"));
+            testCase.verifyFalse(contains(forcingLanding,"Principal controls"));
+            testCase.verifyFalse(contains(closureLanding,"Supported transforms"));
+            testCase.verifyFalse(contains(closureLanding,"Principal controls"));
             testCase.verifySubstring(closureLanding,"Transform-level antialiasing remains the efficient default");
             sidecarFolder = fullfile(testCase.repositoryRoot,"Forcing","detailedDescriptions");
             remainingSidecars = dir(fullfile(sidecarFolder,"*.md"));
@@ -698,6 +704,8 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
                     "wvt.addForcing(WVBottomFrictionQuadratic(wvt,Cd=0.001))"
                     ]
                 "wvfixedamplitudeforcing", [
+                    "keeps selected wave-vortex coefficients at prescribed amplitudes"
+                    "participate in nonlinear interactions"
                     "participate in all the nonlinear dynamics"
                     "spectral-amplitude forcing"
                     "prescribed coefficient values"
@@ -726,6 +734,8 @@ classdef TestCoreAPIDocumentation < matlab.unittest.TestCase
                 expectedLink = "](/classes/forcing/" + classFolder + "/)";
                 testCase.verifySubstring(constructor,expectedLink,classFolder + " constructor does not link to its overview.");
             end
+            fixedAmplitude = testCase.generatedForcingPage(fullfile("wvfixedamplitudeforcing","index.md"));
+            testCase.verifyFalse(contains(fixedAmplitude,"recording the tendency that must be cancelled"));
         end
 
         function coefficientClaimsMatchTransformState(testCase)

--- a/docs/classes/forcing/closures/index.md
+++ b/docs/classes/forcing/closures/index.md
@@ -12,14 +12,14 @@ permalink: /classes/forcing/closures
 
 Closures are `WVForcing` objects that remove variance near unresolved scales. Nonlinear integrations normally include a closure; adaptive damping is the usual starting point.
 
-| Class | Purpose | Supported transforms | Principal controls |
-| --- | --- | --- | --- |
-| [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/) | Adapt spectral damping to the instantaneous flow and effective resolution | All transform families | Computed automatically from the flow |
-| [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/) | Apply horizontal Laplacian viscosity and diffusivity | Wave-bearing three-dimensional transforms | Viscosity `nu` and diffusivity `kappa` |
-| [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) | Apply vertical Laplacian viscosity and diffusivity | Wave-bearing three-dimensional transforms | Viscosity `nu` and diffusivity `kappa` |
-| [`WVVerticalDiffusivity`](/classes/forcing/closures/wvverticaldiffusivity/) | Diffuse displacement vertically and apply its induced QGPV tendency | Three-dimensional wave and stratified-QG transforms | `kappa_z`; optional mean-density-anomaly source |
-| [`WVThermalDamping`](/classes/forcing/closures/wvthermaldamping/) | Apply the current QG thermal-damping formulation | Stratified and barotropic QG transforms | Rate `alpha` |
-| [`WVAntialiasing`](/classes/forcing/closures/wvantialiasing/) | Apply antialias filtering explicitly for diagnostics | All transform families constructed without transform-level antialiasing | Retained vertical-mode count `Nj` |
+| Class | Purpose |
+| --- | --- |
+| [`WVAdaptiveDamping`](/classes/forcing/closures/wvadaptivedamping/) | Adapt spectral damping to the instantaneous flow and effective resolution |
+| [`WVHorizontalDamping`](/classes/forcing/closures/wvhorizontaldamping/) | Apply horizontal Laplacian viscosity and diffusivity |
+| [`WVVerticalDamping`](/classes/forcing/closures/wvverticaldamping/) | Apply vertical Laplacian viscosity and diffusivity |
+| [`WVVerticalDiffusivity`](/classes/forcing/closures/wvverticaldiffusivity/) | Diffuse displacement vertically and apply its induced QGPV tendency |
+| [`WVThermalDamping`](/classes/forcing/closures/wvthermaldamping/) | Apply the current QG thermal-damping formulation |
+| [`WVAntialiasing`](/classes/forcing/closures/wvantialiasing/) | Apply antialias filtering explicitly for diagnostics |
 
 Here *viscosity* $$\nu$$ acts on momentum, *diffusivity* $$\kappa$$ acts on the thermodynamic field, and *damping* is the broader term for small-scale variance removal. Transform-level antialiasing remains the efficient default; explicit `WVAntialiasing` is intended for diagnosing its effect.
 

--- a/docs/classes/forcing/index.md
+++ b/docs/classes/forcing/index.md
@@ -14,11 +14,11 @@ Forcing objects add physical-space tendencies, spectral tendencies, or direct co
 
 All forcing classes derive from [`WVForcing`](/classes/forcing/wvforcing/). New transforms contain nonlinear advection by default; other forcing and [closure](/classes/forcing/closures/) objects are added explicitly.
 
-| Class | Purpose | Supported transforms | Principal controls |
-| --- | --- | --- | --- |
-| [`WVNonlinearAdvection`](/classes/forcing/wvnonlinearadvection/) | Nonlinear momentum, displacement, and QGPV advection | All transform families | None; added by default |
-| [`WVBottomFrictionLinear`](/classes/forcing/wvbottomfrictionlinear/) | Linear drag at the bottom boundary | All transform families | Drag rate `r` |
-| [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/) | Quadratic drag at the bottom boundary | All transform families | Drag coefficient `Cd` |
-| [`WVFixedAmplitudeForcing`](/classes/forcing/wvfixedamplitudeforcing/) | Hold selected `Ap`, `Am`, or `A0` coefficients fixed | All transform families | Registry `name`, selected indices, and target coefficients |
-| [`WVBetaPlanePVAdvection`](/classes/forcing/wvbetaplanepvadvection/) | Add the $$-\beta v_g$$ tendency to balanced QGPV | QG transforms directly; balanced `A0` in wave-bearing transforms | No user parameter |
-| [`WVPseudoTopographicWaveGeneration`](/classes/forcing/wvpseudotopographicwavegeneration/) | Project prescribed bottom velocity onto internal-wave modes | Wave-bearing three-dimensional transforms | Topography, velocity amplitude, tidal frequency, ramp, and spectral bounds |
+| Class | Purpose |
+| --- | --- |
+| [`WVNonlinearAdvection`](/classes/forcing/wvnonlinearadvection/) | Nonlinear momentum, displacement, and QGPV advection |
+| [`WVBottomFrictionLinear`](/classes/forcing/wvbottomfrictionlinear/) | Linear drag at the bottom boundary |
+| [`WVBottomFrictionQuadratic`](/classes/forcing/wvbottomfrictionquadratic/) | Quadratic drag at the bottom boundary |
+| [`WVFixedAmplitudeForcing`](/classes/forcing/wvfixedamplitudeforcing/) | Hold selected `Ap`, `Am`, or `A0` coefficients fixed |
+| [`WVBetaPlanePVAdvection`](/classes/forcing/wvbetaplanepvadvection/) | Add the $$-\beta v_g$$ tendency to balanced QGPV |
+| [`WVPseudoTopographicWaveGeneration`](/classes/forcing/wvpseudotopographicwavegeneration/) | Project prescribed bottom velocity onto internal-wave modes |

--- a/docs/classes/forcing/wvfixedamplitudeforcing/index.md
+++ b/docs/classes/forcing/wvfixedamplitudeforcing/index.md
@@ -22,8 +22,7 @@ Hold selected wave-vortex coefficients at prescribed amplitudes.
 
 ## Overview
 
-The forcing maintains selected wave or geostrophic coefficients while
-recording the tendency that must be cancelled to maintain them.
+This forcing keeps selected wave-vortex coefficients at prescribed amplitudes while those modes continue to participate in nonlinear interactions.
 
 As a simple example, one can set an internal wave mode with amplitude 1 cm/s, and that mode will continue to oscillate and maintain its amplitude. The wave will participate in all the nonlinear dynamics, but its amplitude will be maintained/restored at each time step.
 

--- a/docs/classes/transforms/wvtransform/a0.md
+++ b/docs/classes/transforms/wvtransform/a0.md
@@ -9,12 +9,14 @@ mathjax: true
 
 #  A0
 
-`A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+Zero-frequency wave–vortex coefficient array.
 
 
 ---
 
 ## Discussion
+Zero-frequency wave–vortex coefficient array.
+
 `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
 
 The geostrophic solutions follow the decomposition in [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The complete basis, including the mean-density-anomaly solution, is described in the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269).

--- a/docs/classes/transforms/wvtransform/am.md
+++ b/docs/classes/transforms/wvtransform/am.md
@@ -9,12 +9,14 @@ mathjax: true
 
 #  Am
 
-`Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
+Negative-frequency wave–vortex coefficient array.
 
 
 ---
 
 ## Discussion
+Negative-frequency wave–vortex coefficient array.
+
 `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the negative-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransform/ap.md
+++ b/docs/classes/transforms/wvtransform/ap.md
@@ -9,12 +9,14 @@ mathjax: true
 
 #  Ap
 
-`Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
+Positive-frequency wave–vortex coefficient array.
 
 
 ---
 
 ## Discussion
+Positive-frequency wave–vortex coefficient array.
+
 `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the positive-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransform/index.md
+++ b/docs/classes/transforms/wvtransform/index.md
@@ -57,6 +57,9 @@ corresponding coefficients evaluated at the current transform time.
 + Create and restore a transform
   + [`waveVortexTransformFromFile`](/classes/transforms/wvtransform/wavevortextransformfromfile.html) Initialize a WVTransform instance from an existing file
 + Inspect the domain
+  + Spectral grid
+    + Resolution and shape
+      + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransform/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransform/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
 + Initialize the flow
@@ -77,28 +80,34 @@ corresponding coefficients evaluated at the current transform time.
   + At arbitrary positions
     + [`variableAtPositionWithName`](/classes/transforms/wvtransform/variableatpositionwithname.html) Access dynamical variables at arbitrary positions in the domain.
 + Manage forcing and closures
-  + [`addForcing`](/classes/transforms/wvtransform/addforcing.html) Add forcing or closure objects to this transform.
-  + [`forcing`](/classes/transforms/wvtransform/forcing.html)
-  + [`forcingNames`](/classes/transforms/wvtransform/forcingnames.html) Return forcing and closure names in application order.
-  + [`forcingWithName`](/classes/transforms/wvtransform/forcingwithname.html) Return registered forcing objects by name.
-  + [`hasClosure`](/classes/transforms/wvtransform/hasclosure.html) Whether a closure is currently attached to the transform.
-  + [`hasForcingWithName`](/classes/transforms/wvtransform/hasforcingwithname.html) Test whether forcing objects are registered by name.
-  + [`removeAllForcing`](/classes/transforms/wvtransform/removeallforcing.html) Remove every forcing and closure from this transform.
-  + [`removeForcing`](/classes/transforms/wvtransform/removeforcing.html) Remove the exact registered forcing objects.
-  + [`setForcing`](/classes/transforms/wvtransform/setforcing.html) Replace the complete forcing registry.
-  + [`summarizeForcing`](/classes/transforms/wvtransform/summarizeforcing.html) Print a table of registered forcing and closure objects.
+  + Configure forcing
+    + [`addForcing`](/classes/transforms/wvtransform/addforcing.html) Add forcing or closure objects to this transform.
+    + [`setForcing`](/classes/transforms/wvtransform/setforcing.html) Replace the complete forcing registry.
+    + [`removeForcing`](/classes/transforms/wvtransform/removeforcing.html) Remove the exact registered forcing objects.
+    + [`removeAllForcing`](/classes/transforms/wvtransform/removeallforcing.html) Remove every forcing and closure from this transform.
+  + Inspect forcing and closures
+    + [`forcing`](/classes/transforms/wvtransform/forcing.html)
+    + [`forcingNames`](/classes/transforms/wvtransform/forcingnames.html) Return forcing and closure names in application order.
+    + [`forcingWithName`](/classes/transforms/wvtransform/forcingwithname.html) Return registered forcing objects by name.
+    + [`hasForcingWithName`](/classes/transforms/wvtransform/hasforcingwithname.html) Test whether forcing objects are registered by name.
+    + [`hasClosure`](/classes/transforms/wvtransform/hasclosure.html) Whether a closure is currently attached to the transform.
+  + Summarize forcing
+    + [`summarizeForcing`](/classes/transforms/wvtransform/summarizeforcing.html) Print a table of registered forcing and closure objects.
 + Analyze the flow
-  + Energy and summaries
+  + Flow diagnostics
     + [`hasMeanPressureDifference`](/classes/transforms/wvtransform/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
-    + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransform/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
-    + [`summarizeEnergyContent`](/classes/transforms/wvtransform/summarizeenergycontent.html) displays a summary of the energy content of the fluid
-    + [`summarizeModeEnergy`](/classes/transforms/wvtransform/summarizemodeenergy.html) List the most energetic modes
-    + [`totalEnergy`](/classes/transforms/wvtransform/totalenergy.html) % - Topic: Energetics
-    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransform/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
-    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransform/totalenergyspatiallyintegrated.html) % - Topic: Energetics
   + Spectra
     + Frequency
       + [`convertFromWavenumberToFrequency`](/classes/transforms/wvtransform/convertfromwavenumbertofrequency.html) Bin wave energy by vertical mode and intrinsic frequency
++ Analyze energy
+  + Component energy
+    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransform/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
+  + Total energy
+    + [`totalEnergy`](/classes/transforms/wvtransform/totalenergy.html) Total energy computed from wave-vortex coefficients.
+    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransform/totalenergyspatiallyintegrated.html) Total energy computed from physical-space fields.
+  + Energy summaries
+    + [`summarizeEnergyContent`](/classes/transforms/wvtransform/summarizeenergycontent.html) displays a summary of the energy content of the fluid
+    + [`summarizeModeEnergy`](/classes/transforms/wvtransform/summarizemodeenergy.html) List the most energetic modes
 + Save transform state
   + [`writeToFile`](/classes/transforms/wvtransform/writetofile.html) Write this instance to NetCDF file.
 + Convert representations
@@ -106,19 +115,22 @@ corresponding coefficients evaluated at the current transform time.
     + [`transformUVEtaToWaveVortex`](/classes/transforms/wvtransform/transformuvetatowavevortex.html) transform fluid variables $$(u,v,\eta)$$ to wave-vortex coefficients $$(A_+,A_-,A_0)$$.
     + [`transformWaveVortexToUVWEta`](/classes/transforms/wvtransform/transformwavevortextouvweta.html) transform wave-vortex coefficients $$(A_+,A_-,A_0)$$ to fluid variables $$(u,v,\eta)$$.
 + Inspect flow components
-  + [`flowComponentNames`](/classes/transforms/wvtransform/flowcomponentnames.html) retrieve the names of all available variables
-  + [`flowComponentWithName`](/classes/transforms/wvtransform/flowcomponentwithname.html) retrieve a WVFlowComponent by name
-  + [`flowComponents`](/classes/transforms/wvtransform/flowcomponents.html) All registered physical and diagnostic flow components.
-  + [`primaryFlowComponentNames`](/classes/transforms/wvtransform/primaryflowcomponentnames.html) retrieve the names of all available variables
-  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransform/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
-  + [`primaryFlowComponents`](/classes/transforms/wvtransform/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
-  + [`summarizeFlowComponents`](/classes/transforms/wvtransform/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
-  + [`totalFlowComponent`](/classes/transforms/wvtransform/totalflowcomponent.html) Combined view of all primary flow components.
+  + Primary flow components
+    + [`primaryFlowComponents`](/classes/transforms/wvtransform/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
+    + [`primaryFlowComponentNames`](/classes/transforms/wvtransform/primaryflowcomponentnames.html) retrieve the names of all available variables
+    + [`primaryFlowComponentWithName`](/classes/transforms/wvtransform/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
+  + Registered and combined components
+    + [`flowComponents`](/classes/transforms/wvtransform/flowcomponents.html) All registered physical and diagnostic flow components.
+    + [`flowComponentNames`](/classes/transforms/wvtransform/flowcomponentnames.html) retrieve the names of all available variables
+    + [`flowComponentWithName`](/classes/transforms/wvtransform/flowcomponentwithname.html) retrieve a WVFlowComponent by name
+    + [`totalFlowComponent`](/classes/transforms/wvtransform/totalflowcomponent.html) Combined view of all primary flow components.
+  + Summarize flow components
+    + [`summarizeFlowComponents`](/classes/transforms/wvtransform/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
 + Inspect wave-vortex coefficients
   + Stored coefficients
-    + [`Ap`](/classes/transforms/wvtransform/ap.html) `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`Am`](/classes/transforms/wvtransform/am.html) `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`A0`](/classes/transforms/wvtransform/a0.html) `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+    + [`Ap`](/classes/transforms/wvtransform/ap.html) Positive-frequency wave–vortex coefficient array.
+    + [`Am`](/classes/transforms/wvtransform/am.html) Negative-frequency wave–vortex coefficient array.
+    + [`A0`](/classes/transforms/wvtransform/a0.html) Zero-frequency wave–vortex coefficient array.
   + Coefficient evolution
     + [`t0`](/classes/transforms/wvtransform/t0.html) Reference time for the stored wave phases, in seconds.
     + [`t`](/classes/transforms/wvtransform/t.html) Current transform time in seconds.
@@ -149,9 +161,10 @@ These items document internal implementation details and are not part of the pri
   + [`A0_TZ_factor`](/classes/transforms/wvtransform/a0_tz_factor.html)
   + [`Apm_TE_factor`](/classes/transforms/wvtransform/apm_te_factor.html)
 + Geometry and mode indexing
-  + [`concatenateVariablesAlongTimeDimension`](/classes/transforms/wvtransform/concatenatevariablesalongtimedimension.html) Concatenate variables along the time dimension
-  + [`spatialDimensionNames`](/classes/transforms/wvtransform/spatialdimensionnames.html)
-  + [`spectralDimensionNames`](/classes/transforms/wvtransform/spectraldimensionnames.html)
+  + Additional geometry utilities
+    + [`concatenateVariablesAlongTimeDimension`](/classes/transforms/wvtransform/concatenatevariablesalongtimedimension.html) Concatenate variables along the time dimension
+    + [`spatialDimensionNames`](/classes/transforms/wvtransform/spatialdimensionnames.html)
+    + [`spectralDimensionNames`](/classes/transforms/wvtransform/spectraldimensionnames.html)
 + Spectral transforms and operators
   + [`optimizedTransformsForFlowComponent`](/classes/transforms/wvtransform/optimizedtransformsforflowcomponent.html) returns optimized transforms that avoid unnecessary computation
   + [`transformFromSpatialDomainWithFg`](/classes/transforms/wvtransform/transformfromspatialdomainwithfg.html) Required for transformUVEtaToWaveVortex

--- a/docs/classes/transforms/wvtransform/totalenergy.md
+++ b/docs/classes/transforms/wvtransform/totalenergy.md
@@ -9,13 +9,14 @@ mathjax: true
 
 #  totalEnergy
 
-% - Topic: Energetics
+Total energy computed from wave-vortex coefficients.
 
 
 ---
 
 ## Discussion
-%
+Total energy computed from wave-vortex coefficients.
+
 The horizontally-averaged depth-integrated energy computed from the wave-vortex coefficients
 
 $$

--- a/docs/classes/transforms/wvtransform/totalenergyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransform/totalenergyspatiallyintegrated.md
@@ -9,13 +9,14 @@ mathjax: true
 
 #  totalEnergySpatiallyIntegrated
 
-% - Topic: Energetics
+Total energy computed from physical-space fields.
 
 
 ---
 
 ## Discussion
-%
+Total energy computed from physical-space fields.
+
 The horizontally-averaged depth-integrated energy computed in the spatial domain is defined as,
 
 $$

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0.md
@@ -18,6 +18,8 @@ Zero-frequency geostrophic coefficients.
 Complex valued property with dimension $$kl$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+Zero-frequency wave–vortex coefficient array.
+
 `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
 
 The geostrophic solutions follow the decomposition in [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The complete basis, including the mean-density-anomaly solution, is described in the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269).

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0n.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0n.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0N
 
-These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects density displacement onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the density-displacement state variable onto $
 Real valued property with dimension $$kl$$ and no units.
 
 ## Discussion
+Projects density displacement onto $$A_0$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0u.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0u.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0U
 
-These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$u$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimension $$kl$$ and units of $$s$$.
 
 ## Discussion
+Projects $$u$$ onto $$A_0$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0v.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0v.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0V
 
-These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$v$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimension $$kl$$ and units of $$s$$.
 
 ## Discussion
+Projects $$v$$ onto $$A_0$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformbarotropicqg/a0z.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/a0z.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  A0Z
 
-
+Projects vertical vorticity onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects vertical vorticity onto $$A_0$$.
+
+`A0Z` maps the vertically transformed relative-vorticity state onto the zero-frequency coefficient array.

--- a/docs/classes/transforms/wvtransformbarotropicqg/index.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/index.md
@@ -72,17 +72,16 @@ The quasigeostrophic state is stored in
       + [`Ny`](/classes/transforms/wvtransformbarotropicqg/ny.html) Number of spatial grid points in the y direction.
       + [`spatialMatrixSize`](/classes/transforms/wvtransformbarotropicqg/spatialmatrixsize.html) Shape of a gridded physical-space field.
   + Spectral grid
-    + Axes and spacing
-      + [`kAxis`](/classes/transforms/wvtransformbarotropicqg/kaxis.html) Centered x-direction angular-wavenumber axis.
-      + [`lAxis`](/classes/transforms/wvtransformbarotropicqg/laxis.html) Centered y-direction angular-wavenumber axis.
-      + [`dk`](/classes/transforms/wvtransformbarotropicqg/dk.html) Spacing of the x-direction angular-wavenumber axis.
-      + [`dl`](/classes/transforms/wvtransformbarotropicqg/dl.html) Spacing of the y-direction angular-wavenumber axis.
-    + Coordinate arrays
-      + [`k`](/classes/transforms/wvtransformbarotropicqg/k_.html) Stored x-direction angular wavenumbers on the compact WV grid.
-      + [`l`](/classes/transforms/wvtransformbarotropicqg/l_.html) Stored y-direction angular wavenumbers on the compact WV grid.
+    + Compact grid vectors
+      + [`k`](/classes/transforms/wvtransformbarotropicqg/k_.html) Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
+      + [`l`](/classes/transforms/wvtransformbarotropicqg/l_.html) Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
+    + Compact grid arrays
       + [`K`](/classes/transforms/wvtransformbarotropicqg/k.html) X-direction angular-wavenumber array in rad/m with shape `[1 Nkl]`.
       + [`L`](/classes/transforms/wvtransformbarotropicqg/l.html) Y-direction angular-wavenumber array in rad/m with shape `[1 Nkl]`.
       + [`klGrid`](/classes/transforms/wvtransformbarotropicqg/klgrid.html) Return the barotropic spectral-coordinate arrays.
+    + Wavenumber spacing
+      + [`dk`](/classes/transforms/wvtransformbarotropicqg/dk.html) Spacing of the x-direction angular-wavenumber axis.
+      + [`dl`](/classes/transforms/wvtransformbarotropicqg/dl.html) Spacing of the y-direction angular-wavenumber axis.
     + Horizontal wavenumber geometry
       + [`Kh`](/classes/transforms/wvtransformbarotropicqg/kh.html) Horizontal angular-wavenumber magnitude on the coefficient grid.
       + [`K2`](/classes/transforms/wvtransformbarotropicqg/k2.html) Squared horizontal angular wavenumber on the coefficient grid.
@@ -90,6 +89,7 @@ The quasigeostrophic state is stored in
       + [`Nkl`](/classes/transforms/wvtransformbarotropicqg/nkl.html) Number of retained compact horizontal-wavenumber columns.
       + [`spectralMatrixSize`](/classes/transforms/wvtransformbarotropicqg/spectralmatrixsize.html) Shape of a wave-vortex coefficient array.
       + [`effectiveHorizontalGridResolution`](/classes/transforms/wvtransformbarotropicqg/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
+      + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformbarotropicqg/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
     + Equivalent depth and deformation scale
       + [`h`](/classes/transforms/wvtransformbarotropicqg/h.html) Equivalent depth associated with a vertical mode.
       + [`h_0`](/classes/transforms/wvtransformbarotropicqg/h_0.html) Geostrophic equivalent-depth scale for each vertical mode.
@@ -132,39 +132,46 @@ The quasigeostrophic state is stored in
   + At arbitrary positions
     + [`variableAtPositionWithName`](/classes/transforms/wvtransformbarotropicqg/variableatpositionwithname.html) Access dynamical variables at arbitrary positions in the domain.
 + Manage forcing and closures
-  + [`addForcing`](/classes/transforms/wvtransformbarotropicqg/addforcing.html) Add forcing or closure objects to this transform.
-  + [`forcing`](/classes/transforms/wvtransformbarotropicqg/forcing.html) array of WVForcing objects
-  + [`forcingNames`](/classes/transforms/wvtransformbarotropicqg/forcingnames.html) Return forcing and closure names in application order.
-  + [`forcingWithName`](/classes/transforms/wvtransformbarotropicqg/forcingwithname.html) Return registered forcing objects by name.
-  + [`hasClosure`](/classes/transforms/wvtransformbarotropicqg/hasclosure.html) Whether a closure is currently attached to the transform.
-  + [`hasForcingWithName`](/classes/transforms/wvtransformbarotropicqg/hasforcingwithname.html) Test whether forcing objects are registered by name.
-  + [`removeAllForcing`](/classes/transforms/wvtransformbarotropicqg/removeallforcing.html) Remove every forcing and closure from this transform.
-  + [`removeForcing`](/classes/transforms/wvtransformbarotropicqg/removeforcing.html) Remove the exact registered forcing objects.
-  + [`setForcing`](/classes/transforms/wvtransformbarotropicqg/setforcing.html) Replace the complete forcing registry.
-  + [`summarizeForcing`](/classes/transforms/wvtransformbarotropicqg/summarizeforcing.html) Print a table of registered forcing and closure objects.
+  + Configure forcing
+    + [`addForcing`](/classes/transforms/wvtransformbarotropicqg/addforcing.html) Add forcing or closure objects to this transform.
+    + [`setForcing`](/classes/transforms/wvtransformbarotropicqg/setforcing.html) Replace the complete forcing registry.
+    + [`removeForcing`](/classes/transforms/wvtransformbarotropicqg/removeforcing.html) Remove the exact registered forcing objects.
+    + [`removeAllForcing`](/classes/transforms/wvtransformbarotropicqg/removeallforcing.html) Remove every forcing and closure from this transform.
+  + Inspect forcing and closures
+    + [`forcing`](/classes/transforms/wvtransformbarotropicqg/forcing.html) array of WVForcing objects
+    + [`forcingNames`](/classes/transforms/wvtransformbarotropicqg/forcingnames.html) Return forcing and closure names in application order.
+    + [`forcingWithName`](/classes/transforms/wvtransformbarotropicqg/forcingwithname.html) Return registered forcing objects by name.
+    + [`hasForcingWithName`](/classes/transforms/wvtransformbarotropicqg/hasforcingwithname.html) Test whether forcing objects are registered by name.
+    + [`hasClosure`](/classes/transforms/wvtransformbarotropicqg/hasclosure.html) Whether a closure is currently attached to the transform.
+  + Summarize forcing
+    + [`summarizeForcing`](/classes/transforms/wvtransformbarotropicqg/summarizeforcing.html) Print a table of registered forcing and closure objects.
 + Analyze the flow
-  + Energy and summaries
-    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
-    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
-    + [`geostrophicEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophicenergy.html) total energy, geostrophic
-    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformbarotropicqg/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
-    + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformbarotropicqg/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
-    + [`summarizeEnergyContent`](/classes/transforms/wvtransformbarotropicqg/summarizeenergycontent.html) displays a summary of the energy content of the fluid
-    + [`summarizeModeEnergy`](/classes/transforms/wvtransformbarotropicqg/summarizemodeenergy.html) List the most energetic modes
-    + [`totalEnergy`](/classes/transforms/wvtransformbarotropicqg/totalenergy.html) % - Topic: Energetics
-    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformbarotropicqg/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
-    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformbarotropicqg/totalenergyspatiallyintegrated.html) % - Topic: Energetics
   + Flow diagnostics
+    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformbarotropicqg/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
     + [`uvMax`](/classes/transforms/wvtransformbarotropicqg/uvmax.html) max horizontal fluid speed
   + Potential vorticity and enstrophy
     + [`totalEnstrophy`](/classes/transforms/wvtransformbarotropicqg/totalenstrophy.html) Potential enstrophy computed from geostrophic coefficients.
     + [`totalEnstrophySpatiallyIntegrated`](/classes/transforms/wvtransformbarotropicqg/totalenstrophyspatiallyintegrated.html) Potential enstrophy evaluated from the gridded QGPV field.
   + Spectra
     + Spectral fields
+      + [`kAxis`](/classes/transforms/wvtransformbarotropicqg/kaxis.html) Centered `Nx`-by-1 x-wavenumber axis in rad/m.
+      + [`lAxis`](/classes/transforms/wvtransformbarotropicqg/laxis.html) Centered `Ny`-by-1 y-wavenumber axis in rad/m.
       + [`transformToKLAxes`](/classes/transforms/wvtransformbarotropicqg/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
     + Radial wavenumber
       + [`kRadial`](/classes/transforms/wvtransformbarotropicqg/kradial.html) radial (k,l) wavenumber on the WV grid
       + [`transformToRadialWavenumber`](/classes/transforms/wvtransformbarotropicqg/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
++ Analyze energy
+  + Component energy
+    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
+    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
+    + [`geostrophicEnergy`](/classes/transforms/wvtransformbarotropicqg/geostrophicenergy.html) total energy, geostrophic
+    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformbarotropicqg/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
+  + Total energy
+    + [`totalEnergy`](/classes/transforms/wvtransformbarotropicqg/totalenergy.html) Total energy computed from wave-vortex coefficients.
+    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformbarotropicqg/totalenergyspatiallyintegrated.html) Total energy computed from physical-space fields.
+  + Energy summaries
+    + [`summarizeEnergyContent`](/classes/transforms/wvtransformbarotropicqg/summarizeenergycontent.html) displays a summary of the energy content of the fluid
+    + [`summarizeModeEnergy`](/classes/transforms/wvtransformbarotropicqg/summarizemodeenergy.html) List the most energetic modes
 + Save transform state
   + [`writeToFile`](/classes/transforms/wvtransformbarotropicqg/writetofile.html) Write this instance to NetCDF file.
 + Convert representations
@@ -174,15 +181,18 @@ The quasigeostrophic state is stored in
   + [`diffX`](/classes/transforms/wvtransformbarotropicqg/diffx.html) Differentiate a gridded field in the periodic x direction.
   + [`diffY`](/classes/transforms/wvtransformbarotropicqg/diffy.html) Differentiate a gridded field in the periodic y direction.
 + Inspect flow components
-  + [`geostrophicComponent`](/classes/transforms/wvtransformbarotropicqg/geostrophiccomponent.html) returns the geostrophic flow component
-  + [`flowComponentNames`](/classes/transforms/wvtransformbarotropicqg/flowcomponentnames.html) retrieve the names of all available variables
-  + [`flowComponentWithName`](/classes/transforms/wvtransformbarotropicqg/flowcomponentwithname.html) retrieve a WVFlowComponent by name
-  + [`flowComponents`](/classes/transforms/wvtransformbarotropicqg/flowcomponents.html) All registered physical and diagnostic flow components.
-  + [`primaryFlowComponentNames`](/classes/transforms/wvtransformbarotropicqg/primaryflowcomponentnames.html) retrieve the names of all available variables
-  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformbarotropicqg/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
-  + [`primaryFlowComponents`](/classes/transforms/wvtransformbarotropicqg/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
-  + [`summarizeFlowComponents`](/classes/transforms/wvtransformbarotropicqg/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
-  + [`totalFlowComponent`](/classes/transforms/wvtransformbarotropicqg/totalflowcomponent.html) Combined view of all primary flow components.
+  + Primary flow components
+    + [`geostrophicComponent`](/classes/transforms/wvtransformbarotropicqg/geostrophiccomponent.html) returns the geostrophic flow component
+    + [`primaryFlowComponents`](/classes/transforms/wvtransformbarotropicqg/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
+    + [`primaryFlowComponentNames`](/classes/transforms/wvtransformbarotropicqg/primaryflowcomponentnames.html) retrieve the names of all available variables
+    + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformbarotropicqg/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
+  + Registered and combined components
+    + [`flowComponents`](/classes/transforms/wvtransformbarotropicqg/flowcomponents.html) All registered physical and diagnostic flow components.
+    + [`flowComponentNames`](/classes/transforms/wvtransformbarotropicqg/flowcomponentnames.html) retrieve the names of all available variables
+    + [`flowComponentWithName`](/classes/transforms/wvtransformbarotropicqg/flowcomponentwithname.html) retrieve a WVFlowComponent by name
+    + [`totalFlowComponent`](/classes/transforms/wvtransformbarotropicqg/totalflowcomponent.html) Combined view of all primary flow components.
+  + Summarize flow components
+    + [`summarizeFlowComponents`](/classes/transforms/wvtransformbarotropicqg/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
 + Inspect wave-vortex coefficients
   + Stored coefficients
     + [`A0`](/classes/transforms/wvtransformbarotropicqg/a0.html) Zero-frequency geostrophic coefficients.
@@ -210,43 +220,58 @@ The quasigeostrophic state is stored in
 ## Developer Topics
 These items document internal implementation details and are not part of the primary public API.
 + Projection and reconstruction coefficients
-  + [`A0N`](/classes/transforms/wvtransformbarotropicqg/a0n.html) These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0U`](/classes/transforms/wvtransformbarotropicqg/a0u.html) These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0V`](/classes/transforms/wvtransformbarotropicqg/a0v.html) These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0Z`](/classes/transforms/wvtransformbarotropicqg/a0z.html)
-  + [`F0`](/classes/transforms/wvtransformbarotropicqg/f0.html)
-  + [`Fpv`](/classes/transforms/wvtransformbarotropicqg/fpv.html)
-  + [`NA0`](/classes/transforms/wvtransformbarotropicqg/na0.html) These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`PA0`](/classes/transforms/wvtransformbarotropicqg/pa0.html)
-  + [`UA0`](/classes/transforms/wvtransformbarotropicqg/ua0.html) These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VA0`](/classes/transforms/wvtransformbarotropicqg/va0.html) These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+  + [`A0N`](/classes/transforms/wvtransformbarotropicqg/a0n.html) Projects density displacement onto $$A_0$$.
+  + [`A0U`](/classes/transforms/wvtransformbarotropicqg/a0u.html) Projects $$u$$ onto $$A_0$$.
+  + [`A0V`](/classes/transforms/wvtransformbarotropicqg/a0v.html) Projects $$v$$ onto $$A_0$$.
+  + [`A0Z`](/classes/transforms/wvtransformbarotropicqg/a0z.html) Projects vertical vorticity onto $$A_0$$.
+  + [`NA0`](/classes/transforms/wvtransformbarotropicqg/na0.html) Reconstructs density displacement from $$A_0$$.
+  + [`PA0`](/classes/transforms/wvtransformbarotropicqg/pa0.html) Reconstructs pressure height from $$A_0$$.
+  + [`UA0`](/classes/transforms/wvtransformbarotropicqg/ua0.html) Reconstructs $$u$$ from $$A_0$$.
+  + [`VA0`](/classes/transforms/wvtransformbarotropicqg/va0.html) Reconstructs $$v$$ from $$A_0$$.
 + Geometry and mode indexing
-  + [`conjugateDimension`](/classes/transforms/wvtransformbarotropicqg/conjugatedimension.html) assumed conjugate dimension
-  + [`indexFromKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
-  + [`indexFromModeNumber`](/classes/transforms/wvtransformbarotropicqg/indexfrommodenumber.html)
-  + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformbarotropicqg/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
-  + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
-  + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
-  + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidconjugatemodenumber.html)
-  + [`isValidKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
-  + [`isValidModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidmodenumber.html)
-  + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
-  + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidprimarymodenumber.html)
-  + [`kMode_dft`](/classes/transforms/wvtransformbarotropicqg/kmode_dft.html) k mode-number on the DFT grid
-  + [`kMode_wv`](/classes/transforms/wvtransformbarotropicqg/kmode_wv.html) k mode number on the WV grid
-  + [`klModeNumberFromIndex`](/classes/transforms/wvtransformbarotropicqg/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
-  + [`lMode_dft`](/classes/transforms/wvtransformbarotropicqg/lmode_dft.html) l mode-number on the DFT grid
-  + [`lMode_wv`](/classes/transforms/wvtransformbarotropicqg/lmode_wv.html) l mode number on the WV grid
-  + [`maskForAliasedModes`](/classes/transforms/wvtransformbarotropicqg/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
-  + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformbarotropicqg/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
-  + [`maskForNyquistModes`](/classes/transforms/wvtransformbarotropicqg/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
-  + [`modeNumberFromIndex`](/classes/transforms/wvtransformbarotropicqg/modenumberfromindex.html)
-  + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
-  + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
-  + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
-  + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
-  + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
-  + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Mode numbers and validity
+    + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
+    + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidconjugatemodenumber.html)
+    + [`isValidKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
+    + [`isValidModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidmodenumber.html)
+    + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
+    + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformbarotropicqg/isvalidprimarymodenumber.html)
+    + [`kMode_dft`](/classes/transforms/wvtransformbarotropicqg/kmode_dft.html) k mode-number on the DFT grid
+    + [`kMode_wv`](/classes/transforms/wvtransformbarotropicqg/kmode_wv.html) k mode number on the WV grid
+    + [`lMode_dft`](/classes/transforms/wvtransformbarotropicqg/lmode_dft.html) l mode-number on the DFT grid
+    + [`lMode_wv`](/classes/transforms/wvtransformbarotropicqg/lmode_wv.html) l mode number on the WV grid
+    + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
+  + Linear-index conversion
+    + [`indexFromKLModeNumber`](/classes/transforms/wvtransformbarotropicqg/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
+    + [`indexFromModeNumber`](/classes/transforms/wvtransformbarotropicqg/indexfrommodenumber.html)
+    + [`klModeNumberFromIndex`](/classes/transforms/wvtransformbarotropicqg/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
+    + [`modeNumberFromIndex`](/classes/transforms/wvtransformbarotropicqg/modenumberfromindex.html)
+  + DFT and WV layout metadata
+    + [`Nk_dft`](/classes/transforms/wvtransformbarotropicqg/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
+    + [`Nl_dft`](/classes/transforms/wvtransformbarotropicqg/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
+    + [`conjugateDimension`](/classes/transforms/wvtransformbarotropicqg/conjugatedimension.html) assumed conjugate dimension
+    + [`dftConjugateIndices2D`](/classes/transforms/wvtransformbarotropicqg/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
+    + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformbarotropicqg/dftprimaryindices2d.html) index into the DFT grid of each WV mode
+    + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformbarotropicqg/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
+    + [`k_dft`](/classes/transforms/wvtransformbarotropicqg/k_dft.html) k wavenumber dimension on the DFT grid
+    + [`kl`](/classes/transforms/wvtransformbarotropicqg/kl.html) wavenumber dimension
+    + [`l_dft`](/classes/transforms/wvtransformbarotropicqg/l_dft.html) l wavenumber dimension on the DFT grid
+    + [`shouldExcludeConjugates`](/classes/transforms/wvtransformbarotropicqg/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
+    + [`shouldExcludeNyquist`](/classes/transforms/wvtransformbarotropicqg/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
+  + Layout conversion
+    + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformbarotropicqg/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
+    + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
+    + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
+    + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
+    + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
+    + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
+    + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Masks and Hermitian bookkeeping
+    + [`isHermitian`](/classes/transforms/wvtransformbarotropicqg/ishermitian.html) Check if the matrix is Hermitian. Report errors.
+    + [`maskForAliasedModes`](/classes/transforms/wvtransformbarotropicqg/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
+    + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformbarotropicqg/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
+    + [`maskForNyquistModes`](/classes/transforms/wvtransformbarotropicqg/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
+    + [`setConjugateToUnity`](/classes/transforms/wvtransformbarotropicqg/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
 + Spectral transforms and operators
   + [`degreesOfFreedomForComplexMatrix`](/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforcomplexmatrix.html) a matrix with the number of degrees-of-freedom at each entry
   + [`degreesOfFreedomForRealMatrix`](/classes/transforms/wvtransformbarotropicqg/degreesoffreedomforrealmatrix.html) a matrix with the number of degrees-of-freedom at each entry
@@ -255,6 +280,8 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainWithFourier`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainwithfourier.html)
   + [`transformToSpatialDomainWithFourierAtPosition`](/classes/transforms/wvtransformbarotropicqg/transformtospatialdomainwithfourieratposition.html)
 + Nonlinear flux and forcing internals
+  + [`F0`](/classes/transforms/wvtransformbarotropicqg/f0.html)
+  + [`Fpv`](/classes/transforms/wvtransformbarotropicqg/fpv.html)
   + [`enstrophyFluxFromF0`](/classes/transforms/wvtransformbarotropicqg/enstrophyfluxfromf0.html)
   + [`fluxForForcing`](/classes/transforms/wvtransformbarotropicqg/fluxforforcing.html)
   + [`qgpvFluxFromF0`](/classes/transforms/wvtransformbarotropicqg/qgpvfluxfromf0.html)
@@ -275,19 +302,7 @@ These items document internal implementation details and are not part of the pri
   + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformbarotropicqg/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
   + [`propertyAnnotationsForRotatingFPlane`](/classes/transforms/wvtransformbarotropicqg/propertyannotationsforrotatingfplane.html)
 + Class internals
-  + [`Nk_dft`](/classes/transforms/wvtransformbarotropicqg/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
-  + [`Nl_dft`](/classes/transforms/wvtransformbarotropicqg/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
-  + [`dftConjugateIndices2D`](/classes/transforms/wvtransformbarotropicqg/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformbarotropicqg/dftprimaryindices2d.html) index into the DFT grid of each WV mode
-  + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformbarotropicqg/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
-  + [`isHermitian`](/classes/transforms/wvtransformbarotropicqg/ishermitian.html) Check if the matrix is Hermitian. Report errors.
-  + [`k_dft`](/classes/transforms/wvtransformbarotropicqg/k_dft.html) k wavenumber dimension on the DFT grid
-  + [`kl`](/classes/transforms/wvtransformbarotropicqg/kl.html) wavenumber dimension
-  + [`l_dft`](/classes/transforms/wvtransformbarotropicqg/l_dft.html) l wavenumber dimension on the DFT grid
   + [`maxFg`](/classes/transforms/wvtransformbarotropicqg/maxfg.html)
-  + [`setConjugateToUnity`](/classes/transforms/wvtransformbarotropicqg/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
-  + [`shouldExcludeConjugates`](/classes/transforms/wvtransformbarotropicqg/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
-  + [`shouldExcludeNyquist`](/classes/transforms/wvtransformbarotropicqg/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
 
 
 ---

--- a/docs/classes/transforms/wvtransformbarotropicqg/k_.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/k_.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  k
 
-Stored x-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformbarotropicqg/kaxis.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/kaxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  kAxis
 
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 `kAxis` is an `Nx`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dk`.

--- a/docs/classes/transforms/wvtransformbarotropicqg/l_.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/l_.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  l
 
-Stored y-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformbarotropicqg/laxis.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/laxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  lAxis
 
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 `lAxis` is an `Ny`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dl`.

--- a/docs/classes/transforms/wvtransformbarotropicqg/na0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/na0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NA0
 
-These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the density-displacement stat
 Real valued property with dimension $$kl$$ and no units.
 
 ## Discussion
+Reconstructs density displacement from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformbarotropicqg/pa0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/pa0.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  PA0
 
-
+Reconstructs pressure height from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Reconstructs pressure height from $$A_0$$.
+
+`PA0` maps the zero-frequency coefficient array onto the pressure-height anomaly used to evaluate `pi` and pressure.

--- a/docs/classes/transforms/wvtransformbarotropicqg/totalenergy.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/totalenergy.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergy
 
-% - Topic: Energetics
+Total energy computed from wave-vortex coefficients.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from wave-vortex coefficients.
+
 The horizontally-averaged depth-integrated energy computed from the wave-vortex coefficients
 
 $$

--- a/docs/classes/transforms/wvtransformbarotropicqg/totalenergyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/totalenergyspatiallyintegrated.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergySpatiallyIntegrated
 
-% - Topic: Energetics
+Total energy computed from physical-space fields.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from physical-space fields.
+
 The horizontally-averaged depth-integrated energy computed in the spatial domain is defined as,
 
 $$

--- a/docs/classes/transforms/wvtransformbarotropicqg/ua0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/ua0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In 
 Complex valued property with dimension $$kl$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$u$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformbarotropicqg/va0.md
+++ b/docs/classes/transforms/wvtransformbarotropicqg/va0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In 
 Complex valued property with dimension $$kl$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$v$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/a0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0
 
-`A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+Zero-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+Zero-frequency wave–vortex coefficient array.
+
 `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
 
 The geostrophic solutions follow the decomposition in [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The complete basis, including the mean-density-anomaly solution, is described in the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269).

--- a/docs/classes/transforms/wvtransformboussinesq/a0n.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0n.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0N
 
-These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects density displacement onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the density-displacement state variable onto $
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Projects density displacement onto $$A_0$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/a0u.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0u.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0U
 
-These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$u$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$u$$ onto $$A_0$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/a0v.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0v.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0V
 
-These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$v$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$v$$ onto $$A_0$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/a0z.md
+++ b/docs/classes/transforms/wvtransformboussinesq/a0z.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  A0Z
 
-
+Projects vertical vorticity onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects vertical vorticity onto $$A_0$$.
+
+`A0Z` maps the vertically transformed relative-vorticity state onto the zero-frequency coefficient array.

--- a/docs/classes/transforms/wvtransformboussinesq/am.md
+++ b/docs/classes/transforms/wvtransformboussinesq/am.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Am
 
-`Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
+Negative-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+Negative-frequency wave–vortex coefficient array.
+
 `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the negative-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransformboussinesq/ap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/ap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Ap
 
-`Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
+Positive-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+Positive-frequency wave–vortex coefficient array.
+
 `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the positive-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransformboussinesq/apmd.md
+++ b/docs/classes/transforms/wvtransformboussinesq/apmd.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  ApmD
 
-
+Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
+
+`ApmD` supplies the common divergence contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/docs/classes/transforms/wvtransformboussinesq/apmn.md
+++ b/docs/classes/transforms/wvtransformboussinesq/apmn.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  ApmN
 
-
+Projects density displacement onto $$A_+$$ and $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects density displacement onto $$A_+$$ and $$A_-$$.
+
+`ApmN` supplies the signed density-displacement contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/docs/classes/transforms/wvtransformboussinesq/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/finvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FinvMatrix
 
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 `FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformboussinesq/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/finvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FinvMatrix
 
-transformation matrix $$F_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+
+`FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformboussinesq/fmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/fmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FMatrix
 
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformboussinesq/fmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/fmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FMatrix
 
-transformation matrix $$F_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformboussinesq/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/ginvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GinvMatrix
 
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 `GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformboussinesq/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/ginvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GinvMatrix
 
-transformation matrix $$G_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+
+`GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformboussinesq/gmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/gmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GMatrix
 
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformboussinesq/gmatrix.md
+++ b/docs/classes/transforms/wvtransformboussinesq/gmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GMatrix
 
-transformation matrix $$G_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformboussinesq/index.md
+++ b/docs/classes/transforms/wvtransformboussinesq/index.md
@@ -117,10 +117,10 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`Lr2`](/classes/transforms/wvtransformboussinesq/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformboussinesq/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
     + Vertical-mode transformation matrices
-      + [`FMatrix`](/classes/transforms/wvtransformboussinesq/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`FinvMatrix`](/classes/transforms/wvtransformboussinesq/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
-      + [`GMatrix`](/classes/transforms/wvtransformboussinesq/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`GinvMatrix`](/classes/transforms/wvtransformboussinesq/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`FMatrix`](/classes/transforms/wvtransformboussinesq/fmatrix.html) Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformboussinesq/finvmatrix.html) Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformboussinesq/gmatrix.html) Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformboussinesq/ginvmatrix.html) Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformboussinesq/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformboussinesq/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.

--- a/docs/classes/transforms/wvtransformboussinesq/index.md
+++ b/docs/classes/transforms/wvtransformboussinesq/index.md
@@ -87,19 +87,18 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`z_int`](/classes/transforms/wvtransformboussinesq/z_int.html) Vertical quadrature weights in meters.
       + [`volumeIntegral`](/classes/transforms/wvtransformboussinesq/volumeintegral.html) Compute the horizontally averaged depth integral of a scalar field.
   + Spectral grid
-    + Axes and spacing
-      + [`kAxis`](/classes/transforms/wvtransformboussinesq/kaxis.html) Centered x-direction angular-wavenumber axis.
-      + [`lAxis`](/classes/transforms/wvtransformboussinesq/laxis.html) Centered y-direction angular-wavenumber axis.
-      + [`j`](/classes/transforms/wvtransformboussinesq/j.html) Vertical-mode index axis.
-      + [`dk`](/classes/transforms/wvtransformboussinesq/dk.html) Spacing of the x-direction angular-wavenumber axis.
-      + [`dl`](/classes/transforms/wvtransformboussinesq/dl.html) Spacing of the y-direction angular-wavenumber axis.
-    + Coordinate arrays
-      + [`k`](/classes/transforms/wvtransformboussinesq/k.html) Stored x-direction angular wavenumbers on the compact WV grid.
-      + [`l`](/classes/transforms/wvtransformboussinesq/l.html) Stored y-direction angular wavenumbers on the compact WV grid.
+    + Compact grid vectors
+      + [`k`](/classes/transforms/wvtransformboussinesq/k.html) Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
+      + [`l`](/classes/transforms/wvtransformboussinesq/l.html) Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
+      + [`j`](/classes/transforms/wvtransformboussinesq/j.html) Dimensionless `Nj`-by-1 vertical-mode index vector.
+    + Compact grid arrays
       + [`K`](/classes/transforms/wvtransformboussinesq/k_.html) X-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`L`](/classes/transforms/wvtransformboussinesq/l_.html) Y-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`J`](/classes/transforms/wvtransformboussinesq/j_.html) Dimensionless vertical-mode index array with shape `[Nj Nkl]`.
       + [`kljGrid`](/classes/transforms/wvtransformboussinesq/kljgrid.html) Return spectral-coordinate arrays in wave-vortex layout.
+    + Wavenumber spacing
+      + [`dk`](/classes/transforms/wvtransformboussinesq/dk.html) Spacing of the x-direction angular-wavenumber axis.
+      + [`dl`](/classes/transforms/wvtransformboussinesq/dl.html) Spacing of the y-direction angular-wavenumber axis.
     + Horizontal wavenumber geometry
       + [`Kh`](/classes/transforms/wvtransformboussinesq/kh.html) Horizontal angular-wavenumber magnitude on the coefficient grid.
       + [`K2`](/classes/transforms/wvtransformboussinesq/k2.html) Squared horizontal angular wavenumber on the coefficient grid.
@@ -110,12 +109,18 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`effectiveHorizontalGridResolution`](/classes/transforms/wvtransformboussinesq/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
       + [`effectiveVerticalGridResolution`](/classes/transforms/wvtransformboussinesq/effectiveverticalgridresolution.html) returns the effective vertical grid resolution in meters
       + [`effectiveJMax`](/classes/transforms/wvtransformboussinesq/effectivejmax.html) Largest active vertical-mode index.
+      + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformboussinesq/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
     + Vertical modes and scaling
       + [`verticalModes`](/classes/transforms/wvtransformboussinesq/verticalmodes.html) Vertical-mode solution used to construct the transform basis.
       + [`h_0`](/classes/transforms/wvtransformboussinesq/h_0.html) Geostrophic equivalent-depth scale for each vertical mode.
       + [`h_pm`](/classes/transforms/wvtransformboussinesq/h_pm.html) Wave equivalent depth on the spectral grid.
       + [`Lr2`](/classes/transforms/wvtransformboussinesq/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformboussinesq/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
+    + Vertical-mode transformation matrices
+      + [`FMatrix`](/classes/transforms/wvtransformboussinesq/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformboussinesq/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformboussinesq/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformboussinesq/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformboussinesq/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformboussinesq/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.
@@ -170,10 +175,10 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`w`](/classes/transforms/wvtransformboussinesq/w.html) z-component of the fluid velocity
     + Density and displacement
       + [`eta`](/classes/transforms/wvtransformboussinesq/eta.html) approximate isopycnal deviation
-      + [`rho_bar`](/classes/transforms/wvtransformboussinesq/rho_bar.html) mean density
+      + [`rho_bar`](/classes/transforms/wvtransformboussinesq/rho_bar.html) Current horizontally averaged density, `[Nz 1]`, in kg/m³.
       + [`rho_e`](/classes/transforms/wvtransformboussinesq/rho_e.html) excess density
-      + [`rho_nm`](/classes/transforms/wvtransformboussinesq/rho_nm.html) no-motion density profile
-      + [`rho_nm0`](/classes/transforms/wvtransformboussinesq/rho_nm0.html) No-motion density profile sampled on the vertical grid.
+      + [`rho_nm`](/classes/transforms/wvtransformboussinesq/rho_nm.html) Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
+      + [`rho_nm0`](/classes/transforms/wvtransformboussinesq/rho_nm0.html) Reference no-motion density profile, `[Nz 1]`, in kg/m³.
       + [`rho_total`](/classes/transforms/wvtransformboussinesq/rho_total.html) total potential density
     + Pressure and surface fields
       + [`p`](/classes/transforms/wvtransformboussinesq/p.html) pressure anomaly
@@ -192,33 +197,22 @@ views are `Apt`, `Amt`, and `A0t`.
   + Isopycnal utilities
     + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformboussinesq/placeparticlesonisopycnal.html) Return particle depths on the isopycnal identified by a no-motion depth.
 + Manage forcing and closures
-  + [`addForcing`](/classes/transforms/wvtransformboussinesq/addforcing.html) Add forcing or closure objects to this transform.
-  + [`forcing`](/classes/transforms/wvtransformboussinesq/forcing.html) array of WVForcing objects
-  + [`forcingNames`](/classes/transforms/wvtransformboussinesq/forcingnames.html) Return forcing and closure names in application order.
-  + [`forcingWithName`](/classes/transforms/wvtransformboussinesq/forcingwithname.html) Return registered forcing objects by name.
-  + [`hasClosure`](/classes/transforms/wvtransformboussinesq/hasclosure.html) Whether a closure is currently attached to the transform.
-  + [`hasForcingWithName`](/classes/transforms/wvtransformboussinesq/hasforcingwithname.html) Test whether forcing objects are registered by name.
-  + [`removeAllForcing`](/classes/transforms/wvtransformboussinesq/removeallforcing.html) Remove every forcing and closure from this transform.
-  + [`removeForcing`](/classes/transforms/wvtransformboussinesq/removeforcing.html) Remove the exact registered forcing objects.
-  + [`setForcing`](/classes/transforms/wvtransformboussinesq/setforcing.html) Replace the complete forcing registry.
-  + [`summarizeForcing`](/classes/transforms/wvtransformboussinesq/summarizeforcing.html) Print a table of registered forcing and closure objects.
+  + Configure forcing
+    + [`addForcing`](/classes/transforms/wvtransformboussinesq/addforcing.html) Add forcing or closure objects to this transform.
+    + [`setForcing`](/classes/transforms/wvtransformboussinesq/setforcing.html) Replace the complete forcing registry.
+    + [`removeForcing`](/classes/transforms/wvtransformboussinesq/removeforcing.html) Remove the exact registered forcing objects.
+    + [`removeAllForcing`](/classes/transforms/wvtransformboussinesq/removeallforcing.html) Remove every forcing and closure from this transform.
+  + Inspect forcing and closures
+    + [`forcing`](/classes/transforms/wvtransformboussinesq/forcing.html) array of WVForcing objects
+    + [`forcingNames`](/classes/transforms/wvtransformboussinesq/forcingnames.html) Return forcing and closure names in application order.
+    + [`forcingWithName`](/classes/transforms/wvtransformboussinesq/forcingwithname.html) Return registered forcing objects by name.
+    + [`hasForcingWithName`](/classes/transforms/wvtransformboussinesq/hasforcingwithname.html) Test whether forcing objects are registered by name.
+    + [`hasClosure`](/classes/transforms/wvtransformboussinesq/hasclosure.html) Whether a closure is currently attached to the transform.
+  + Summarize forcing
+    + [`summarizeForcing`](/classes/transforms/wvtransformboussinesq/summarizeforcing.html) Print a table of registered forcing and closure objects.
 + Analyze the flow
-  + Energy and summaries
-    + [`inertialEnergy`](/classes/transforms/wvtransformboussinesq/inertialenergy.html) total energy of the inertial flow
-    + [`mdaEnergy`](/classes/transforms/wvtransformboussinesq/mdaenergy.html) total energy of the mean density anomaly
-    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformboussinesq/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
-    + [`waveEnergy`](/classes/transforms/wvtransformboussinesq/waveenergy.html) Total energy of the internal-gravity-wave flow.
-    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformboussinesq/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
-    + [`exactTotalEnergy`](/classes/transforms/wvtransformboussinesq/exacttotalenergy.html) Nonlinear total energy evaluated from physical-space fields.
-    + [`geostrophicEnergy`](/classes/transforms/wvtransformboussinesq/geostrophicenergy.html) total energy, geostrophic
-    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformboussinesq/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
-    + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformboussinesq/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
-    + [`summarizeEnergyContent`](/classes/transforms/wvtransformboussinesq/summarizeenergycontent.html) displays a summary of the energy content of the fluid
-    + [`summarizeModeEnergy`](/classes/transforms/wvtransformboussinesq/summarizemodeenergy.html) List the most energetic modes
-    + [`totalEnergy`](/classes/transforms/wvtransformboussinesq/totalenergy.html) % - Topic: Energetics
-    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformboussinesq/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
-    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformboussinesq/totalenergyspatiallyintegrated.html) % - Topic: Energetics
   + Flow diagnostics
+    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformboussinesq/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
     + [`uvMax`](/classes/transforms/wvtransformboussinesq/uvmax.html) max horizontal fluid speed
     + [`wMax`](/classes/transforms/wvtransformboussinesq/wmax.html) max vertical fluid speed
   + Density validity
@@ -229,16 +223,34 @@ views are `Apt`, `Amt`, and `A0t`.
     + [`totalEnstrophySpatiallyIntegrated`](/classes/transforms/wvtransformboussinesq/totalenstrophyspatiallyintegrated.html) Potential enstrophy evaluated from the gridded QGPV field.
   + Spectra
     + Spectral fields
+      + [`kAxis`](/classes/transforms/wvtransformboussinesq/kaxis.html) Centered `Nx`-by-1 x-wavenumber axis in rad/m.
+      + [`lAxis`](/classes/transforms/wvtransformboussinesq/laxis.html) Centered `Ny`-by-1 y-wavenumber axis in rad/m.
+      + [`transformToKLAxes`](/classes/transforms/wvtransformboussinesq/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
       + [`crossSpectrumWithFgTransform`](/classes/transforms/wvtransformboussinesq/crossspectrumwithfgtransform.html) Compute a real modal cross-spectrum using the F-basis transform.
       + [`crossSpectrumWithGgTransform`](/classes/transforms/wvtransformboussinesq/crossspectrumwithggtransform.html) Compute a real modal cross-spectrum using the G-basis transform.
       + [`spectrumWithFgTransform`](/classes/transforms/wvtransformboussinesq/spectrumwithfgtransform.html) Compute a modal autospectrum using the F-basis transform.
       + [`spectrumWithGgTransform`](/classes/transforms/wvtransformboussinesq/spectrumwithggtransform.html) Compute a modal autospectrum using the G-basis transform.
-      + [`transformToKLAxes`](/classes/transforms/wvtransformboussinesq/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
     + Radial wavenumber
       + [`kRadial`](/classes/transforms/wvtransformboussinesq/kradial.html) radial (k,l) wavenumber on the WV grid
       + [`transformToRadialWavenumber`](/classes/transforms/wvtransformboussinesq/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
     + Frequency
       + [`convertFromWavenumberToFrequency`](/classes/transforms/wvtransformboussinesq/convertfromwavenumbertofrequency.html) Bin wave energy by vertical mode and intrinsic frequency
++ Analyze energy
+  + Component energy
+    + [`inertialEnergy`](/classes/transforms/wvtransformboussinesq/inertialenergy.html) total energy of the inertial flow
+    + [`mdaEnergy`](/classes/transforms/wvtransformboussinesq/mdaenergy.html) total energy of the mean density anomaly
+    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformboussinesq/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
+    + [`waveEnergy`](/classes/transforms/wvtransformboussinesq/waveenergy.html) Total energy of the internal-gravity-wave flow.
+    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformboussinesq/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
+    + [`geostrophicEnergy`](/classes/transforms/wvtransformboussinesq/geostrophicenergy.html) total energy, geostrophic
+    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformboussinesq/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
+  + Total energy
+    + [`exactTotalEnergy`](/classes/transforms/wvtransformboussinesq/exacttotalenergy.html) Nonlinear total energy evaluated from physical-space fields.
+    + [`totalEnergy`](/classes/transforms/wvtransformboussinesq/totalenergy.html) Total energy computed from wave-vortex coefficients.
+    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformboussinesq/totalenergyspatiallyintegrated.html) Total energy computed from physical-space fields.
+  + Energy summaries
+    + [`summarizeEnergyContent`](/classes/transforms/wvtransformboussinesq/summarizeenergycontent.html) displays a summary of the energy content of the fluid
+    + [`summarizeModeEnergy`](/classes/transforms/wvtransformboussinesq/summarizemodeenergy.html) List the most energetic modes
 + Save transform state
   + [`writeToFile`](/classes/transforms/wvtransformboussinesq/writetofile.html) Write this instance to NetCDF file.
 + Convert representations
@@ -254,23 +266,26 @@ views are `Apt`, `Amt`, and `A0t`.
   + [`intZF`](/classes/transforms/wvtransformboussinesq/intzf.html) Return the first antiderivative of an F-representation.
   + [`intZG`](/classes/transforms/wvtransformboussinesq/intzg.html) Return the bottom-zero first antiderivative of a G-representation.
 + Inspect flow components
-  + [`geostrophicComponent`](/classes/transforms/wvtransformboussinesq/geostrophiccomponent.html) returns the geostrophic flow component
-  + [`waveComponent`](/classes/transforms/wvtransformboussinesq/wavecomponent.html) returns the internal gravity wave flow component
-  + [`inertialComponent`](/classes/transforms/wvtransformboussinesq/inertialcomponent.html) returns the inertial oscillation flow component
-  + [`mdaComponent`](/classes/transforms/wvtransformboussinesq/mdacomponent.html) returns the mean density anomaly component
-  + [`flowComponentNames`](/classes/transforms/wvtransformboussinesq/flowcomponentnames.html) retrieve the names of all available variables
-  + [`flowComponentWithName`](/classes/transforms/wvtransformboussinesq/flowcomponentwithname.html) retrieve a WVFlowComponent by name
-  + [`flowComponents`](/classes/transforms/wvtransformboussinesq/flowcomponents.html) All registered physical and diagnostic flow components.
-  + [`primaryFlowComponentNames`](/classes/transforms/wvtransformboussinesq/primaryflowcomponentnames.html) retrieve the names of all available variables
-  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformboussinesq/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
-  + [`primaryFlowComponents`](/classes/transforms/wvtransformboussinesq/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
-  + [`summarizeFlowComponents`](/classes/transforms/wvtransformboussinesq/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
-  + [`totalFlowComponent`](/classes/transforms/wvtransformboussinesq/totalflowcomponent.html) Combined view of all primary flow components.
+  + Primary flow components
+    + [`waveComponent`](/classes/transforms/wvtransformboussinesq/wavecomponent.html) returns the internal gravity wave flow component
+    + [`inertialComponent`](/classes/transforms/wvtransformboussinesq/inertialcomponent.html) returns the inertial oscillation flow component
+    + [`geostrophicComponent`](/classes/transforms/wvtransformboussinesq/geostrophiccomponent.html) returns the geostrophic flow component
+    + [`mdaComponent`](/classes/transforms/wvtransformboussinesq/mdacomponent.html) returns the mean density anomaly component
+    + [`primaryFlowComponents`](/classes/transforms/wvtransformboussinesq/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
+    + [`primaryFlowComponentNames`](/classes/transforms/wvtransformboussinesq/primaryflowcomponentnames.html) retrieve the names of all available variables
+    + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformboussinesq/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
+  + Registered and combined components
+    + [`flowComponents`](/classes/transforms/wvtransformboussinesq/flowcomponents.html) All registered physical and diagnostic flow components.
+    + [`flowComponentNames`](/classes/transforms/wvtransformboussinesq/flowcomponentnames.html) retrieve the names of all available variables
+    + [`flowComponentWithName`](/classes/transforms/wvtransformboussinesq/flowcomponentwithname.html) retrieve a WVFlowComponent by name
+    + [`totalFlowComponent`](/classes/transforms/wvtransformboussinesq/totalflowcomponent.html) Combined view of all primary flow components.
+  + Summarize flow components
+    + [`summarizeFlowComponents`](/classes/transforms/wvtransformboussinesq/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
 + Inspect wave-vortex coefficients
   + Stored coefficients
-    + [`Ap`](/classes/transforms/wvtransformboussinesq/ap.html) `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`Am`](/classes/transforms/wvtransformboussinesq/am.html) `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`A0`](/classes/transforms/wvtransformboussinesq/a0.html) `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+    + [`Ap`](/classes/transforms/wvtransformboussinesq/ap.html) Positive-frequency wave–vortex coefficient array.
+    + [`Am`](/classes/transforms/wvtransformboussinesq/am.html) Negative-frequency wave–vortex coefficient array.
+    + [`A0`](/classes/transforms/wvtransformboussinesq/a0.html) Zero-frequency wave–vortex coefficient array.
   + Coefficients at the current time
     + [`Apt`](/classes/transforms/wvtransformboussinesq/apt.html) `Apt` is the positive-frequency coefficient array evaluated at the current transform time:
     + [`Amt`](/classes/transforms/wvtransformboussinesq/amt.html) `Amt` is the negative-frequency coefficient array evaluated at the current transform time:
@@ -303,71 +318,82 @@ views are `Apt`, `Amt`, and `A0t`.
 ## Developer Topics
 These items document internal implementation details and are not part of the primary public API.
 + Projection and reconstruction coefficients
-  + [`A0N`](/classes/transforms/wvtransformboussinesq/a0n.html) These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0U`](/classes/transforms/wvtransformboussinesq/a0u.html) These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0V`](/classes/transforms/wvtransformboussinesq/a0v.html) These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0Z`](/classes/transforms/wvtransformboussinesq/a0z.html)
-  + [`ApmD`](/classes/transforms/wvtransformboussinesq/apmd.html)
-  + [`ApmN`](/classes/transforms/wvtransformboussinesq/apmn.html)
+  + [`A0N`](/classes/transforms/wvtransformboussinesq/a0n.html) Projects density displacement onto $$A_0$$.
+  + [`A0U`](/classes/transforms/wvtransformboussinesq/a0u.html) Projects $$u$$ onto $$A_0$$.
+  + [`A0V`](/classes/transforms/wvtransformboussinesq/a0v.html) Projects $$v$$ onto $$A_0$$.
+  + [`A0Z`](/classes/transforms/wvtransformboussinesq/a0z.html) Projects vertical vorticity onto $$A_0$$.
+  + [`ApmD`](/classes/transforms/wvtransformboussinesq/apmd.html) Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
+  + [`ApmN`](/classes/transforms/wvtransformboussinesq/apmn.html) Projects density displacement onto $$A_+$$ and $$A_-$$.
   + [`ApmW`](/classes/transforms/wvtransformboussinesq/apmw.html)
-  + [`Feta`](/classes/transforms/wvtransformboussinesq/feta.html)
-  + [`Fu`](/classes/transforms/wvtransformboussinesq/fu.html)
-  + [`Fv`](/classes/transforms/wvtransformboussinesq/fv.html)
-  + [`NA0`](/classes/transforms/wvtransformboussinesq/na0.html) These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`NAm`](/classes/transforms/wvtransformboussinesq/nam.html) These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`NAp`](/classes/transforms/wvtransformboussinesq/nap.html) These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`P0`](/classes/transforms/wvtransformboussinesq/p0.html) Preconditioner for F, size(P)=[Nj 1]. F*u = uhat, (PF)*u = P*uhat, so ubar==P*uhat
-  + [`PA0`](/classes/transforms/wvtransformboussinesq/pa0.html)
-  + [`Q0`](/classes/transforms/wvtransformboussinesq/q0.html) Preconditioner for G, size(Q)=[Nj 1]. G*eta = etahat, (QG)*eta = Q*etahat, so etabar==Q*etahat.
-  + [`UA0`](/classes/transforms/wvtransformboussinesq/ua0.html) These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`UAm`](/classes/transforms/wvtransformboussinesq/uam.html) These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`UAp`](/classes/transforms/wvtransformboussinesq/uap.html) These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VA0`](/classes/transforms/wvtransformboussinesq/va0.html) These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VAm`](/classes/transforms/wvtransformboussinesq/vam.html) These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VAp`](/classes/transforms/wvtransformboussinesq/vap.html) These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`WAm`](/classes/transforms/wvtransformboussinesq/wam.html) These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`WAp`](/classes/transforms/wvtransformboussinesq/wap.html) These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+  + [`NA0`](/classes/transforms/wvtransformboussinesq/na0.html) Reconstructs density displacement from $$A_0$$.
+  + [`NAm`](/classes/transforms/wvtransformboussinesq/nam.html) Reconstructs density displacement from $$A_-$$.
+  + [`NAp`](/classes/transforms/wvtransformboussinesq/nap.html) Reconstructs density displacement from $$A_+$$.
+  + [`PA0`](/classes/transforms/wvtransformboussinesq/pa0.html) Reconstructs pressure height from $$A_0$$.
+  + [`UA0`](/classes/transforms/wvtransformboussinesq/ua0.html) Reconstructs $$u$$ from $$A_0$$.
+  + [`UAm`](/classes/transforms/wvtransformboussinesq/uam.html) Reconstructs $$u$$ from $$A_-$$.
+  + [`UAp`](/classes/transforms/wvtransformboussinesq/uap.html) Reconstructs $$u$$ from $$A_+$$.
+  + [`VA0`](/classes/transforms/wvtransformboussinesq/va0.html) Reconstructs $$v$$ from $$A_0$$.
+  + [`VAm`](/classes/transforms/wvtransformboussinesq/vam.html) Reconstructs $$v$$ from $$A_-$$.
+  + [`VAp`](/classes/transforms/wvtransformboussinesq/vap.html) Reconstructs $$v$$ from $$A_+$$.
+  + [`WAm`](/classes/transforms/wvtransformboussinesq/wam.html) Reconstructs $$w$$ from $$A_-$$.
+  + [`WAp`](/classes/transforms/wvtransformboussinesq/wap.html) Reconstructs $$w$$ from $$A_+$$.
 + Geometry and mode indexing
-  + [`buildVerticalModeProjectionOperators`](/classes/transforms/wvtransformboussinesq/buildverticalmodeprojectionoperators.html)
-  + [`conjugateDimension`](/classes/transforms/wvtransformboussinesq/conjugatedimension.html) assumed conjugate dimension
-  + [`indexFromKLModeNumber`](/classes/transforms/wvtransformboussinesq/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
-  + [`indexFromModeNumber`](/classes/transforms/wvtransformboussinesq/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
-  + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformboussinesq/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
-  + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformboussinesq/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
-  + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
-  + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
-  + [`isValidKLModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
-  + [`isValidModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
-  + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
-  + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
-  + [`kMode_dft`](/classes/transforms/wvtransformboussinesq/kmode_dft.html) k mode-number on the DFT grid
-  + [`kMode_wv`](/classes/transforms/wvtransformboussinesq/kmode_wv.html) k mode number on the WV grid
-  + [`klModeNumberFromIndex`](/classes/transforms/wvtransformboussinesq/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
-  + [`lMode_dft`](/classes/transforms/wvtransformboussinesq/lmode_dft.html) l mode-number on the DFT grid
-  + [`lMode_wv`](/classes/transforms/wvtransformboussinesq/lmode_wv.html) l mode number on the WV grid
-  + [`maskForAliasedModes`](/classes/transforms/wvtransformboussinesq/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
-  + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformboussinesq/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
-  + [`maskForNyquistModes`](/classes/transforms/wvtransformboussinesq/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
-  + [`modeNumberFromIndex`](/classes/transforms/wvtransformboussinesq/modenumberfromindex.html) Return mode numbers for spectral linear indices.
-  + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformboussinesq/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
-  + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformboussinesq/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
-  + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformboussinesq/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
-  + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformboussinesq/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
-  + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
-  + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Mode numbers and validity
+    + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
+    + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
+    + [`isValidKLModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
+    + [`isValidModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
+    + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
+    + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformboussinesq/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
+    + [`kMode_dft`](/classes/transforms/wvtransformboussinesq/kmode_dft.html) k mode-number on the DFT grid
+    + [`kMode_wv`](/classes/transforms/wvtransformboussinesq/kmode_wv.html) k mode number on the WV grid
+    + [`lMode_dft`](/classes/transforms/wvtransformboussinesq/lmode_dft.html) l mode-number on the DFT grid
+    + [`lMode_wv`](/classes/transforms/wvtransformboussinesq/lmode_wv.html) l mode number on the WV grid
+    + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformboussinesq/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
+  + Linear-index conversion
+    + [`indexFromKLModeNumber`](/classes/transforms/wvtransformboussinesq/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
+    + [`indexFromModeNumber`](/classes/transforms/wvtransformboussinesq/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
+    + [`klModeNumberFromIndex`](/classes/transforms/wvtransformboussinesq/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
+    + [`modeNumberFromIndex`](/classes/transforms/wvtransformboussinesq/modenumberfromindex.html) Return mode numbers for spectral linear indices.
+  + DFT and WV layout metadata
+    + [`Nk_dft`](/classes/transforms/wvtransformboussinesq/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
+    + [`Nl_dft`](/classes/transforms/wvtransformboussinesq/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
+    + [`conjugateDimension`](/classes/transforms/wvtransformboussinesq/conjugatedimension.html) assumed conjugate dimension
+    + [`dftConjugateIndices2D`](/classes/transforms/wvtransformboussinesq/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
+    + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformboussinesq/dftprimaryindices2d.html) index into the DFT grid of each WV mode
+    + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformboussinesq/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
+    + [`k_dft`](/classes/transforms/wvtransformboussinesq/k_dft.html) k wavenumber dimension on the DFT grid
+    + [`kl`](/classes/transforms/wvtransformboussinesq/kl.html) wavenumber dimension
+    + [`l_dft`](/classes/transforms/wvtransformboussinesq/l_dft.html) l wavenumber dimension on the DFT grid
+    + [`shouldExcludeConjugates`](/classes/transforms/wvtransformboussinesq/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
+    + [`shouldExcludeNyquist`](/classes/transforms/wvtransformboussinesq/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
+  + Layout conversion
+    + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformboussinesq/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
+    + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformboussinesq/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
+    + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformboussinesq/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
+    + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformboussinesq/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
+    + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformboussinesq/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
+    + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
+    + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Masks and Hermitian bookkeeping
+    + [`isHermitian`](/classes/transforms/wvtransformboussinesq/ishermitian.html) Check if the matrix is Hermitian. Report errors.
+    + [`maskForAliasedModes`](/classes/transforms/wvtransformboussinesq/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
+    + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformboussinesq/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
+    + [`maskForNyquistModes`](/classes/transforms/wvtransformboussinesq/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
+    + [`setConjugateToUnity`](/classes/transforms/wvtransformboussinesq/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
+  + Additional geometry utilities
+    + [`buildVerticalModeProjectionOperators`](/classes/transforms/wvtransformboussinesq/buildverticalmodeprojectionoperators.html)
 + Spectral transforms and operators
-  + [`FMatrix`](/classes/transforms/wvtransformboussinesq/fmatrix.html) transformation matrix $$F_g$$
-  + [`FinvMatrix`](/classes/transforms/wvtransformboussinesq/finvmatrix.html) transformation matrix $$F_g^{-1}$$
   + [`FwInvMatrix`](/classes/transforms/wvtransformboussinesq/fwinvmatrix.html) transformation matrix $$F_w^{-1}$$
   + [`FwMatrix`](/classes/transforms/wvtransformboussinesq/fwmatrix.html) transformation matrix $$F_w$$
-  + [`GMatrix`](/classes/transforms/wvtransformboussinesq/gmatrix.html) transformation matrix $$G_g$$
-  + [`GinvMatrix`](/classes/transforms/wvtransformboussinesq/ginvmatrix.html) transformation matrix $$G_g^{-1}$$
   + [`GwInvMatrix`](/classes/transforms/wvtransformboussinesq/gwinvmatrix.html) transformation matrix $$G_w^{-1}$$
   + [`GwMatrix`](/classes/transforms/wvtransformboussinesq/gwmatrix.html) transformation matrix $$G_w$$
+  + [`P0`](/classes/transforms/wvtransformboussinesq/p0.html) Preconditioner for F, size(P)=[Nj 1]. F*u = uhat, (PF)*u = P*uhat, so ubar==P*uhat
   + [`PF0`](/classes/transforms/wvtransformboussinesq/pf0.html) size(PF,PG)=[Nj x Nz]
   + [`PF0inv`](/classes/transforms/wvtransformboussinesq/pf0inv.html) Transformation matrices
   + [`PFpm`](/classes/transforms/wvtransformboussinesq/pfpm.html) size(PF,PG)=[Nj x Nz x Nk]
   + [`PFpmInv`](/classes/transforms/wvtransformboussinesq/pfpminv.html) IGW transformation matrices
+  + [`Q0`](/classes/transforms/wvtransformboussinesq/q0.html) Preconditioner for G, size(Q)=[Nj 1]. G*eta = etahat, (QG)*eta = Q*etahat, so etabar==Q*etahat.
   + [`QG0`](/classes/transforms/wvtransformboussinesq/qg0.html) Preconditioned G-mode forward transformation
   + [`QG0inv`](/classes/transforms/wvtransformboussinesq/qg0inv.html) Preconditioned G-mode inverse transformation
   + [`QGpm`](/classes/transforms/wvtransformboussinesq/qgpm.html) Preconditioned G-mode forward transformation
@@ -387,6 +413,9 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainWithGw`](/classes/transforms/wvtransformboussinesq/transformtospatialdomainwithgw.html)
   + [`transformWithG_wg`](/classes/transforms/wvtransformboussinesq/transformwithg_wg.html)
 + Nonlinear flux and forcing internals
+  + [`Feta`](/classes/transforms/wvtransformboussinesq/feta.html)
+  + [`Fu`](/classes/transforms/wvtransformboussinesq/fu.html)
+  + [`Fv`](/classes/transforms/wvtransformboussinesq/fv.html)
   + [`enstrophyFluxFromF0`](/classes/transforms/wvtransformboussinesq/enstrophyfluxfromf0.html)
   + [`fluxForForcing`](/classes/transforms/wvtransformboussinesq/fluxforforcing.html)
   + [`qgpvFluxFromF0`](/classes/transforms/wvtransformboussinesq/qgpvfluxfromf0.html)
@@ -411,28 +440,16 @@ These items document internal implementation details and are not part of the pri
   + [`Ddelta`](/classes/transforms/wvtransformboussinesq/ddelta.html)
   + [`K2unique`](/classes/transforms/wvtransformboussinesq/k2unique.html) unique squared-wavenumbers
   + [`K2uniqueK2Map`](/classes/transforms/wvtransformboussinesq/k2uniquek2map.html) cell array Nk in length. Each cell contains indices back to K2
-  + [`Nk_dft`](/classes/transforms/wvtransformboussinesq/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
-  + [`Nl_dft`](/classes/transforms/wvtransformboussinesq/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
   + [`Ppm`](/classes/transforms/wvtransformboussinesq/ppm.html) Preconditioner for F, size(P)=[Nj x Nk]. F*u = uhat, (PF)*u = P*uhat, so ubar==P*uhat
   + [`Qpm`](/classes/transforms/wvtransformboussinesq/qpm.html) Preconditioner for G, size(Q)=[Nj x Nk]. G*eta = etahat, (QG)*eta = Q*etahat, so etabar==Q*etahat.
   + [`chebfunForZArray`](/classes/transforms/wvtransformboussinesq/chebfunforzarray.html)
   + [`delta_uhat`](/classes/transforms/wvtransformboussinesq/delta_uhat.html)
   + [`delta_vhat`](/classes/transforms/wvtransformboussinesq/delta_vhat.html)
-  + [`dftConjugateIndices2D`](/classes/transforms/wvtransformboussinesq/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformboussinesq/dftprimaryindices2d.html) index into the DFT grid of each WV mode
   + [`iK2unique`](/classes/transforms/wvtransformboussinesq/ik2unique.html) map from 2-dim K2, to 1-dim K2unique
-  + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformboussinesq/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
-  + [`isHermitian`](/classes/transforms/wvtransformboussinesq/ishermitian.html) Check if the matrix is Hermitian. Report errors.
-  + [`k_dft`](/classes/transforms/wvtransformboussinesq/k_dft.html) k wavenumber dimension on the DFT grid
-  + [`kl`](/classes/transforms/wvtransformboussinesq/kl.html) wavenumber dimension
-  + [`l_dft`](/classes/transforms/wvtransformboussinesq/l_dft.html) l wavenumber dimension on the DFT grid
   + [`maxFg`](/classes/transforms/wvtransformboussinesq/maxfg.html)
   + [`maxFw`](/classes/transforms/wvtransformboussinesq/maxfw.html)
   + [`nK2unique`](/classes/transforms/wvtransformboussinesq/nk2unique.html) number of unique squared-wavenumbers
   + [`quadraturePointsForStratifiedFlow`](/classes/transforms/wvtransformboussinesq/quadraturepointsforstratifiedflow.html) return the quadrature points for a given stratification
-  + [`setConjugateToUnity`](/classes/transforms/wvtransformboussinesq/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
-  + [`shouldExcludeConjugates`](/classes/transforms/wvtransformboussinesq/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
-  + [`shouldExcludeNyquist`](/classes/transforms/wvtransformboussinesq/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
   + [`throwErrorIfDensityViolation`](/classes/transforms/wvtransformboussinesq/throwerrorifdensityviolation.html) checks if the proposed coefficients are a valid adiabatic re-arrangement of the base state
   + [`verticalProjectionOperatorsWithRigidLid`](/classes/transforms/wvtransformboussinesq/verticalprojectionoperatorswithrigidlid.html) return the normalized projection operators with prefactors
   + [`wvBuffer`](/classes/transforms/wvtransformboussinesq/wvbuffer.html)

--- a/docs/classes/transforms/wvtransformboussinesq/j.md
+++ b/docs/classes/transforms/wvtransformboussinesq/j.md
@@ -9,13 +9,13 @@ mathjax: true
 
 #  j
 
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 
 ---
 
 ## Discussion
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 `j` is an `Nj`-by-1 column vector of dimensionless nonnegative mode numbers. Three-dimensional rigid-lid transforms include the barotropic index `j=0`; wave motions occupy internal modes with `j>0`.
 

--- a/docs/classes/transforms/wvtransformboussinesq/k.md
+++ b/docs/classes/transforms/wvtransformboussinesq/k.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  k
 
-Stored x-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformboussinesq/kaxis.md
+++ b/docs/classes/transforms/wvtransformboussinesq/kaxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  kAxis
 
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 `kAxis` is an `Nx`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dk`.

--- a/docs/classes/transforms/wvtransformboussinesq/l.md
+++ b/docs/classes/transforms/wvtransformboussinesq/l.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  l
 
-Stored y-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformboussinesq/laxis.md
+++ b/docs/classes/transforms/wvtransformboussinesq/laxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  lAxis
 
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 `lAxis` is an `Ny`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dl`.

--- a/docs/classes/transforms/wvtransformboussinesq/na0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/na0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NA0
 
-These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the density-displacement stat
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Reconstructs density displacement from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/nam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/nam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NAm
 
-These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the density-displacement stat
 ---
 
 ## Discussion
+Reconstructs density displacement from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/nap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/nap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NAp
 
-These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the density-displacement stat
 ---
 
 ## Discussion
+Reconstructs density displacement from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/pa0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/pa0.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  PA0
 
-
+Reconstructs pressure height from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Reconstructs pressure height from $$A_0$$.
+
+`PA0` maps the zero-frequency coefficient array onto the pressure-height anomaly used to evaluate `pi` and pressure.

--- a/docs/classes/transforms/wvtransformboussinesq/rho_bar.md
+++ b/docs/classes/transforms/wvtransformboussinesq/rho_bar.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_bar
 
-mean density
+Current horizontally averaged density, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Current horizontally averaged density, `[Nz 1]`, in kg/m³.
+
+`rho_bar` is the horizontal mean of the density represented by the current transform state, including any mean-density-anomaly contribution.

--- a/docs/classes/transforms/wvtransformboussinesq/rho_nm.md
+++ b/docs/classes/transforms/wvtransformboussinesq/rho_nm.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_nm
 
-no-motion density profile
+Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm` is the statically rearranged no-motion profile diagnosed from the current density field while preserving its density moments.

--- a/docs/classes/transforms/wvtransformboussinesq/rho_nm0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/rho_nm0.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_nm0
 
-No-motion density profile sampled on the vertical grid.
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm0` is the fixed profile supplied when constructing the transform and sampled on the vertical grid.

--- a/docs/classes/transforms/wvtransformboussinesq/totalenergy.md
+++ b/docs/classes/transforms/wvtransformboussinesq/totalenergy.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergy
 
-% - Topic: Energetics
+Total energy computed from wave-vortex coefficients.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from wave-vortex coefficients.
+
 The horizontally-averaged depth-integrated energy computed from the wave-vortex coefficients
 
 $$

--- a/docs/classes/transforms/wvtransformboussinesq/totalenergyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransformboussinesq/totalenergyspatiallyintegrated.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergySpatiallyIntegrated
 
-% - Topic: Energetics
+Total energy computed from physical-space fields.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from physical-space fields.
+
 The horizontally-averaged depth-integrated energy computed in the spatial domain is defined as,
 
 $$

--- a/docs/classes/transforms/wvtransformboussinesq/ua0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/ua0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$u$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/uam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/uam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$u$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/uap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/uap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$u$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/va0.md
+++ b/docs/classes/transforms/wvtransformboussinesq/va0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$v$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/vam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/vam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$v$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/vap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/vap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$v$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/wam.md
+++ b/docs/classes/transforms/wvtransformboussinesq/wam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$w$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$w$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformboussinesq/wap.md
+++ b/docs/classes/transforms/wvtransformboussinesq/wap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$w$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$w$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/a0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0
 
-`A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+Zero-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+Zero-frequency wave–vortex coefficient array.
+
 `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
 
 The geostrophic solutions follow the decomposition in [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The complete basis, including the mean-density-anomaly solution, is described in the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269).

--- a/docs/classes/transforms/wvtransformconstantstratification/a0n.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0n.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0N
 
-These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects density displacement onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the density-displacement state variable onto $
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Projects density displacement onto $$A_0$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/a0u.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0u.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0U
 
-These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$u$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$u$$ onto $$A_0$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/a0v.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0v.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0V
 
-These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$v$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$v$$ onto $$A_0$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/a0z.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/a0z.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  A0Z
 
-
+Projects vertical vorticity onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects vertical vorticity onto $$A_0$$.
+
+`A0Z` maps the vertically transformed relative-vorticity state onto the zero-frequency coefficient array.

--- a/docs/classes/transforms/wvtransformconstantstratification/am.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/am.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Am
 
-`Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
+Negative-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+Negative-frequency wave–vortex coefficient array.
+
 `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the negative-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransformconstantstratification/ap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/ap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Ap
 
-`Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
+Positive-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+Positive-frequency wave–vortex coefficient array.
+
 `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the positive-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransformconstantstratification/apmd.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/apmd.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  ApmD
 
-
+Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
+
+`ApmD` supplies the common divergence contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/docs/classes/transforms/wvtransformconstantstratification/apmn.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/apmn.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  ApmN
 
-
+Projects density displacement onto $$A_+$$ and $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects density displacement onto $$A_+$$ and $$A_-$$.
+
+`ApmN` supplies the signed density-displacement contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/docs/classes/transforms/wvtransformconstantstratification/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/finvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FinvMatrix
 
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 `FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformconstantstratification/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/finvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FinvMatrix
 
-transformation matrix $$F_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+
+`FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformconstantstratification/fmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/fmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FMatrix
 
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformconstantstratification/fmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/fmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FMatrix
 
-transformation matrix $$F_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformconstantstratification/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/ginvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GinvMatrix
 
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 `GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformconstantstratification/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/ginvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GinvMatrix
 
-transformation matrix $$G_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+
+`GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformconstantstratification/gmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/gmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GMatrix
 
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformconstantstratification/gmatrix.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/gmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GMatrix
 
-transformation matrix $$G_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformconstantstratification/index.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/index.md
@@ -116,10 +116,10 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`Lr2`](/classes/transforms/wvtransformconstantstratification/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformconstantstratification/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
     + Vertical-mode transformation matrices
-      + [`FMatrix`](/classes/transforms/wvtransformconstantstratification/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`FinvMatrix`](/classes/transforms/wvtransformconstantstratification/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
-      + [`GMatrix`](/classes/transforms/wvtransformconstantstratification/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`GinvMatrix`](/classes/transforms/wvtransformconstantstratification/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`FMatrix`](/classes/transforms/wvtransformconstantstratification/fmatrix.html) Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformconstantstratification/finvmatrix.html) Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformconstantstratification/gmatrix.html) Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformconstantstratification/ginvmatrix.html) Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformconstantstratification/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformconstantstratification/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.

--- a/docs/classes/transforms/wvtransformconstantstratification/index.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/index.md
@@ -86,19 +86,18 @@ views are `Apt`, `Amt`, and `A0t`.
     + Quadrature and integration
       + [`z_int`](/classes/transforms/wvtransformconstantstratification/z_int.html) Vertical quadrature weights in meters.
   + Spectral grid
-    + Axes and spacing
-      + [`kAxis`](/classes/transforms/wvtransformconstantstratification/kaxis.html) Centered x-direction angular-wavenumber axis.
-      + [`lAxis`](/classes/transforms/wvtransformconstantstratification/laxis.html) Centered y-direction angular-wavenumber axis.
-      + [`j`](/classes/transforms/wvtransformconstantstratification/j.html) Vertical-mode index axis.
-      + [`dk`](/classes/transforms/wvtransformconstantstratification/dk.html) Spacing of the x-direction angular-wavenumber axis.
-      + [`dl`](/classes/transforms/wvtransformconstantstratification/dl.html) Spacing of the y-direction angular-wavenumber axis.
-    + Coordinate arrays
-      + [`k`](/classes/transforms/wvtransformconstantstratification/k.html) Stored x-direction angular wavenumbers on the compact WV grid.
-      + [`l`](/classes/transforms/wvtransformconstantstratification/l.html) Stored y-direction angular wavenumbers on the compact WV grid.
+    + Compact grid vectors
+      + [`k`](/classes/transforms/wvtransformconstantstratification/k.html) Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
+      + [`l`](/classes/transforms/wvtransformconstantstratification/l.html) Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
+      + [`j`](/classes/transforms/wvtransformconstantstratification/j.html) Dimensionless `Nj`-by-1 vertical-mode index vector.
+    + Compact grid arrays
       + [`K`](/classes/transforms/wvtransformconstantstratification/k_.html) X-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`L`](/classes/transforms/wvtransformconstantstratification/l_.html) Y-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`J`](/classes/transforms/wvtransformconstantstratification/j_.html) Dimensionless vertical-mode index array with shape `[Nj Nkl]`.
       + [`kljGrid`](/classes/transforms/wvtransformconstantstratification/kljgrid.html) Return spectral-coordinate arrays in wave-vortex layout.
+    + Wavenumber spacing
+      + [`dk`](/classes/transforms/wvtransformconstantstratification/dk.html) Spacing of the x-direction angular-wavenumber axis.
+      + [`dl`](/classes/transforms/wvtransformconstantstratification/dl.html) Spacing of the y-direction angular-wavenumber axis.
     + Horizontal wavenumber geometry
       + [`Kh`](/classes/transforms/wvtransformconstantstratification/kh.html) Horizontal angular-wavenumber magnitude on the coefficient grid.
       + [`K2`](/classes/transforms/wvtransformconstantstratification/k2.html) Squared horizontal angular wavenumber on the coefficient grid.
@@ -109,12 +108,18 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`effectiveHorizontalGridResolution`](/classes/transforms/wvtransformconstantstratification/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
       + [`effectiveVerticalGridResolution`](/classes/transforms/wvtransformconstantstratification/effectiveverticalgridresolution.html) returns the effective vertical grid resolution in meters
       + [`effectiveJMax`](/classes/transforms/wvtransformconstantstratification/effectivejmax.html) Largest active vertical-mode index.
+      + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformconstantstratification/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
     + Vertical modes and scaling
       + [`verticalModes`](/classes/transforms/wvtransformconstantstratification/verticalmodes.html) Vertical-mode solution used to construct the transform basis.
       + [`h_0`](/classes/transforms/wvtransformconstantstratification/h_0.html) Geostrophic equivalent-depth scale for each vertical mode.
       + [`h_pm`](/classes/transforms/wvtransformconstantstratification/h_pm.html) Wave equivalent depth on the spectral grid.
       + [`Lr2`](/classes/transforms/wvtransformconstantstratification/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformconstantstratification/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
+    + Vertical-mode transformation matrices
+      + [`FMatrix`](/classes/transforms/wvtransformconstantstratification/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformconstantstratification/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformconstantstratification/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformconstantstratification/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformconstantstratification/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformconstantstratification/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.
@@ -170,8 +175,8 @@ views are `Apt`, `Amt`, and `A0t`.
     + Density and displacement
       + [`eta`](/classes/transforms/wvtransformconstantstratification/eta.html) approximate isopycnal deviation
       + [`rho_e`](/classes/transforms/wvtransformconstantstratification/rho_e.html) excess density
-      + [`rho_nm`](/classes/transforms/wvtransformconstantstratification/rho_nm.html) no-motion density profile
-      + [`rho_nm0`](/classes/transforms/wvtransformconstantstratification/rho_nm0.html) No-motion density profile sampled on the vertical grid.
+      + [`rho_nm`](/classes/transforms/wvtransformconstantstratification/rho_nm.html) Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
+      + [`rho_nm0`](/classes/transforms/wvtransformconstantstratification/rho_nm0.html) Reference no-motion density profile, `[Nz 1]`, in kg/m³.
       + [`rho_total`](/classes/transforms/wvtransformconstantstratification/rho_total.html) total potential density
     + Pressure and surface fields
       + [`p`](/classes/transforms/wvtransformconstantstratification/p.html) pressure anomaly
@@ -190,32 +195,22 @@ views are `Apt`, `Amt`, and `A0t`.
   + Isopycnal utilities
     + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformconstantstratification/placeparticlesonisopycnal.html) Return particle depths on the isopycnal identified by a no-motion depth.
 + Manage forcing and closures
-  + [`addForcing`](/classes/transforms/wvtransformconstantstratification/addforcing.html) Add forcing or closure objects to this transform.
-  + [`forcing`](/classes/transforms/wvtransformconstantstratification/forcing.html) array of WVForcing objects
-  + [`forcingNames`](/classes/transforms/wvtransformconstantstratification/forcingnames.html) Return forcing and closure names in application order.
-  + [`forcingWithName`](/classes/transforms/wvtransformconstantstratification/forcingwithname.html) Return registered forcing objects by name.
-  + [`hasClosure`](/classes/transforms/wvtransformconstantstratification/hasclosure.html) Whether a closure is currently attached to the transform.
-  + [`hasForcingWithName`](/classes/transforms/wvtransformconstantstratification/hasforcingwithname.html) Test whether forcing objects are registered by name.
-  + [`removeAllForcing`](/classes/transforms/wvtransformconstantstratification/removeallforcing.html) Remove every forcing and closure from this transform.
-  + [`removeForcing`](/classes/transforms/wvtransformconstantstratification/removeforcing.html) Remove the exact registered forcing objects.
-  + [`setForcing`](/classes/transforms/wvtransformconstantstratification/setforcing.html) Replace the complete forcing registry.
-  + [`summarizeForcing`](/classes/transforms/wvtransformconstantstratification/summarizeforcing.html) Print a table of registered forcing and closure objects.
+  + Configure forcing
+    + [`addForcing`](/classes/transforms/wvtransformconstantstratification/addforcing.html) Add forcing or closure objects to this transform.
+    + [`setForcing`](/classes/transforms/wvtransformconstantstratification/setforcing.html) Replace the complete forcing registry.
+    + [`removeForcing`](/classes/transforms/wvtransformconstantstratification/removeforcing.html) Remove the exact registered forcing objects.
+    + [`removeAllForcing`](/classes/transforms/wvtransformconstantstratification/removeallforcing.html) Remove every forcing and closure from this transform.
+  + Inspect forcing and closures
+    + [`forcing`](/classes/transforms/wvtransformconstantstratification/forcing.html) array of WVForcing objects
+    + [`forcingNames`](/classes/transforms/wvtransformconstantstratification/forcingnames.html) Return forcing and closure names in application order.
+    + [`forcingWithName`](/classes/transforms/wvtransformconstantstratification/forcingwithname.html) Return registered forcing objects by name.
+    + [`hasForcingWithName`](/classes/transforms/wvtransformconstantstratification/hasforcingwithname.html) Test whether forcing objects are registered by name.
+    + [`hasClosure`](/classes/transforms/wvtransformconstantstratification/hasclosure.html) Whether a closure is currently attached to the transform.
+  + Summarize forcing
+    + [`summarizeForcing`](/classes/transforms/wvtransformconstantstratification/summarizeforcing.html) Print a table of registered forcing and closure objects.
 + Analyze the flow
-  + Energy and summaries
-    + [`inertialEnergy`](/classes/transforms/wvtransformconstantstratification/inertialenergy.html) total energy of the inertial flow
-    + [`mdaEnergy`](/classes/transforms/wvtransformconstantstratification/mdaenergy.html) total energy of the mean density anomaly
-    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformconstantstratification/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
-    + [`waveEnergy`](/classes/transforms/wvtransformconstantstratification/waveenergy.html) Total energy of the internal-gravity-wave flow.
-    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformconstantstratification/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
-    + [`geostrophicEnergy`](/classes/transforms/wvtransformconstantstratification/geostrophicenergy.html) total energy, geostrophic
-    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformconstantstratification/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
-    + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformconstantstratification/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
-    + [`summarizeEnergyContent`](/classes/transforms/wvtransformconstantstratification/summarizeenergycontent.html) displays a summary of the energy content of the fluid
-    + [`summarizeModeEnergy`](/classes/transforms/wvtransformconstantstratification/summarizemodeenergy.html) List the most energetic modes
-    + [`totalEnergy`](/classes/transforms/wvtransformconstantstratification/totalenergy.html) % - Topic: Energetics
-    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformconstantstratification/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
-    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformconstantstratification/totalenergyspatiallyintegrated.html) % - Topic: Energetics
   + Flow diagnostics
+    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformconstantstratification/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
     + [`uvMax`](/classes/transforms/wvtransformconstantstratification/uvmax.html) max horizontal fluid speed
     + [`wMax`](/classes/transforms/wvtransformconstantstratification/wmax.html) max vertical fluid speed
   + Density validity
@@ -225,16 +220,33 @@ views are `Apt`, `Amt`, and `A0t`.
     + [`totalEnstrophySpatiallyIntegrated`](/classes/transforms/wvtransformconstantstratification/totalenstrophyspatiallyintegrated.html) Potential enstrophy evaluated from the gridded QGPV field.
   + Spectra
     + Spectral fields
+      + [`kAxis`](/classes/transforms/wvtransformconstantstratification/kaxis.html) Centered `Nx`-by-1 x-wavenumber axis in rad/m.
+      + [`lAxis`](/classes/transforms/wvtransformconstantstratification/laxis.html) Centered `Ny`-by-1 y-wavenumber axis in rad/m.
+      + [`transformToKLAxes`](/classes/transforms/wvtransformconstantstratification/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
       + [`crossSpectrumWithFgTransform`](/classes/transforms/wvtransformconstantstratification/crossspectrumwithfgtransform.html) Compute a real modal cross-spectrum using the F-basis transform.
       + [`crossSpectrumWithGgTransform`](/classes/transforms/wvtransformconstantstratification/crossspectrumwithggtransform.html) Compute a real modal cross-spectrum using the G-basis transform.
       + [`spectrumWithFgTransform`](/classes/transforms/wvtransformconstantstratification/spectrumwithfgtransform.html) Compute a modal autospectrum using the F-basis transform.
       + [`spectrumWithGgTransform`](/classes/transforms/wvtransformconstantstratification/spectrumwithggtransform.html) Compute a modal autospectrum using the G-basis transform.
-      + [`transformToKLAxes`](/classes/transforms/wvtransformconstantstratification/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
     + Radial wavenumber
       + [`kRadial`](/classes/transforms/wvtransformconstantstratification/kradial.html) radial (k,l) wavenumber on the WV grid
       + [`transformToRadialWavenumber`](/classes/transforms/wvtransformconstantstratification/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
     + Frequency
       + [`convertFromWavenumberToFrequency`](/classes/transforms/wvtransformconstantstratification/convertfromwavenumbertofrequency.html) Bin wave energy by vertical mode and intrinsic frequency
++ Analyze energy
+  + Component energy
+    + [`inertialEnergy`](/classes/transforms/wvtransformconstantstratification/inertialenergy.html) total energy of the inertial flow
+    + [`mdaEnergy`](/classes/transforms/wvtransformconstantstratification/mdaenergy.html) total energy of the mean density anomaly
+    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformconstantstratification/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
+    + [`waveEnergy`](/classes/transforms/wvtransformconstantstratification/waveenergy.html) Total energy of the internal-gravity-wave flow.
+    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformconstantstratification/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
+    + [`geostrophicEnergy`](/classes/transforms/wvtransformconstantstratification/geostrophicenergy.html) total energy, geostrophic
+    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformconstantstratification/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
+  + Total energy
+    + [`totalEnergy`](/classes/transforms/wvtransformconstantstratification/totalenergy.html) Total energy computed from wave-vortex coefficients.
+    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformconstantstratification/totalenergyspatiallyintegrated.html) Total energy computed from physical-space fields.
+  + Energy summaries
+    + [`summarizeEnergyContent`](/classes/transforms/wvtransformconstantstratification/summarizeenergycontent.html) displays a summary of the energy content of the fluid
+    + [`summarizeModeEnergy`](/classes/transforms/wvtransformconstantstratification/summarizemodeenergy.html) List the most energetic modes
 + Save transform state
   + [`writeToFile`](/classes/transforms/wvtransformconstantstratification/writetofile.html) Write this instance to NetCDF file.
 + Convert representations
@@ -250,23 +262,26 @@ views are `Apt`, `Amt`, and `A0t`.
   + [`intZF`](/classes/transforms/wvtransformconstantstratification/intzf.html) Return the first antiderivative of an F-representation.
   + [`intZG`](/classes/transforms/wvtransformconstantstratification/intzg.html) Return the bottom-zero first antiderivative of a G-representation.
 + Inspect flow components
-  + [`geostrophicComponent`](/classes/transforms/wvtransformconstantstratification/geostrophiccomponent.html) returns the geostrophic flow component
-  + [`waveComponent`](/classes/transforms/wvtransformconstantstratification/wavecomponent.html) returns the internal gravity wave flow component
-  + [`inertialComponent`](/classes/transforms/wvtransformconstantstratification/inertialcomponent.html) returns the inertial oscillation flow component
-  + [`mdaComponent`](/classes/transforms/wvtransformconstantstratification/mdacomponent.html) returns the mean density anomaly component
-  + [`flowComponentNames`](/classes/transforms/wvtransformconstantstratification/flowcomponentnames.html) retrieve the names of all available variables
-  + [`flowComponentWithName`](/classes/transforms/wvtransformconstantstratification/flowcomponentwithname.html) retrieve a WVFlowComponent by name
-  + [`flowComponents`](/classes/transforms/wvtransformconstantstratification/flowcomponents.html) All registered physical and diagnostic flow components.
-  + [`primaryFlowComponentNames`](/classes/transforms/wvtransformconstantstratification/primaryflowcomponentnames.html) retrieve the names of all available variables
-  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformconstantstratification/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
-  + [`primaryFlowComponents`](/classes/transforms/wvtransformconstantstratification/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
-  + [`summarizeFlowComponents`](/classes/transforms/wvtransformconstantstratification/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
-  + [`totalFlowComponent`](/classes/transforms/wvtransformconstantstratification/totalflowcomponent.html) Combined view of all primary flow components.
+  + Primary flow components
+    + [`waveComponent`](/classes/transforms/wvtransformconstantstratification/wavecomponent.html) returns the internal gravity wave flow component
+    + [`inertialComponent`](/classes/transforms/wvtransformconstantstratification/inertialcomponent.html) returns the inertial oscillation flow component
+    + [`geostrophicComponent`](/classes/transforms/wvtransformconstantstratification/geostrophiccomponent.html) returns the geostrophic flow component
+    + [`mdaComponent`](/classes/transforms/wvtransformconstantstratification/mdacomponent.html) returns the mean density anomaly component
+    + [`primaryFlowComponents`](/classes/transforms/wvtransformconstantstratification/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
+    + [`primaryFlowComponentNames`](/classes/transforms/wvtransformconstantstratification/primaryflowcomponentnames.html) retrieve the names of all available variables
+    + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformconstantstratification/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
+  + Registered and combined components
+    + [`flowComponents`](/classes/transforms/wvtransformconstantstratification/flowcomponents.html) All registered physical and diagnostic flow components.
+    + [`flowComponentNames`](/classes/transforms/wvtransformconstantstratification/flowcomponentnames.html) retrieve the names of all available variables
+    + [`flowComponentWithName`](/classes/transforms/wvtransformconstantstratification/flowcomponentwithname.html) retrieve a WVFlowComponent by name
+    + [`totalFlowComponent`](/classes/transforms/wvtransformconstantstratification/totalflowcomponent.html) Combined view of all primary flow components.
+  + Summarize flow components
+    + [`summarizeFlowComponents`](/classes/transforms/wvtransformconstantstratification/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
 + Inspect wave-vortex coefficients
   + Stored coefficients
-    + [`Ap`](/classes/transforms/wvtransformconstantstratification/ap.html) `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`Am`](/classes/transforms/wvtransformconstantstratification/am.html) `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`A0`](/classes/transforms/wvtransformconstantstratification/a0.html) `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+    + [`Ap`](/classes/transforms/wvtransformconstantstratification/ap.html) Positive-frequency wave–vortex coefficient array.
+    + [`Am`](/classes/transforms/wvtransformconstantstratification/am.html) Negative-frequency wave–vortex coefficient array.
+    + [`A0`](/classes/transforms/wvtransformconstantstratification/a0.html) Zero-frequency wave–vortex coefficient array.
   + Coefficients at the current time
     + [`Apt`](/classes/transforms/wvtransformconstantstratification/apt.html) `Apt` is the positive-frequency coefficient array evaluated at the current transform time:
     + [`Amt`](/classes/transforms/wvtransformconstantstratification/amt.html) `Amt` is the negative-frequency coefficient array evaluated at the current transform time:
@@ -299,68 +314,79 @@ views are `Apt`, `Amt`, and `A0t`.
 ## Developer Topics
 These items document internal implementation details and are not part of the primary public API.
 + Projection and reconstruction coefficients
-  + [`A0N`](/classes/transforms/wvtransformconstantstratification/a0n.html) These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0U`](/classes/transforms/wvtransformconstantstratification/a0u.html) These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0V`](/classes/transforms/wvtransformconstantstratification/a0v.html) These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0Z`](/classes/transforms/wvtransformconstantstratification/a0z.html)
-  + [`ApmD`](/classes/transforms/wvtransformconstantstratification/apmd.html)
+  + [`A0N`](/classes/transforms/wvtransformconstantstratification/a0n.html) Projects density displacement onto $$A_0$$.
+  + [`A0U`](/classes/transforms/wvtransformconstantstratification/a0u.html) Projects $$u$$ onto $$A_0$$.
+  + [`A0V`](/classes/transforms/wvtransformconstantstratification/a0v.html) Projects $$v$$ onto $$A_0$$.
+  + [`A0Z`](/classes/transforms/wvtransformconstantstratification/a0z.html) Projects vertical vorticity onto $$A_0$$.
+  + [`ApmD`](/classes/transforms/wvtransformconstantstratification/apmd.html) Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
   + [`ApmD_scaled`](/classes/transforms/wvtransformconstantstratification/apmd_scaled.html)
-  + [`ApmN`](/classes/transforms/wvtransformconstantstratification/apmn.html)
+  + [`ApmN`](/classes/transforms/wvtransformconstantstratification/apmn.html) Projects density displacement onto $$A_+$$ and $$A_-$$.
   + [`ApmW_scaled`](/classes/transforms/wvtransformconstantstratification/apmw_scaled.html)
-  + [`Feta`](/classes/transforms/wvtransformconstantstratification/feta.html)
-  + [`Fu`](/classes/transforms/wvtransformconstantstratification/fu.html)
-  + [`Fv`](/classes/transforms/wvtransformconstantstratification/fv.html)
-  + [`NA0`](/classes/transforms/wvtransformconstantstratification/na0.html) These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`NAm`](/classes/transforms/wvtransformconstantstratification/nam.html) These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`NAp`](/classes/transforms/wvtransformconstantstratification/nap.html) These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`PA0`](/classes/transforms/wvtransformconstantstratification/pa0.html)
-  + [`UA0`](/classes/transforms/wvtransformconstantstratification/ua0.html) These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`UAm`](/classes/transforms/wvtransformconstantstratification/uam.html) These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`UAp`](/classes/transforms/wvtransformconstantstratification/uap.html) These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VA0`](/classes/transforms/wvtransformconstantstratification/va0.html) These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VAm`](/classes/transforms/wvtransformconstantstratification/vam.html) These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VAp`](/classes/transforms/wvtransformconstantstratification/vap.html) These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`WAm`](/classes/transforms/wvtransformconstantstratification/wam.html) These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`WAp`](/classes/transforms/wvtransformconstantstratification/wap.html) These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+  + [`NA0`](/classes/transforms/wvtransformconstantstratification/na0.html) Reconstructs density displacement from $$A_0$$.
+  + [`NAm`](/classes/transforms/wvtransformconstantstratification/nam.html) Reconstructs density displacement from $$A_-$$.
+  + [`NAp`](/classes/transforms/wvtransformconstantstratification/nap.html) Reconstructs density displacement from $$A_+$$.
+  + [`PA0`](/classes/transforms/wvtransformconstantstratification/pa0.html) Reconstructs pressure height from $$A_0$$.
+  + [`UA0`](/classes/transforms/wvtransformconstantstratification/ua0.html) Reconstructs $$u$$ from $$A_0$$.
+  + [`UAm`](/classes/transforms/wvtransformconstantstratification/uam.html) Reconstructs $$u$$ from $$A_-$$.
+  + [`UAp`](/classes/transforms/wvtransformconstantstratification/uap.html) Reconstructs $$u$$ from $$A_+$$.
+  + [`VA0`](/classes/transforms/wvtransformconstantstratification/va0.html) Reconstructs $$v$$ from $$A_0$$.
+  + [`VAm`](/classes/transforms/wvtransformconstantstratification/vam.html) Reconstructs $$v$$ from $$A_-$$.
+  + [`VAp`](/classes/transforms/wvtransformconstantstratification/vap.html) Reconstructs $$v$$ from $$A_+$$.
+  + [`WAm`](/classes/transforms/wvtransformconstantstratification/wam.html) Reconstructs $$w$$ from $$A_-$$.
+  + [`WAp`](/classes/transforms/wvtransformconstantstratification/wap.html) Reconstructs $$w$$ from $$A_+$$.
 + Geometry and mode indexing
-  + [`buildVerticalModeProjectionOperators`](/classes/transforms/wvtransformconstantstratification/buildverticalmodeprojectionoperators.html) Build the transformation matrices
-  + [`conjugateDimension`](/classes/transforms/wvtransformconstantstratification/conjugatedimension.html) assumed conjugate dimension
-  + [`indexFromKLModeNumber`](/classes/transforms/wvtransformconstantstratification/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
-  + [`indexFromModeNumber`](/classes/transforms/wvtransformconstantstratification/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
-  + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformconstantstratification/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
-  + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformconstantstratification/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
-  + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
-  + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
-  + [`isValidKLModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
-  + [`isValidModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
-  + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
-  + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
-  + [`kMode_dft`](/classes/transforms/wvtransformconstantstratification/kmode_dft.html) k mode-number on the DFT grid
-  + [`kMode_wv`](/classes/transforms/wvtransformconstantstratification/kmode_wv.html) k mode number on the WV grid
-  + [`klModeNumberFromIndex`](/classes/transforms/wvtransformconstantstratification/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
-  + [`lMode_dft`](/classes/transforms/wvtransformconstantstratification/lmode_dft.html) l mode-number on the DFT grid
-  + [`lMode_wv`](/classes/transforms/wvtransformconstantstratification/lmode_wv.html) l mode number on the WV grid
-  + [`maskForAliasedModes`](/classes/transforms/wvtransformconstantstratification/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
-  + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformconstantstratification/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
-  + [`maskForNyquistModes`](/classes/transforms/wvtransformconstantstratification/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
-  + [`modeNumberFromIndex`](/classes/transforms/wvtransformconstantstratification/modenumberfromindex.html) Return mode numbers for spectral linear indices.
-  + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformconstantstratification/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
-  + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformconstantstratification/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
-  + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
-  + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
-  + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
-  + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Mode numbers and validity
+    + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
+    + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
+    + [`isValidKLModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
+    + [`isValidModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
+    + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
+    + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformconstantstratification/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
+    + [`kMode_dft`](/classes/transforms/wvtransformconstantstratification/kmode_dft.html) k mode-number on the DFT grid
+    + [`kMode_wv`](/classes/transforms/wvtransformconstantstratification/kmode_wv.html) k mode number on the WV grid
+    + [`lMode_dft`](/classes/transforms/wvtransformconstantstratification/lmode_dft.html) l mode-number on the DFT grid
+    + [`lMode_wv`](/classes/transforms/wvtransformconstantstratification/lmode_wv.html) l mode number on the WV grid
+    + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformconstantstratification/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
+  + Linear-index conversion
+    + [`indexFromKLModeNumber`](/classes/transforms/wvtransformconstantstratification/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
+    + [`indexFromModeNumber`](/classes/transforms/wvtransformconstantstratification/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
+    + [`klModeNumberFromIndex`](/classes/transforms/wvtransformconstantstratification/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
+    + [`modeNumberFromIndex`](/classes/transforms/wvtransformconstantstratification/modenumberfromindex.html) Return mode numbers for spectral linear indices.
+  + DFT and WV layout metadata
+    + [`Nk_dft`](/classes/transforms/wvtransformconstantstratification/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
+    + [`Nl_dft`](/classes/transforms/wvtransformconstantstratification/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
+    + [`conjugateDimension`](/classes/transforms/wvtransformconstantstratification/conjugatedimension.html) assumed conjugate dimension
+    + [`dftConjugateIndices2D`](/classes/transforms/wvtransformconstantstratification/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
+    + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformconstantstratification/dftprimaryindices2d.html) index into the DFT grid of each WV mode
+    + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformconstantstratification/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
+    + [`k_dft`](/classes/transforms/wvtransformconstantstratification/k_dft.html) k wavenumber dimension on the DFT grid
+    + [`kl`](/classes/transforms/wvtransformconstantstratification/kl.html) wavenumber dimension
+    + [`l_dft`](/classes/transforms/wvtransformconstantstratification/l_dft.html) l wavenumber dimension on the DFT grid
+    + [`shouldExcludeConjugates`](/classes/transforms/wvtransformconstantstratification/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
+    + [`shouldExcludeNyquist`](/classes/transforms/wvtransformconstantstratification/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
+  + Layout conversion
+    + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformconstantstratification/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
+    + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformconstantstratification/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
+    + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformconstantstratification/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
+    + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
+    + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
+    + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
+    + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Masks and Hermitian bookkeeping
+    + [`isHermitian`](/classes/transforms/wvtransformconstantstratification/ishermitian.html) Check if the matrix is Hermitian. Report errors.
+    + [`maskForAliasedModes`](/classes/transforms/wvtransformconstantstratification/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
+    + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformconstantstratification/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
+    + [`maskForNyquistModes`](/classes/transforms/wvtransformconstantstratification/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
+    + [`setConjugateToUnity`](/classes/transforms/wvtransformconstantstratification/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
+  + Additional geometry utilities
+    + [`buildVerticalModeProjectionOperators`](/classes/transforms/wvtransformconstantstratification/buildverticalmodeprojectionoperators.html) Build the transformation matrices
 + Spectral transforms and operators
   + [`CosineTransformBackMatrix`](/classes/transforms/wvtransformconstantstratification/cosinetransformbackmatrix.html) Discrete Cosine Transform (DCT-I) matrix
   + [`CosineTransformForwardMatrix`](/classes/transforms/wvtransformconstantstratification/cosinetransformforwardmatrix.html) Discrete Cosine Transform (DCT-I) matrix
   + [`DCT`](/classes/transforms/wvtransformconstantstratification/dct.html)
   + [`DST`](/classes/transforms/wvtransformconstantstratification/dst.html)
-  + [`FMatrix`](/classes/transforms/wvtransformconstantstratification/fmatrix.html) transformation matrix $$F_g$$
-  + [`FinvMatrix`](/classes/transforms/wvtransformconstantstratification/finvmatrix.html) transformation matrix $$F_g^{-1}$$
   + [`FwInvMatrix`](/classes/transforms/wvtransformconstantstratification/fwinvmatrix.html) transformation matrix $$F_w^{-1}$$
   + [`FwMatrix`](/classes/transforms/wvtransformconstantstratification/fwmatrix.html) transformation matrix $$F_w$$
-  + [`GMatrix`](/classes/transforms/wvtransformconstantstratification/gmatrix.html) transformation matrix $$G_g$$
-  + [`GinvMatrix`](/classes/transforms/wvtransformconstantstratification/ginvmatrix.html) transformation matrix $$G_g^{-1}$$
   + [`GwInvMatrix`](/classes/transforms/wvtransformconstantstratification/gwinvmatrix.html) transformation matrix $$G_w^{-1}$$
   + [`GwMatrix`](/classes/transforms/wvtransformconstantstratification/gwmatrix.html) transformation matrix $$G_w$$
   + [`SineTransformBackMatrix`](/classes/transforms/wvtransformconstantstratification/sinetransformbackmatrix.html) CosineTransformBackMatrix  Discrete Cosine Transform (DCT-I) matrix
@@ -377,6 +403,9 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainWithFourierAtPosition`](/classes/transforms/wvtransformconstantstratification/transformtospatialdomainwithfourieratposition.html)
   + [`transformWithG_wg`](/classes/transforms/wvtransformconstantstratification/transformwithg_wg.html)
 + Nonlinear flux and forcing internals
+  + [`Feta`](/classes/transforms/wvtransformconstantstratification/feta.html)
+  + [`Fu`](/classes/transforms/wvtransformconstantstratification/fu.html)
+  + [`Fv`](/classes/transforms/wvtransformconstantstratification/fv.html)
   + [`enstrophyFluxFromF0`](/classes/transforms/wvtransformconstantstratification/enstrophyfluxfromf0.html)
   + [`fluxForForcing`](/classes/transforms/wvtransformconstantstratification/fluxforforcing.html)
   + [`nonlinearFluxFunction`](/classes/transforms/wvtransformconstantstratification/nonlinearfluxfunction.html)
@@ -405,23 +434,11 @@ These items document internal implementation details and are not part of the pri
   + [`F_wg`](/classes/transforms/wvtransformconstantstratification/f_wg.html)
   + [`G_g`](/classes/transforms/wvtransformconstantstratification/g_g.html)
   + [`G_wg`](/classes/transforms/wvtransformconstantstratification/g_wg.html)
-  + [`Nk_dft`](/classes/transforms/wvtransformconstantstratification/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
-  + [`Nl_dft`](/classes/transforms/wvtransformconstantstratification/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
   + [`chebfunForZArray`](/classes/transforms/wvtransformconstantstratification/chebfunforzarray.html)
   + [`cos_alpha`](/classes/transforms/wvtransformconstantstratification/cos_alpha.html)
-  + [`dftConjugateIndices2D`](/classes/transforms/wvtransformconstantstratification/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformconstantstratification/dftprimaryindices2d.html) index into the DFT grid of each WV mode
-  + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformconstantstratification/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
-  + [`isHermitian`](/classes/transforms/wvtransformconstantstratification/ishermitian.html) Check if the matrix is Hermitian. Report errors.
-  + [`k_dft`](/classes/transforms/wvtransformconstantstratification/k_dft.html) k wavenumber dimension on the DFT grid
-  + [`kl`](/classes/transforms/wvtransformconstantstratification/kl.html) wavenumber dimension
-  + [`l_dft`](/classes/transforms/wvtransformconstantstratification/l_dft.html) l wavenumber dimension on the DFT grid
   + [`maxFg`](/classes/transforms/wvtransformconstantstratification/maxfg.html)
   + [`maxFw`](/classes/transforms/wvtransformconstantstratification/maxfw.html)
   + [`quadraturePointsForStratifiedFlow`](/classes/transforms/wvtransformconstantstratification/quadraturepointsforstratifiedflow.html) return the quadrature points for a given stratification
-  + [`setConjugateToUnity`](/classes/transforms/wvtransformconstantstratification/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
-  + [`shouldExcludeConjugates`](/classes/transforms/wvtransformconstantstratification/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
-  + [`shouldExcludeNyquist`](/classes/transforms/wvtransformconstantstratification/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
   + [`sin_alpha`](/classes/transforms/wvtransformconstantstratification/sin_alpha.html)
   + [`throwErrorIfDensityViolation`](/classes/transforms/wvtransformconstantstratification/throwerrorifdensityviolation.html) checks if the proposed coefficients are a valid adiabatic re-arrangement of the base state
   + [`verticalProjectionOperatorsWithRigidLid`](/classes/transforms/wvtransformconstantstratification/verticalprojectionoperatorswithrigidlid.html) return the normalized projection operators with prefactors

--- a/docs/classes/transforms/wvtransformconstantstratification/j.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/j.md
@@ -9,13 +9,13 @@ mathjax: true
 
 #  j
 
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 
 ---
 
 ## Discussion
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 `j` is an `Nj`-by-1 column vector of dimensionless nonnegative mode numbers. Three-dimensional rigid-lid transforms include the barotropic index `j=0`; wave motions occupy internal modes with `j>0`.
 

--- a/docs/classes/transforms/wvtransformconstantstratification/k.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/k.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  k
 
-Stored x-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformconstantstratification/kaxis.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/kaxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  kAxis
 
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 `kAxis` is an `Nx`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dk`.

--- a/docs/classes/transforms/wvtransformconstantstratification/l.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/l.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  l
 
-Stored y-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformconstantstratification/laxis.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/laxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  lAxis
 
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 `lAxis` is an `Ny`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dl`.

--- a/docs/classes/transforms/wvtransformconstantstratification/na0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/na0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NA0
 
-These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the density-displacement stat
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Reconstructs density displacement from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/nam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/nam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NAm
 
-These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the density-displacement stat
 ---
 
 ## Discussion
+Reconstructs density displacement from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/nap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/nap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NAp
 
-These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the density-displacement stat
 ---
 
 ## Discussion
+Reconstructs density displacement from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/pa0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/pa0.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  PA0
 
-
+Reconstructs pressure height from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Reconstructs pressure height from $$A_0$$.
+
+`PA0` maps the zero-frequency coefficient array onto the pressure-height anomaly used to evaluate `pi` and pressure.

--- a/docs/classes/transforms/wvtransformconstantstratification/rho_nm.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/rho_nm.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_nm
 
-no-motion density profile
+Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm` is the statically rearranged no-motion profile diagnosed from the current density field while preserving its density moments.

--- a/docs/classes/transforms/wvtransformconstantstratification/rho_nm0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/rho_nm0.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_nm0
 
-No-motion density profile sampled on the vertical grid.
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm0` is the fixed profile supplied when constructing the transform and sampled on the vertical grid.

--- a/docs/classes/transforms/wvtransformconstantstratification/totalenergy.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/totalenergy.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergy
 
-% - Topic: Energetics
+Total energy computed from wave-vortex coefficients.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from wave-vortex coefficients.
+
 The horizontally-averaged depth-integrated energy computed from the wave-vortex coefficients
 
 $$

--- a/docs/classes/transforms/wvtransformconstantstratification/totalenergyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/totalenergyspatiallyintegrated.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergySpatiallyIntegrated
 
-% - Topic: Energetics
+Total energy computed from physical-space fields.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from physical-space fields.
+
 The horizontally-averaged depth-integrated energy computed in the spatial domain is defined as,
 
 $$

--- a/docs/classes/transforms/wvtransformconstantstratification/ua0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/ua0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$u$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/uam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/uam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$u$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/uap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/uap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$u$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/va0.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/va0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$v$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/vam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/vam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$v$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/vap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/vap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$v$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/wam.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$w$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$w$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformconstantstratification/wap.md
+++ b/docs/classes/transforms/wvtransformconstantstratification/wap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$w$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$w$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/a0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0
 
-`A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+Zero-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+Zero-frequency wave–vortex coefficient array.
+
 `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
 
 The geostrophic solutions follow the decomposition in [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The complete basis, including the mean-density-anomaly solution, is described in the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269).

--- a/docs/classes/transforms/wvtransformhydrostatic/a0n.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0n.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0N
 
-These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects density displacement onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the density-displacement state variable onto $
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Projects density displacement onto $$A_0$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/a0u.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0u.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0U
 
-These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$u$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$u$$ onto $$A_0$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/a0v.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0v.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0V
 
-These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$v$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$v$$ onto $$A_0$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/a0z.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/a0z.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  A0Z
 
-
+Projects vertical vorticity onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects vertical vorticity onto $$A_0$$.
+
+`A0Z` maps the vertically transformed relative-vorticity state onto the zero-frequency coefficient array.

--- a/docs/classes/transforms/wvtransformhydrostatic/am.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/am.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Am
 
-`Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
+Negative-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+Negative-frequency wave–vortex coefficient array.
+
 `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the negative-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransformhydrostatic/ap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/ap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  Ap
 
-`Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
+Positive-frequency wave–vortex coefficient array.
 
 
 ---
@@ -18,6 +18,8 @@ mathjax: true
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m/s$$.
 
 ## Discussion
+Positive-frequency wave–vortex coefficient array.
+
 `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
 
 These coefficients multiply the positive-frequency wave solutions described by [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995) and the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269). The internal-gravity-wave and inertial-oscillation solutions appear as equations (3.18) and (3.15), respectively, in the 2021 paper.

--- a/docs/classes/transforms/wvtransformhydrostatic/apmd.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/apmd.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  ApmD
 
-
+Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
+
+`ApmD` supplies the common divergence contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/docs/classes/transforms/wvtransformhydrostatic/apmn.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/apmn.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  ApmN
 
-
+Projects density displacement onto $$A_+$$ and $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects density displacement onto $$A_+$$ and $$A_-$$.
+
+`ApmN` supplies the signed density-displacement contribution used when recovering the positive- and negative-frequency wave coefficients from physical fields.

--- a/docs/classes/transforms/wvtransformhydrostatic/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/finvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FinvMatrix
 
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 `FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformhydrostatic/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/finvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FinvMatrix
 
-transformation matrix $$F_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+
+`FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformhydrostatic/fmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/fmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FMatrix
 
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformhydrostatic/fmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/fmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FMatrix
 
-transformation matrix $$F_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformhydrostatic/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/ginvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GinvMatrix
 
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 `GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformhydrostatic/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/ginvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GinvMatrix
 
-transformation matrix $$G_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+
+`GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformhydrostatic/gmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/gmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GMatrix
 
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformhydrostatic/gmatrix.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/gmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GMatrix
 
-transformation matrix $$G_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformhydrostatic/index.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/index.md
@@ -117,10 +117,10 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`Lr2`](/classes/transforms/wvtransformhydrostatic/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformhydrostatic/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
     + Vertical-mode transformation matrices
-      + [`FMatrix`](/classes/transforms/wvtransformhydrostatic/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`FinvMatrix`](/classes/transforms/wvtransformhydrostatic/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
-      + [`GMatrix`](/classes/transforms/wvtransformhydrostatic/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`GinvMatrix`](/classes/transforms/wvtransformhydrostatic/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`FMatrix`](/classes/transforms/wvtransformhydrostatic/fmatrix.html) Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformhydrostatic/finvmatrix.html) Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformhydrostatic/gmatrix.html) Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformhydrostatic/ginvmatrix.html) Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformhydrostatic/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformhydrostatic/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.

--- a/docs/classes/transforms/wvtransformhydrostatic/index.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/index.md
@@ -87,19 +87,18 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`z_int`](/classes/transforms/wvtransformhydrostatic/z_int.html) Vertical quadrature weights in meters.
       + [`volumeIntegral`](/classes/transforms/wvtransformhydrostatic/volumeintegral.html) Compute the horizontally averaged depth integral of a scalar field.
   + Spectral grid
-    + Axes and spacing
-      + [`kAxis`](/classes/transforms/wvtransformhydrostatic/kaxis.html) Centered x-direction angular-wavenumber axis.
-      + [`lAxis`](/classes/transforms/wvtransformhydrostatic/laxis.html) Centered y-direction angular-wavenumber axis.
-      + [`j`](/classes/transforms/wvtransformhydrostatic/j.html) Vertical-mode index axis.
-      + [`dk`](/classes/transforms/wvtransformhydrostatic/dk.html) Spacing of the x-direction angular-wavenumber axis.
-      + [`dl`](/classes/transforms/wvtransformhydrostatic/dl.html) Spacing of the y-direction angular-wavenumber axis.
-    + Coordinate arrays
-      + [`k`](/classes/transforms/wvtransformhydrostatic/k.html) Stored x-direction angular wavenumbers on the compact WV grid.
-      + [`l`](/classes/transforms/wvtransformhydrostatic/l.html) Stored y-direction angular wavenumbers on the compact WV grid.
+    + Compact grid vectors
+      + [`k`](/classes/transforms/wvtransformhydrostatic/k.html) Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
+      + [`l`](/classes/transforms/wvtransformhydrostatic/l.html) Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
+      + [`j`](/classes/transforms/wvtransformhydrostatic/j.html) Dimensionless `Nj`-by-1 vertical-mode index vector.
+    + Compact grid arrays
       + [`K`](/classes/transforms/wvtransformhydrostatic/k_.html) X-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`L`](/classes/transforms/wvtransformhydrostatic/l_.html) Y-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`J`](/classes/transforms/wvtransformhydrostatic/j_.html) Dimensionless vertical-mode index array with shape `[Nj Nkl]`.
       + [`kljGrid`](/classes/transforms/wvtransformhydrostatic/kljgrid.html) Return spectral-coordinate arrays in wave-vortex layout.
+    + Wavenumber spacing
+      + [`dk`](/classes/transforms/wvtransformhydrostatic/dk.html) Spacing of the x-direction angular-wavenumber axis.
+      + [`dl`](/classes/transforms/wvtransformhydrostatic/dl.html) Spacing of the y-direction angular-wavenumber axis.
     + Horizontal wavenumber geometry
       + [`Kh`](/classes/transforms/wvtransformhydrostatic/kh.html) Horizontal angular-wavenumber magnitude on the coefficient grid.
       + [`K2`](/classes/transforms/wvtransformhydrostatic/k2.html) Squared horizontal angular wavenumber on the coefficient grid.
@@ -110,12 +109,18 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`effectiveHorizontalGridResolution`](/classes/transforms/wvtransformhydrostatic/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
       + [`effectiveVerticalGridResolution`](/classes/transforms/wvtransformhydrostatic/effectiveverticalgridresolution.html) returns the effective vertical grid resolution in meters
       + [`effectiveJMax`](/classes/transforms/wvtransformhydrostatic/effectivejmax.html) Largest active vertical-mode index.
+      + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformhydrostatic/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
     + Vertical modes and scaling
       + [`verticalModes`](/classes/transforms/wvtransformhydrostatic/verticalmodes.html) Vertical-mode solution used to construct the transform basis.
       + [`h_0`](/classes/transforms/wvtransformhydrostatic/h_0.html) Geostrophic equivalent-depth scale for each vertical mode.
       + [`h_pm`](/classes/transforms/wvtransformhydrostatic/h_pm.html) Wave equivalent depth on the spectral grid.
       + [`Lr2`](/classes/transforms/wvtransformhydrostatic/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformhydrostatic/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
+    + Vertical-mode transformation matrices
+      + [`FMatrix`](/classes/transforms/wvtransformhydrostatic/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformhydrostatic/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformhydrostatic/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformhydrostatic/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformhydrostatic/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformhydrostatic/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.
@@ -170,10 +175,10 @@ views are `Apt`, `Amt`, and `A0t`.
       + [`w`](/classes/transforms/wvtransformhydrostatic/w.html) z-component of the fluid velocity
     + Density and displacement
       + [`eta`](/classes/transforms/wvtransformhydrostatic/eta.html) approximate isopycnal deviation
-      + [`rho_bar`](/classes/transforms/wvtransformhydrostatic/rho_bar.html) mean density
+      + [`rho_bar`](/classes/transforms/wvtransformhydrostatic/rho_bar.html) Current horizontally averaged density, `[Nz 1]`, in kg/m³.
       + [`rho_e`](/classes/transforms/wvtransformhydrostatic/rho_e.html) excess density
-      + [`rho_nm`](/classes/transforms/wvtransformhydrostatic/rho_nm.html) no-motion density profile
-      + [`rho_nm0`](/classes/transforms/wvtransformhydrostatic/rho_nm0.html) No-motion density profile sampled on the vertical grid.
+      + [`rho_nm`](/classes/transforms/wvtransformhydrostatic/rho_nm.html) Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
+      + [`rho_nm0`](/classes/transforms/wvtransformhydrostatic/rho_nm0.html) Reference no-motion density profile, `[Nz 1]`, in kg/m³.
       + [`rho_total`](/classes/transforms/wvtransformhydrostatic/rho_total.html) total potential density
     + Pressure and surface fields
       + [`p`](/classes/transforms/wvtransformhydrostatic/p.html) pressure anomaly
@@ -192,33 +197,22 @@ views are `Apt`, `Amt`, and `A0t`.
   + Isopycnal utilities
     + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformhydrostatic/placeparticlesonisopycnal.html) Return particle depths on the isopycnal identified by a no-motion depth.
 + Manage forcing and closures
-  + [`addForcing`](/classes/transforms/wvtransformhydrostatic/addforcing.html) Add forcing or closure objects to this transform.
-  + [`forcing`](/classes/transforms/wvtransformhydrostatic/forcing.html) array of WVForcing objects
-  + [`forcingNames`](/classes/transforms/wvtransformhydrostatic/forcingnames.html) Return forcing and closure names in application order.
-  + [`forcingWithName`](/classes/transforms/wvtransformhydrostatic/forcingwithname.html) Return registered forcing objects by name.
-  + [`hasClosure`](/classes/transforms/wvtransformhydrostatic/hasclosure.html) Whether a closure is currently attached to the transform.
-  + [`hasForcingWithName`](/classes/transforms/wvtransformhydrostatic/hasforcingwithname.html) Test whether forcing objects are registered by name.
-  + [`removeAllForcing`](/classes/transforms/wvtransformhydrostatic/removeallforcing.html) Remove every forcing and closure from this transform.
-  + [`removeForcing`](/classes/transforms/wvtransformhydrostatic/removeforcing.html) Remove the exact registered forcing objects.
-  + [`setForcing`](/classes/transforms/wvtransformhydrostatic/setforcing.html) Replace the complete forcing registry.
-  + [`summarizeForcing`](/classes/transforms/wvtransformhydrostatic/summarizeforcing.html) Print a table of registered forcing and closure objects.
+  + Configure forcing
+    + [`addForcing`](/classes/transforms/wvtransformhydrostatic/addforcing.html) Add forcing or closure objects to this transform.
+    + [`setForcing`](/classes/transforms/wvtransformhydrostatic/setforcing.html) Replace the complete forcing registry.
+    + [`removeForcing`](/classes/transforms/wvtransformhydrostatic/removeforcing.html) Remove the exact registered forcing objects.
+    + [`removeAllForcing`](/classes/transforms/wvtransformhydrostatic/removeallforcing.html) Remove every forcing and closure from this transform.
+  + Inspect forcing and closures
+    + [`forcing`](/classes/transforms/wvtransformhydrostatic/forcing.html) array of WVForcing objects
+    + [`forcingNames`](/classes/transforms/wvtransformhydrostatic/forcingnames.html) Return forcing and closure names in application order.
+    + [`forcingWithName`](/classes/transforms/wvtransformhydrostatic/forcingwithname.html) Return registered forcing objects by name.
+    + [`hasForcingWithName`](/classes/transforms/wvtransformhydrostatic/hasforcingwithname.html) Test whether forcing objects are registered by name.
+    + [`hasClosure`](/classes/transforms/wvtransformhydrostatic/hasclosure.html) Whether a closure is currently attached to the transform.
+  + Summarize forcing
+    + [`summarizeForcing`](/classes/transforms/wvtransformhydrostatic/summarizeforcing.html) Print a table of registered forcing and closure objects.
 + Analyze the flow
-  + Energy and summaries
-    + [`inertialEnergy`](/classes/transforms/wvtransformhydrostatic/inertialenergy.html) total energy of the inertial flow
-    + [`mdaEnergy`](/classes/transforms/wvtransformhydrostatic/mdaenergy.html) total energy of the mean density anomaly
-    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformhydrostatic/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
-    + [`waveEnergy`](/classes/transforms/wvtransformhydrostatic/waveenergy.html) Total energy of the internal-gravity-wave flow.
-    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformhydrostatic/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
-    + [`exactTotalEnergy`](/classes/transforms/wvtransformhydrostatic/exacttotalenergy.html) Nonlinear total energy evaluated from physical-space fields.
-    + [`geostrophicEnergy`](/classes/transforms/wvtransformhydrostatic/geostrophicenergy.html) total energy, geostrophic
-    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformhydrostatic/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
-    + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformhydrostatic/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
-    + [`summarizeEnergyContent`](/classes/transforms/wvtransformhydrostatic/summarizeenergycontent.html) displays a summary of the energy content of the fluid
-    + [`summarizeModeEnergy`](/classes/transforms/wvtransformhydrostatic/summarizemodeenergy.html) List the most energetic modes
-    + [`totalEnergy`](/classes/transforms/wvtransformhydrostatic/totalenergy.html) % - Topic: Energetics
-    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformhydrostatic/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
-    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformhydrostatic/totalenergyspatiallyintegrated.html) % - Topic: Energetics
   + Flow diagnostics
+    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformhydrostatic/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
     + [`uvMax`](/classes/transforms/wvtransformhydrostatic/uvmax.html) max horizontal fluid speed
     + [`wMax`](/classes/transforms/wvtransformhydrostatic/wmax.html) max vertical fluid speed
   + Density validity
@@ -229,16 +223,34 @@ views are `Apt`, `Amt`, and `A0t`.
     + [`totalEnstrophySpatiallyIntegrated`](/classes/transforms/wvtransformhydrostatic/totalenstrophyspatiallyintegrated.html) Potential enstrophy evaluated from the gridded QGPV field.
   + Spectra
     + Spectral fields
+      + [`kAxis`](/classes/transforms/wvtransformhydrostatic/kaxis.html) Centered `Nx`-by-1 x-wavenumber axis in rad/m.
+      + [`lAxis`](/classes/transforms/wvtransformhydrostatic/laxis.html) Centered `Ny`-by-1 y-wavenumber axis in rad/m.
+      + [`transformToKLAxes`](/classes/transforms/wvtransformhydrostatic/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
       + [`crossSpectrumWithFgTransform`](/classes/transforms/wvtransformhydrostatic/crossspectrumwithfgtransform.html) Compute a real modal cross-spectrum using the F-basis transform.
       + [`crossSpectrumWithGgTransform`](/classes/transforms/wvtransformhydrostatic/crossspectrumwithggtransform.html) Compute a real modal cross-spectrum using the G-basis transform.
       + [`spectrumWithFgTransform`](/classes/transforms/wvtransformhydrostatic/spectrumwithfgtransform.html) Compute a modal autospectrum using the F-basis transform.
       + [`spectrumWithGgTransform`](/classes/transforms/wvtransformhydrostatic/spectrumwithggtransform.html) Compute a modal autospectrum using the G-basis transform.
-      + [`transformToKLAxes`](/classes/transforms/wvtransformhydrostatic/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
     + Radial wavenumber
       + [`kRadial`](/classes/transforms/wvtransformhydrostatic/kradial.html) radial (k,l) wavenumber on the WV grid
       + [`transformToRadialWavenumber`](/classes/transforms/wvtransformhydrostatic/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
     + Frequency
       + [`convertFromWavenumberToFrequency`](/classes/transforms/wvtransformhydrostatic/convertfromwavenumbertofrequency.html) Bin wave energy by vertical mode and intrinsic frequency
++ Analyze energy
+  + Component energy
+    + [`inertialEnergy`](/classes/transforms/wvtransformhydrostatic/inertialenergy.html) total energy of the inertial flow
+    + [`mdaEnergy`](/classes/transforms/wvtransformhydrostatic/mdaenergy.html) total energy of the mean density anomaly
+    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformhydrostatic/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
+    + [`waveEnergy`](/classes/transforms/wvtransformhydrostatic/waveenergy.html) Total energy of the internal-gravity-wave flow.
+    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformhydrostatic/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
+    + [`geostrophicEnergy`](/classes/transforms/wvtransformhydrostatic/geostrophicenergy.html) total energy, geostrophic
+    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformhydrostatic/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
+  + Total energy
+    + [`exactTotalEnergy`](/classes/transforms/wvtransformhydrostatic/exacttotalenergy.html) Nonlinear total energy evaluated from physical-space fields.
+    + [`totalEnergy`](/classes/transforms/wvtransformhydrostatic/totalenergy.html) Total energy computed from wave-vortex coefficients.
+    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformhydrostatic/totalenergyspatiallyintegrated.html) Total energy computed from physical-space fields.
+  + Energy summaries
+    + [`summarizeEnergyContent`](/classes/transforms/wvtransformhydrostatic/summarizeenergycontent.html) displays a summary of the energy content of the fluid
+    + [`summarizeModeEnergy`](/classes/transforms/wvtransformhydrostatic/summarizemodeenergy.html) List the most energetic modes
 + Save transform state
   + [`writeToFile`](/classes/transforms/wvtransformhydrostatic/writetofile.html) Write this instance to NetCDF file.
 + Convert representations
@@ -253,23 +265,26 @@ views are `Apt`, `Amt`, and `A0t`.
   + [`intZF`](/classes/transforms/wvtransformhydrostatic/intzf.html) Return the first antiderivative of an F-representation.
   + [`intZG`](/classes/transforms/wvtransformhydrostatic/intzg.html) Return the bottom-zero first antiderivative of a G-representation.
 + Inspect flow components
-  + [`geostrophicComponent`](/classes/transforms/wvtransformhydrostatic/geostrophiccomponent.html) returns the geostrophic flow component
-  + [`waveComponent`](/classes/transforms/wvtransformhydrostatic/wavecomponent.html) returns the internal gravity wave flow component
-  + [`inertialComponent`](/classes/transforms/wvtransformhydrostatic/inertialcomponent.html) returns the inertial oscillation flow component
-  + [`mdaComponent`](/classes/transforms/wvtransformhydrostatic/mdacomponent.html) returns the mean density anomaly component
-  + [`flowComponentNames`](/classes/transforms/wvtransformhydrostatic/flowcomponentnames.html) retrieve the names of all available variables
-  + [`flowComponentWithName`](/classes/transforms/wvtransformhydrostatic/flowcomponentwithname.html) retrieve a WVFlowComponent by name
-  + [`flowComponents`](/classes/transforms/wvtransformhydrostatic/flowcomponents.html) All registered physical and diagnostic flow components.
-  + [`primaryFlowComponentNames`](/classes/transforms/wvtransformhydrostatic/primaryflowcomponentnames.html) retrieve the names of all available variables
-  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformhydrostatic/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
-  + [`primaryFlowComponents`](/classes/transforms/wvtransformhydrostatic/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
-  + [`summarizeFlowComponents`](/classes/transforms/wvtransformhydrostatic/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
-  + [`totalFlowComponent`](/classes/transforms/wvtransformhydrostatic/totalflowcomponent.html) Combined view of all primary flow components.
+  + Primary flow components
+    + [`waveComponent`](/classes/transforms/wvtransformhydrostatic/wavecomponent.html) returns the internal gravity wave flow component
+    + [`inertialComponent`](/classes/transforms/wvtransformhydrostatic/inertialcomponent.html) returns the inertial oscillation flow component
+    + [`geostrophicComponent`](/classes/transforms/wvtransformhydrostatic/geostrophiccomponent.html) returns the geostrophic flow component
+    + [`mdaComponent`](/classes/transforms/wvtransformhydrostatic/mdacomponent.html) returns the mean density anomaly component
+    + [`primaryFlowComponents`](/classes/transforms/wvtransformhydrostatic/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
+    + [`primaryFlowComponentNames`](/classes/transforms/wvtransformhydrostatic/primaryflowcomponentnames.html) retrieve the names of all available variables
+    + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformhydrostatic/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
+  + Registered and combined components
+    + [`flowComponents`](/classes/transforms/wvtransformhydrostatic/flowcomponents.html) All registered physical and diagnostic flow components.
+    + [`flowComponentNames`](/classes/transforms/wvtransformhydrostatic/flowcomponentnames.html) retrieve the names of all available variables
+    + [`flowComponentWithName`](/classes/transforms/wvtransformhydrostatic/flowcomponentwithname.html) retrieve a WVFlowComponent by name
+    + [`totalFlowComponent`](/classes/transforms/wvtransformhydrostatic/totalflowcomponent.html) Combined view of all primary flow components.
+  + Summarize flow components
+    + [`summarizeFlowComponents`](/classes/transforms/wvtransformhydrostatic/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
 + Inspect wave-vortex coefficients
   + Stored coefficients
-    + [`Ap`](/classes/transforms/wvtransformhydrostatic/ap.html) `Ap` stores the positive-frequency coefficients $$A_+^{k\ell j}$$ for internal gravity waves and the positive-frequency member of the paired inertial representation. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`Am`](/classes/transforms/wvtransformhydrostatic/am.html) `Am` stores the negative-frequency coefficients $$A_-^{k\ell j}$$ for internal gravity waves and inertial oscillations. The coefficients have units of velocity and use the transform's spectral layout.
-    + [`A0`](/classes/transforms/wvtransformhydrostatic/a0.html) `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
+    + [`Ap`](/classes/transforms/wvtransformhydrostatic/ap.html) Positive-frequency wave–vortex coefficient array.
+    + [`Am`](/classes/transforms/wvtransformhydrostatic/am.html) Negative-frequency wave–vortex coefficient array.
+    + [`A0`](/classes/transforms/wvtransformhydrostatic/a0.html) Zero-frequency wave–vortex coefficient array.
   + Coefficients at the current time
     + [`Apt`](/classes/transforms/wvtransformhydrostatic/apt.html) `Apt` is the positive-frequency coefficient array evaluated at the current transform time:
     + [`Amt`](/classes/transforms/wvtransformhydrostatic/amt.html) `Amt` is the negative-frequency coefficient array evaluated at the current transform time:
@@ -303,63 +318,73 @@ views are `Apt`, `Amt`, and `A0t`.
 ## Developer Topics
 These items document internal implementation details and are not part of the primary public API.
 + Projection and reconstruction coefficients
-  + [`A0N`](/classes/transforms/wvtransformhydrostatic/a0n.html) These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0U`](/classes/transforms/wvtransformhydrostatic/a0u.html) These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0V`](/classes/transforms/wvtransformhydrostatic/a0v.html) These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0Z`](/classes/transforms/wvtransformhydrostatic/a0z.html)
-  + [`ApmD`](/classes/transforms/wvtransformhydrostatic/apmd.html)
-  + [`ApmN`](/classes/transforms/wvtransformhydrostatic/apmn.html)
-  + [`Feta`](/classes/transforms/wvtransformhydrostatic/feta.html)
-  + [`Fu`](/classes/transforms/wvtransformhydrostatic/fu.html)
-  + [`Fv`](/classes/transforms/wvtransformhydrostatic/fv.html)
-  + [`NA0`](/classes/transforms/wvtransformhydrostatic/na0.html) These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`NAm`](/classes/transforms/wvtransformhydrostatic/nam.html) These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`NAp`](/classes/transforms/wvtransformhydrostatic/nap.html) These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`P0`](/classes/transforms/wvtransformhydrostatic/p0.html) Preconditioner for F, size(P)=[Nj 1]. F*u = uhat, (PF)*u = P*uhat, so ubar==P*uhat
-  + [`PA0`](/classes/transforms/wvtransformhydrostatic/pa0.html)
-  + [`Q0`](/classes/transforms/wvtransformhydrostatic/q0.html) Preconditioner for G, size(Q)=[Nj 1]. G*eta = etahat, (QG)*eta = Q*etahat, so etabar==Q*etahat.
-  + [`UA0`](/classes/transforms/wvtransformhydrostatic/ua0.html) These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`UAm`](/classes/transforms/wvtransformhydrostatic/uam.html) These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`UAp`](/classes/transforms/wvtransformhydrostatic/uap.html) These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VA0`](/classes/transforms/wvtransformhydrostatic/va0.html) These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VAm`](/classes/transforms/wvtransformhydrostatic/vam.html) These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VAp`](/classes/transforms/wvtransformhydrostatic/vap.html) These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`WAm`](/classes/transforms/wvtransformhydrostatic/wam.html) These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`WAp`](/classes/transforms/wvtransformhydrostatic/wap.html) These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+  + [`A0N`](/classes/transforms/wvtransformhydrostatic/a0n.html) Projects density displacement onto $$A_0$$.
+  + [`A0U`](/classes/transforms/wvtransformhydrostatic/a0u.html) Projects $$u$$ onto $$A_0$$.
+  + [`A0V`](/classes/transforms/wvtransformhydrostatic/a0v.html) Projects $$v$$ onto $$A_0$$.
+  + [`A0Z`](/classes/transforms/wvtransformhydrostatic/a0z.html) Projects vertical vorticity onto $$A_0$$.
+  + [`ApmD`](/classes/transforms/wvtransformhydrostatic/apmd.html) Projects horizontal divergence onto $$A_+$$ and $$A_-$$.
+  + [`ApmN`](/classes/transforms/wvtransformhydrostatic/apmn.html) Projects density displacement onto $$A_+$$ and $$A_-$$.
+  + [`NA0`](/classes/transforms/wvtransformhydrostatic/na0.html) Reconstructs density displacement from $$A_0$$.
+  + [`NAm`](/classes/transforms/wvtransformhydrostatic/nam.html) Reconstructs density displacement from $$A_-$$.
+  + [`NAp`](/classes/transforms/wvtransformhydrostatic/nap.html) Reconstructs density displacement from $$A_+$$.
+  + [`PA0`](/classes/transforms/wvtransformhydrostatic/pa0.html) Reconstructs pressure height from $$A_0$$.
+  + [`UA0`](/classes/transforms/wvtransformhydrostatic/ua0.html) Reconstructs $$u$$ from $$A_0$$.
+  + [`UAm`](/classes/transforms/wvtransformhydrostatic/uam.html) Reconstructs $$u$$ from $$A_-$$.
+  + [`UAp`](/classes/transforms/wvtransformhydrostatic/uap.html) Reconstructs $$u$$ from $$A_+$$.
+  + [`VA0`](/classes/transforms/wvtransformhydrostatic/va0.html) Reconstructs $$v$$ from $$A_0$$.
+  + [`VAm`](/classes/transforms/wvtransformhydrostatic/vam.html) Reconstructs $$v$$ from $$A_-$$.
+  + [`VAp`](/classes/transforms/wvtransformhydrostatic/vap.html) Reconstructs $$v$$ from $$A_+$$.
+  + [`WAm`](/classes/transforms/wvtransformhydrostatic/wam.html) Reconstructs $$w$$ from $$A_-$$.
+  + [`WAp`](/classes/transforms/wvtransformhydrostatic/wap.html) Reconstructs $$w$$ from $$A_+$$.
 + Geometry and mode indexing
-  + [`conjugateDimension`](/classes/transforms/wvtransformhydrostatic/conjugatedimension.html) assumed conjugate dimension
-  + [`indexFromKLModeNumber`](/classes/transforms/wvtransformhydrostatic/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
-  + [`indexFromModeNumber`](/classes/transforms/wvtransformhydrostatic/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
-  + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformhydrostatic/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
-  + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformhydrostatic/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
-  + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
-  + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
-  + [`isValidKLModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
-  + [`isValidModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
-  + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
-  + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
-  + [`kMode_dft`](/classes/transforms/wvtransformhydrostatic/kmode_dft.html) k mode-number on the DFT grid
-  + [`kMode_wv`](/classes/transforms/wvtransformhydrostatic/kmode_wv.html) k mode number on the WV grid
-  + [`klModeNumberFromIndex`](/classes/transforms/wvtransformhydrostatic/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
-  + [`lMode_dft`](/classes/transforms/wvtransformhydrostatic/lmode_dft.html) l mode-number on the DFT grid
-  + [`lMode_wv`](/classes/transforms/wvtransformhydrostatic/lmode_wv.html) l mode number on the WV grid
-  + [`maskForAliasedModes`](/classes/transforms/wvtransformhydrostatic/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
-  + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformhydrostatic/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
-  + [`maskForNyquistModes`](/classes/transforms/wvtransformhydrostatic/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
-  + [`modeNumberFromIndex`](/classes/transforms/wvtransformhydrostatic/modenumberfromindex.html) Return mode numbers for spectral linear indices.
-  + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformhydrostatic/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
-  + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformhydrostatic/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
-  + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformhydrostatic/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
-  + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformhydrostatic/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
-  + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
-  + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Mode numbers and validity
+    + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
+    + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
+    + [`isValidKLModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
+    + [`isValidModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
+    + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
+    + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformhydrostatic/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
+    + [`kMode_dft`](/classes/transforms/wvtransformhydrostatic/kmode_dft.html) k mode-number on the DFT grid
+    + [`kMode_wv`](/classes/transforms/wvtransformhydrostatic/kmode_wv.html) k mode number on the WV grid
+    + [`lMode_dft`](/classes/transforms/wvtransformhydrostatic/lmode_dft.html) l mode-number on the DFT grid
+    + [`lMode_wv`](/classes/transforms/wvtransformhydrostatic/lmode_wv.html) l mode number on the WV grid
+    + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformhydrostatic/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
+  + Linear-index conversion
+    + [`indexFromKLModeNumber`](/classes/transforms/wvtransformhydrostatic/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
+    + [`indexFromModeNumber`](/classes/transforms/wvtransformhydrostatic/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
+    + [`klModeNumberFromIndex`](/classes/transforms/wvtransformhydrostatic/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
+    + [`modeNumberFromIndex`](/classes/transforms/wvtransformhydrostatic/modenumberfromindex.html) Return mode numbers for spectral linear indices.
+  + DFT and WV layout metadata
+    + [`Nk_dft`](/classes/transforms/wvtransformhydrostatic/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
+    + [`Nl_dft`](/classes/transforms/wvtransformhydrostatic/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
+    + [`conjugateDimension`](/classes/transforms/wvtransformhydrostatic/conjugatedimension.html) assumed conjugate dimension
+    + [`dftConjugateIndices2D`](/classes/transforms/wvtransformhydrostatic/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
+    + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformhydrostatic/dftprimaryindices2d.html) index into the DFT grid of each WV mode
+    + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformhydrostatic/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
+    + [`k_dft`](/classes/transforms/wvtransformhydrostatic/k_dft.html) k wavenumber dimension on the DFT grid
+    + [`kl`](/classes/transforms/wvtransformhydrostatic/kl.html) wavenumber dimension
+    + [`l_dft`](/classes/transforms/wvtransformhydrostatic/l_dft.html) l wavenumber dimension on the DFT grid
+    + [`shouldExcludeConjugates`](/classes/transforms/wvtransformhydrostatic/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
+    + [`shouldExcludeNyquist`](/classes/transforms/wvtransformhydrostatic/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
+  + Layout conversion
+    + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformhydrostatic/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
+    + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformhydrostatic/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
+    + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformhydrostatic/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
+    + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformhydrostatic/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
+    + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformhydrostatic/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
+    + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
+    + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformhydrostatic/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Masks and Hermitian bookkeeping
+    + [`isHermitian`](/classes/transforms/wvtransformhydrostatic/ishermitian.html) Check if the matrix is Hermitian. Report errors.
+    + [`maskForAliasedModes`](/classes/transforms/wvtransformhydrostatic/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
+    + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformhydrostatic/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
+    + [`maskForNyquistModes`](/classes/transforms/wvtransformhydrostatic/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
+    + [`setConjugateToUnity`](/classes/transforms/wvtransformhydrostatic/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
 + Spectral transforms and operators
-  + [`FMatrix`](/classes/transforms/wvtransformhydrostatic/fmatrix.html) transformation matrix $$F_g$$
-  + [`FinvMatrix`](/classes/transforms/wvtransformhydrostatic/finvmatrix.html) transformation matrix $$F_g^{-1}$$
-  + [`GMatrix`](/classes/transforms/wvtransformhydrostatic/gmatrix.html) transformation matrix $$G_g$$
-  + [`GinvMatrix`](/classes/transforms/wvtransformhydrostatic/ginvmatrix.html) transformation matrix $$G_g^{-1}$$
+  + [`P0`](/classes/transforms/wvtransformhydrostatic/p0.html) Preconditioner for F, size(P)=[Nj 1]. F*u = uhat, (PF)*u = P*uhat, so ubar==P*uhat
   + [`PF0`](/classes/transforms/wvtransformhydrostatic/pf0.html) size(PF,PG)=[Nj x Nz]
   + [`PF0inv`](/classes/transforms/wvtransformhydrostatic/pf0inv.html) Transformation matrices
+  + [`Q0`](/classes/transforms/wvtransformhydrostatic/q0.html) Preconditioner for G, size(Q)=[Nj 1]. G*eta = etahat, (QG)*eta = Q*etahat, so etabar==Q*etahat.
   + [`QG0`](/classes/transforms/wvtransformhydrostatic/qg0.html) Preconditioned G-mode forward transformation
   + [`QG0inv`](/classes/transforms/wvtransformhydrostatic/qg0inv.html) Preconditioned G-mode inverse transformation
   + [`degreesOfFreedomForComplexMatrix`](/classes/transforms/wvtransformhydrostatic/degreesoffreedomforcomplexmatrix.html) a matrix with the number of degrees-of-freedom at each entry
@@ -371,6 +396,9 @@ These items document internal implementation details and are not part of the pri
   + [`transformToSpatialDomainWithFourierAtPosition`](/classes/transforms/wvtransformhydrostatic/transformtospatialdomainwithfourieratposition.html)
   + [`transformWithG_wg`](/classes/transforms/wvtransformhydrostatic/transformwithg_wg.html)
 + Nonlinear flux and forcing internals
+  + [`Feta`](/classes/transforms/wvtransformhydrostatic/feta.html)
+  + [`Fu`](/classes/transforms/wvtransformhydrostatic/fu.html)
+  + [`Fv`](/classes/transforms/wvtransformhydrostatic/fv.html)
   + [`enstrophyFluxFromF0`](/classes/transforms/wvtransformhydrostatic/enstrophyfluxfromf0.html)
   + [`fluxAtTimeCellArray`](/classes/transforms/wvtransformhydrostatic/fluxattimecellarray.html) y0 is a 3x1 cell array
   + [`fluxForForcing`](/classes/transforms/wvtransformhydrostatic/fluxforforcing.html)
@@ -395,22 +423,10 @@ These items document internal implementation details and are not part of the pri
   + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformhydrostatic/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
   + [`propertyAnnotationsForRotatingFPlane`](/classes/transforms/wvtransformhydrostatic/propertyannotationsforrotatingfplane.html)
 + Class internals
-  + [`Nk_dft`](/classes/transforms/wvtransformhydrostatic/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
-  + [`Nl_dft`](/classes/transforms/wvtransformhydrostatic/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
   + [`chebfunForZArray`](/classes/transforms/wvtransformhydrostatic/chebfunforzarray.html)
-  + [`dftConjugateIndices2D`](/classes/transforms/wvtransformhydrostatic/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformhydrostatic/dftprimaryindices2d.html) index into the DFT grid of each WV mode
-  + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformhydrostatic/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
-  + [`isHermitian`](/classes/transforms/wvtransformhydrostatic/ishermitian.html) Check if the matrix is Hermitian. Report errors.
-  + [`k_dft`](/classes/transforms/wvtransformhydrostatic/k_dft.html) k wavenumber dimension on the DFT grid
-  + [`kl`](/classes/transforms/wvtransformhydrostatic/kl.html) wavenumber dimension
-  + [`l_dft`](/classes/transforms/wvtransformhydrostatic/l_dft.html) l wavenumber dimension on the DFT grid
   + [`maxFg`](/classes/transforms/wvtransformhydrostatic/maxfg.html)
   + [`maxFw`](/classes/transforms/wvtransformhydrostatic/maxfw.html)
   + [`quadraturePointsForStratifiedFlow`](/classes/transforms/wvtransformhydrostatic/quadraturepointsforstratifiedflow.html) return the quadrature points for a given stratification
-  + [`setConjugateToUnity`](/classes/transforms/wvtransformhydrostatic/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
-  + [`shouldExcludeConjugates`](/classes/transforms/wvtransformhydrostatic/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
-  + [`shouldExcludeNyquist`](/classes/transforms/wvtransformhydrostatic/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
   + [`throwErrorIfDensityViolation`](/classes/transforms/wvtransformhydrostatic/throwerrorifdensityviolation.html) checks if the proposed coefficients are a valid adiabatic re-arrangement of the base state
   + [`verticalProjectionOperatorsWithRigidLid`](/classes/transforms/wvtransformhydrostatic/verticalprojectionoperatorswithrigidlid.html) return the normalized projection operators with prefactors
 

--- a/docs/classes/transforms/wvtransformhydrostatic/j.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/j.md
@@ -9,13 +9,13 @@ mathjax: true
 
 #  j
 
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 
 ---
 
 ## Discussion
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 `j` is an `Nj`-by-1 column vector of dimensionless nonnegative mode numbers. Three-dimensional rigid-lid transforms include the barotropic index `j=0`; wave motions occupy internal modes with `j>0`.
 

--- a/docs/classes/transforms/wvtransformhydrostatic/k.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/k.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  k
 
-Stored x-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformhydrostatic/kaxis.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/kaxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  kAxis
 
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 `kAxis` is an `Nx`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dk`.

--- a/docs/classes/transforms/wvtransformhydrostatic/l.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/l.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  l
 
-Stored y-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformhydrostatic/laxis.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/laxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  lAxis
 
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 `lAxis` is an `Ny`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dl`.

--- a/docs/classes/transforms/wvtransformhydrostatic/na0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/na0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NA0
 
-These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the density-displacement stat
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Reconstructs density displacement from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/nam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/nam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NAm
 
-These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the density-displacement stat
 ---
 
 ## Discussion
+Reconstructs density displacement from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/nap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/nap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NAp
 
-These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the density-displacement stat
 ---
 
 ## Discussion
+Reconstructs density displacement from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/pa0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/pa0.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  PA0
 
-
+Reconstructs pressure height from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Reconstructs pressure height from $$A_0$$.
+
+`PA0` maps the zero-frequency coefficient array onto the pressure-height anomaly used to evaluate `pi` and pressure.

--- a/docs/classes/transforms/wvtransformhydrostatic/rho_bar.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/rho_bar.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_bar
 
-mean density
+Current horizontally averaged density, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Current horizontally averaged density, `[Nz 1]`, in kg/m³.
+
+`rho_bar` is the horizontal mean of the density represented by the current transform state, including any mean-density-anomaly contribution.

--- a/docs/classes/transforms/wvtransformhydrostatic/rho_nm.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/rho_nm.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_nm
 
-no-motion density profile
+Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Diagnosed no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm` is the statically rearranged no-motion profile diagnosed from the current density field while preserving its density moments.

--- a/docs/classes/transforms/wvtransformhydrostatic/rho_nm0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/rho_nm0.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_nm0
 
-No-motion density profile sampled on the vertical grid.
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm0` is the fixed profile supplied when constructing the transform and sampled on the vertical grid.

--- a/docs/classes/transforms/wvtransformhydrostatic/totalenergy.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/totalenergy.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergy
 
-% - Topic: Energetics
+Total energy computed from wave-vortex coefficients.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from wave-vortex coefficients.
+
 The horizontally-averaged depth-integrated energy computed from the wave-vortex coefficients
 
 $$

--- a/docs/classes/transforms/wvtransformhydrostatic/totalenergyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/totalenergyspatiallyintegrated.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergySpatiallyIntegrated
 
-% - Topic: Energetics
+Total energy computed from physical-space fields.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from physical-space fields.
+
 The horizontally-averaged depth-integrated energy computed in the spatial domain is defined as,
 
 $$

--- a/docs/classes/transforms/wvtransformhydrostatic/ua0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/ua0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$u$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/uam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/uam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$u$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/uap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/uap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$u$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/va0.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/va0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$v$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/vam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/vam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$v$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/vap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/vap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$v$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/wam.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/wam.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WAm
 
-These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$w$$ from $$A_-$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$w$$ from $$A_-$$.
+
 These reconstruction coefficients map $$A_-$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 2 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformhydrostatic/wap.md
+++ b/docs/classes/transforms/wvtransformhydrostatic/wap.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  WAp
 
-These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$w$$ from $$A_+$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -17,6 +17,8 @@ These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In 
 ---
 
 ## Discussion
+Reconstructs $$w$$ from $$A_+$$.
+
 These reconstruction coefficients map $$A_+$$ onto the $$w$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 4, column 1 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0.md
@@ -18,6 +18,8 @@ Zero-frequency geostrophic coefficients.
 Complex valued property with dimensions $$(j,kl)$$ and units of $$m^2 s^{-1}$$.
 
 ## Discussion
+Zero-frequency wave–vortex coefficient array.
+
 `A0` stores the zero-frequency coefficients $$A_0^{k\ell j}$$ with units of streamfunction, $$\mathrm{m^2\,s^{-1}}$$. It is the active coefficient family for geostrophic and quasigeostrophic flow and, on transforms that include it, the mean-density anomaly.
 
 The geostrophic solutions follow the decomposition in [Early, Lelong, and Sundermeyer (2021)](https://doi.org/10.1017/jfm.2020.995). The complete basis, including the mean-density-anomaly solution, is described in the current [available-potential-vorticity formulation](https://doi.org/10.48550/arXiv.2403.20269).

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0n.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0n.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0N
 
-These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects density displacement onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the density-displacement state variable onto $
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Projects density displacement onto $$A_0$$.
+
 These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0u.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0u.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0U
 
-These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$u$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$u$$ onto $$A_0$$.
+
 These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0v.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0v.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  A0V
 
-These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
+Projects $$v$$ onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s$$.
 
 ## Discussion
+Projects $$v$$ onto $$A_0$$.
+
 These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
 
 For $$k^2+l^2>0, j>0$$ (from either equation B14 or C5) this is written as,

--- a/docs/classes/transforms/wvtransformstratifiedqg/a0z.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/a0z.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  A0Z
 
-
+Projects vertical vorticity onto $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Projects vertical vorticity onto $$A_0$$.
+
+`A0Z` maps the vertically transformed relative-vorticity state onto the zero-frequency coefficient array.

--- a/docs/classes/transforms/wvtransformstratifiedqg/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/finvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FinvMatrix
 
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
 
 `FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformstratifiedqg/finvmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/finvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FinvMatrix
 
-transformation matrix $$F_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+
+`FinvMatrix` maps F-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformstratifiedqg/fmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/fmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  FMatrix
 
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformstratifiedqg/fmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/fmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  FMatrix
 
-transformation matrix $$F_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`FMatrix` maps a column sampled on the physical vertical grid into coefficients of the F vertical-mode basis.

--- a/docs/classes/transforms/wvtransformstratifiedqg/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/ginvmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GinvMatrix
 
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 
 ---
@@ -18,6 +18,6 @@ Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 Real valued property with dimensions $$(z,j)$$ and no units.
 
 ## Discussion
-Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
 
 `GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformstratifiedqg/ginvmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/ginvmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GinvMatrix
 
-transformation matrix $$G_g^{-1}$$
-
-> Developer documentation: this item describes internal implementation details.
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(z,j)$$ and no units.
+
+## Discussion
+Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+
+`GinvMatrix` maps G-basis modal coefficients back to values on the physical vertical grid.

--- a/docs/classes/transforms/wvtransformstratifiedqg/gmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/gmatrix.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  GMatrix
 
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 
 ---
@@ -18,6 +18,6 @@ Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 Real valued property with dimensions $$(j,z)$$ and no units.
 
 ## Discussion
-Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
 
 `GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformstratifiedqg/gmatrix.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/gmatrix.md
@@ -9,12 +9,15 @@ mathjax: true
 
 #  GMatrix
 
-transformation matrix $$G_g$$
-
-> Developer documentation: this item describes internal implementation details.
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
 
 
 ---
 
 ## Description
 Real valued property with dimensions $$(j,z)$$ and no units.
+
+## Discussion
+Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+
+`GMatrix` maps a column sampled on the physical vertical grid into coefficients of the G vertical-mode basis.

--- a/docs/classes/transforms/wvtransformstratifiedqg/index.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/index.md
@@ -114,10 +114,10 @@ The quasigeostrophic state is stored in
       + [`Lr2`](/classes/transforms/wvtransformstratifiedqg/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformstratifiedqg/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
     + Vertical-mode transformation matrices
-      + [`FMatrix`](/classes/transforms/wvtransformstratifiedqg/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`FinvMatrix`](/classes/transforms/wvtransformstratifiedqg/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
-      + [`GMatrix`](/classes/transforms/wvtransformstratifiedqg/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
-      + [`GinvMatrix`](/classes/transforms/wvtransformstratifiedqg/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`FMatrix`](/classes/transforms/wvtransformstratifiedqg/fmatrix.html) Transformation matrix $$F$$ projecting F-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformstratifiedqg/finvmatrix.html) Transformation matrix $$F^{-1}$$ reconstructing F-grid values from vertical modes; shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformstratifiedqg/gmatrix.html) Transformation matrix $$G$$ projecting G-grid values onto vertical modes; shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformstratifiedqg/ginvmatrix.html) Transformation matrix $$G^{-1}$$ reconstructing G-grid values from vertical modes; shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformstratifiedqg/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformstratifiedqg/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.

--- a/docs/classes/transforms/wvtransformstratifiedqg/index.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/index.md
@@ -84,19 +84,18 @@ The quasigeostrophic state is stored in
     + Quadrature and integration
       + [`z_int`](/classes/transforms/wvtransformstratifiedqg/z_int.html) Vertical quadrature weights in meters.
   + Spectral grid
-    + Axes and spacing
-      + [`kAxis`](/classes/transforms/wvtransformstratifiedqg/kaxis.html) Centered x-direction angular-wavenumber axis.
-      + [`lAxis`](/classes/transforms/wvtransformstratifiedqg/laxis.html) Centered y-direction angular-wavenumber axis.
-      + [`j`](/classes/transforms/wvtransformstratifiedqg/j.html) Vertical-mode index axis.
-      + [`dk`](/classes/transforms/wvtransformstratifiedqg/dk.html) Spacing of the x-direction angular-wavenumber axis.
-      + [`dl`](/classes/transforms/wvtransformstratifiedqg/dl.html) Spacing of the y-direction angular-wavenumber axis.
-    + Coordinate arrays
-      + [`k`](/classes/transforms/wvtransformstratifiedqg/k.html) Stored x-direction angular wavenumbers on the compact WV grid.
-      + [`l`](/classes/transforms/wvtransformstratifiedqg/l.html) Stored y-direction angular wavenumbers on the compact WV grid.
+    + Compact grid vectors
+      + [`k`](/classes/transforms/wvtransformstratifiedqg/k.html) Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
+      + [`l`](/classes/transforms/wvtransformstratifiedqg/l.html) Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
+      + [`j`](/classes/transforms/wvtransformstratifiedqg/j.html) Dimensionless `Nj`-by-1 vertical-mode index vector.
+    + Compact grid arrays
       + [`K`](/classes/transforms/wvtransformstratifiedqg/k_.html) X-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`L`](/classes/transforms/wvtransformstratifiedqg/l_.html) Y-direction angular-wavenumber array in rad/m with shape `[Nj Nkl]`.
       + [`J`](/classes/transforms/wvtransformstratifiedqg/j_.html) Dimensionless vertical-mode index array with shape `[Nj Nkl]`.
       + [`kljGrid`](/classes/transforms/wvtransformstratifiedqg/kljgrid.html) Return spectral-coordinate arrays in wave-vortex layout.
+    + Wavenumber spacing
+      + [`dk`](/classes/transforms/wvtransformstratifiedqg/dk.html) Spacing of the x-direction angular-wavenumber axis.
+      + [`dl`](/classes/transforms/wvtransformstratifiedqg/dl.html) Spacing of the y-direction angular-wavenumber axis.
     + Horizontal wavenumber geometry
       + [`Kh`](/classes/transforms/wvtransformstratifiedqg/kh.html) Horizontal angular-wavenumber magnitude on the coefficient grid.
       + [`K2`](/classes/transforms/wvtransformstratifiedqg/k2.html) Squared horizontal angular wavenumber on the coefficient grid.
@@ -107,12 +106,18 @@ The quasigeostrophic state is stored in
       + [`effectiveHorizontalGridResolution`](/classes/transforms/wvtransformstratifiedqg/effectivehorizontalgridresolution.html) returns the effective grid resolution in meters
       + [`effectiveVerticalGridResolution`](/classes/transforms/wvtransformstratifiedqg/effectiveverticalgridresolution.html) returns the effective vertical grid resolution in meters
       + [`effectiveJMax`](/classes/transforms/wvtransformstratifiedqg/effectivejmax.html) Largest active vertical-mode index.
+      + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformstratifiedqg/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
     + Vertical modes and scaling
       + [`verticalModes`](/classes/transforms/wvtransformstratifiedqg/verticalmodes.html) Vertical-mode solution used to construct the transform basis.
       + [`h_0`](/classes/transforms/wvtransformstratifiedqg/h_0.html) Geostrophic equivalent-depth scale for each vertical mode.
       + [`h_pm`](/classes/transforms/wvtransformstratifiedqg/h_pm.html) Wave equivalent depth on the spectral grid.
       + [`Lr2`](/classes/transforms/wvtransformstratifiedqg/lr2.html) Squared Rossby deformation radius in square meters.
       + [`waveModeVerticalStructureAtIndex`](/classes/transforms/wvtransformstratifiedqg/wavemodeverticalstructureatindex.html) Return wave vertical-structure factors at one vertical grid index.
+    + Vertical-mode transformation matrices
+      + [`FMatrix`](/classes/transforms/wvtransformstratifiedqg/fmatrix.html) Projects F-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`FinvMatrix`](/classes/transforms/wvtransformstratifiedqg/finvmatrix.html) Reconstructs F-grid values from vertical modes with shape `[Nz Nj]`.
+      + [`GMatrix`](/classes/transforms/wvtransformstratifiedqg/gmatrix.html) Projects G-grid values onto vertical modes with shape `[Nj Nz]`.
+      + [`GinvMatrix`](/classes/transforms/wvtransformstratifiedqg/ginvmatrix.html) Reconstructs G-grid values from vertical modes with shape `[Nz Nj]`.
   + Transform configuration
     + [`isHydrostatic`](/classes/transforms/wvtransformstratifiedqg/ishydrostatic.html) Whether the transform uses the hydrostatic approximation.
     + [`shouldAntialias`](/classes/transforms/wvtransformstratifiedqg/shouldantialias.html) Whether the spectral grid excludes modes that alias quadratic products.
@@ -145,7 +150,7 @@ The quasigeostrophic state is stored in
     + Density and displacement
       + [`eta`](/classes/transforms/wvtransformstratifiedqg/eta.html) approximate isopycnal deviation
       + [`rho_e`](/classes/transforms/wvtransformstratifiedqg/rho_e.html) excess density
-      + [`rho_nm0`](/classes/transforms/wvtransformstratifiedqg/rho_nm0.html) No-motion density profile sampled on the vertical grid.
+      + [`rho_nm0`](/classes/transforms/wvtransformstratifiedqg/rho_nm0.html) Reference no-motion density profile, `[Nz 1]`, in kg/m³.
       + [`rho_total`](/classes/transforms/wvtransformstratifiedqg/rho_total.html) total potential density
     + Pressure and surface fields
       + [`p`](/classes/transforms/wvtransformstratifiedqg/p.html) pressure anomaly
@@ -162,29 +167,22 @@ The quasigeostrophic state is stored in
   + Isopycnal utilities
     + [`placeParticlesOnIsopycnal`](/classes/transforms/wvtransformstratifiedqg/placeparticlesonisopycnal.html) Return particle depths on the isopycnal identified by a no-motion depth.
 + Manage forcing and closures
-  + [`addForcing`](/classes/transforms/wvtransformstratifiedqg/addforcing.html) Add forcing or closure objects to this transform.
-  + [`forcing`](/classes/transforms/wvtransformstratifiedqg/forcing.html) array of WVForcing objects
-  + [`forcingNames`](/classes/transforms/wvtransformstratifiedqg/forcingnames.html) Return forcing and closure names in application order.
-  + [`forcingWithName`](/classes/transforms/wvtransformstratifiedqg/forcingwithname.html) Return registered forcing objects by name.
-  + [`hasClosure`](/classes/transforms/wvtransformstratifiedqg/hasclosure.html) Whether a closure is currently attached to the transform.
-  + [`hasForcingWithName`](/classes/transforms/wvtransformstratifiedqg/hasforcingwithname.html) Test whether forcing objects are registered by name.
-  + [`removeAllForcing`](/classes/transforms/wvtransformstratifiedqg/removeallforcing.html) Remove every forcing and closure from this transform.
-  + [`removeForcing`](/classes/transforms/wvtransformstratifiedqg/removeforcing.html) Remove the exact registered forcing objects.
-  + [`setForcing`](/classes/transforms/wvtransformstratifiedqg/setforcing.html) Replace the complete forcing registry.
-  + [`summarizeForcing`](/classes/transforms/wvtransformstratifiedqg/summarizeforcing.html) Print a table of registered forcing and closure objects.
+  + Configure forcing
+    + [`addForcing`](/classes/transforms/wvtransformstratifiedqg/addforcing.html) Add forcing or closure objects to this transform.
+    + [`setForcing`](/classes/transforms/wvtransformstratifiedqg/setforcing.html) Replace the complete forcing registry.
+    + [`removeForcing`](/classes/transforms/wvtransformstratifiedqg/removeforcing.html) Remove the exact registered forcing objects.
+    + [`removeAllForcing`](/classes/transforms/wvtransformstratifiedqg/removeallforcing.html) Remove every forcing and closure from this transform.
+  + Inspect forcing and closures
+    + [`forcing`](/classes/transforms/wvtransformstratifiedqg/forcing.html) array of WVForcing objects
+    + [`forcingNames`](/classes/transforms/wvtransformstratifiedqg/forcingnames.html) Return forcing and closure names in application order.
+    + [`forcingWithName`](/classes/transforms/wvtransformstratifiedqg/forcingwithname.html) Return registered forcing objects by name.
+    + [`hasForcingWithName`](/classes/transforms/wvtransformstratifiedqg/hasforcingwithname.html) Test whether forcing objects are registered by name.
+    + [`hasClosure`](/classes/transforms/wvtransformstratifiedqg/hasclosure.html) Whether a closure is currently attached to the transform.
+  + Summarize forcing
+    + [`summarizeForcing`](/classes/transforms/wvtransformstratifiedqg/summarizeforcing.html) Print a table of registered forcing and closure objects.
 + Analyze the flow
-  + Energy and summaries
-    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformstratifiedqg/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
-    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformstratifiedqg/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
-    + [`geostrophicEnergy`](/classes/transforms/wvtransformstratifiedqg/geostrophicenergy.html) total energy, geostrophic
-    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformstratifiedqg/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
-    + [`summarizeDegreesOfFreedom`](/classes/transforms/wvtransformstratifiedqg/summarizedegreesoffreedom.html) Summarize the spatial grid and active spectral degrees of freedom.
-    + [`summarizeEnergyContent`](/classes/transforms/wvtransformstratifiedqg/summarizeenergycontent.html) displays a summary of the energy content of the fluid
-    + [`summarizeModeEnergy`](/classes/transforms/wvtransformstratifiedqg/summarizemodeenergy.html) List the most energetic modes
-    + [`totalEnergy`](/classes/transforms/wvtransformstratifiedqg/totalenergy.html) % - Topic: Energetics
-    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformstratifiedqg/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
-    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformstratifiedqg/totalenergyspatiallyintegrated.html) % - Topic: Energetics
   + Flow diagnostics
+    + [`hasMeanPressureDifference`](/classes/transforms/wvtransformstratifiedqg/hasmeanpressuredifference.html) Diagnose an MDA mean-pressure difference between the boundaries.
     + [`uvMax`](/classes/transforms/wvtransformstratifiedqg/uvmax.html) max horizontal fluid speed
   + Density validity
     + [`isDensityInValidRange`](/classes/transforms/wvtransformstratifiedqg/isdensityinvalidrange.html) Test whether total density remains within the no-motion density range.
@@ -193,14 +191,28 @@ The quasigeostrophic state is stored in
     + [`totalEnstrophySpatiallyIntegrated`](/classes/transforms/wvtransformstratifiedqg/totalenstrophyspatiallyintegrated.html) Potential enstrophy evaluated from the gridded QGPV field.
   + Spectra
     + Spectral fields
+      + [`kAxis`](/classes/transforms/wvtransformstratifiedqg/kaxis.html) Centered `Nx`-by-1 x-wavenumber axis in rad/m.
+      + [`lAxis`](/classes/transforms/wvtransformstratifiedqg/laxis.html) Centered `Ny`-by-1 y-wavenumber axis in rad/m.
+      + [`transformToKLAxes`](/classes/transforms/wvtransformstratifiedqg/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
       + [`crossSpectrumWithFgTransform`](/classes/transforms/wvtransformstratifiedqg/crossspectrumwithfgtransform.html) Compute a real modal cross-spectrum using the F-basis transform.
       + [`crossSpectrumWithGgTransform`](/classes/transforms/wvtransformstratifiedqg/crossspectrumwithggtransform.html) Compute a real modal cross-spectrum using the G-basis transform.
       + [`spectrumWithFgTransform`](/classes/transforms/wvtransformstratifiedqg/spectrumwithfgtransform.html) Compute a modal autospectrum using the F-basis transform.
       + [`spectrumWithGgTransform`](/classes/transforms/wvtransformstratifiedqg/spectrumwithggtransform.html) Compute a modal autospectrum using the G-basis transform.
-      + [`transformToKLAxes`](/classes/transforms/wvtransformstratifiedqg/transformtoklaxes.html) transforms in the spectral domain from (j,kl) to (kAxis,lAxis,j)
     + Radial wavenumber
       + [`kRadial`](/classes/transforms/wvtransformstratifiedqg/kradial.html) radial (k,l) wavenumber on the WV grid
       + [`transformToRadialWavenumber`](/classes/transforms/wvtransformstratifiedqg/transformtoradialwavenumber.html) transforms in the spectral domain from (j,kl) to (j,kRadial)
++ Analyze energy
+  + Component energy
+    + [`geostrophicKineticEnergy`](/classes/transforms/wvtransformstratifiedqg/geostrophickineticenergy.html) kinetic energy of the geostrophic flow
+    + [`geostrophicPotentialEnergy`](/classes/transforms/wvtransformstratifiedqg/geostrophicpotentialenergy.html) potential energy of the geostrophic flow
+    + [`geostrophicEnergy`](/classes/transforms/wvtransformstratifiedqg/geostrophicenergy.html) total energy, geostrophic
+    + [`totalEnergyOfFlowComponent`](/classes/transforms/wvtransformstratifiedqg/totalenergyofflowcomponent.html) Compute the energy carried by one flow component.
+  + Total energy
+    + [`totalEnergy`](/classes/transforms/wvtransformstratifiedqg/totalenergy.html) Total energy computed from wave-vortex coefficients.
+    + [`totalEnergySpatiallyIntegrated`](/classes/transforms/wvtransformstratifiedqg/totalenergyspatiallyintegrated.html) Total energy computed from physical-space fields.
+  + Energy summaries
+    + [`summarizeEnergyContent`](/classes/transforms/wvtransformstratifiedqg/summarizeenergycontent.html) displays a summary of the energy content of the fluid
+    + [`summarizeModeEnergy`](/classes/transforms/wvtransformstratifiedqg/summarizemodeenergy.html) List the most energetic modes
 + Save transform state
   + [`writeToFile`](/classes/transforms/wvtransformstratifiedqg/writetofile.html) Write this instance to NetCDF file.
 + Convert representations
@@ -216,15 +228,18 @@ The quasigeostrophic state is stored in
   + [`intZF`](/classes/transforms/wvtransformstratifiedqg/intzf.html) Return the first antiderivative of an F-representation.
   + [`intZG`](/classes/transforms/wvtransformstratifiedqg/intzg.html) Return the bottom-zero first antiderivative of a G-representation.
 + Inspect flow components
-  + [`geostrophicComponent`](/classes/transforms/wvtransformstratifiedqg/geostrophiccomponent.html) returns the geostrophic flow component
-  + [`flowComponentNames`](/classes/transforms/wvtransformstratifiedqg/flowcomponentnames.html) retrieve the names of all available variables
-  + [`flowComponentWithName`](/classes/transforms/wvtransformstratifiedqg/flowcomponentwithname.html) retrieve a WVFlowComponent by name
-  + [`flowComponents`](/classes/transforms/wvtransformstratifiedqg/flowcomponents.html) All registered physical and diagnostic flow components.
-  + [`primaryFlowComponentNames`](/classes/transforms/wvtransformstratifiedqg/primaryflowcomponentnames.html) retrieve the names of all available variables
-  + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformstratifiedqg/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
-  + [`primaryFlowComponents`](/classes/transforms/wvtransformstratifiedqg/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
-  + [`summarizeFlowComponents`](/classes/transforms/wvtransformstratifiedqg/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
-  + [`totalFlowComponent`](/classes/transforms/wvtransformstratifiedqg/totalflowcomponent.html) Combined view of all primary flow components.
+  + Primary flow components
+    + [`geostrophicComponent`](/classes/transforms/wvtransformstratifiedqg/geostrophiccomponent.html) returns the geostrophic flow component
+    + [`primaryFlowComponents`](/classes/transforms/wvtransformstratifiedqg/primaryflowcomponents.html) Primary flow components that partition the active coefficient state.
+    + [`primaryFlowComponentNames`](/classes/transforms/wvtransformstratifiedqg/primaryflowcomponentnames.html) retrieve the names of all available variables
+    + [`primaryFlowComponentWithName`](/classes/transforms/wvtransformstratifiedqg/primaryflowcomponentwithname.html) retrieve a WVPrimaryFlowComponent by name
+  + Registered and combined components
+    + [`flowComponents`](/classes/transforms/wvtransformstratifiedqg/flowcomponents.html) All registered physical and diagnostic flow components.
+    + [`flowComponentNames`](/classes/transforms/wvtransformstratifiedqg/flowcomponentnames.html) retrieve the names of all available variables
+    + [`flowComponentWithName`](/classes/transforms/wvtransformstratifiedqg/flowcomponentwithname.html) retrieve a WVFlowComponent by name
+    + [`totalFlowComponent`](/classes/transforms/wvtransformstratifiedqg/totalflowcomponent.html) Combined view of all primary flow components.
+  + Summarize flow components
+    + [`summarizeFlowComponents`](/classes/transforms/wvtransformstratifiedqg/summarizeflowcomponents.html) Print a table of registered primary and diagnostic components.
 + Inspect wave-vortex coefficients
   + Stored coefficients
     + [`A0`](/classes/transforms/wvtransformstratifiedqg/a0.html) Zero-frequency geostrophic coefficients.
@@ -253,50 +268,63 @@ The quasigeostrophic state is stored in
 ## Developer Topics
 These items document internal implementation details and are not part of the primary public API.
 + Projection and reconstruction coefficients
-  + [`A0N`](/classes/transforms/wvtransformstratifiedqg/a0n.html) These projection coefficients map the density-displacement state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0U`](/classes/transforms/wvtransformstratifiedqg/a0u.html) These projection coefficients map the $$u$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 1 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0V`](/classes/transforms/wvtransformstratifiedqg/a0v.html) These projection coefficients map the $$v$$ state variable onto $$A_0$$. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 2 entries of $$S^{-1}$$ for the primary internal-gravity-wave and geostrophic solutions in equation C5.
-  + [`A0Z`](/classes/transforms/wvtransformstratifiedqg/a0z.html)
-  + [`NA0`](/classes/transforms/wvtransformstratifiedqg/na0.html) These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`P0`](/classes/transforms/wvtransformstratifiedqg/p0.html) Preconditioner for F, size(P)=[Nj 1]. F*u = uhat, (PF)*u = P*uhat, so ubar==P*uhat
-  + [`PA0`](/classes/transforms/wvtransformstratifiedqg/pa0.html)
-  + [`Q0`](/classes/transforms/wvtransformstratifiedqg/q0.html) Preconditioner for G, size(Q)=[Nj 1]. G*eta = etahat, (QG)*eta = Q*etahat, so etabar==Q*etahat.
-  + [`UA0`](/classes/transforms/wvtransformstratifiedqg/ua0.html) These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
-  + [`VA0`](/classes/transforms/wvtransformstratifiedqg/va0.html) These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+  + [`A0N`](/classes/transforms/wvtransformstratifiedqg/a0n.html) Projects density displacement onto $$A_0$$.
+  + [`A0U`](/classes/transforms/wvtransformstratifiedqg/a0u.html) Projects $$u$$ onto $$A_0$$.
+  + [`A0V`](/classes/transforms/wvtransformstratifiedqg/a0v.html) Projects $$v$$ onto $$A_0$$.
+  + [`A0Z`](/classes/transforms/wvtransformstratifiedqg/a0z.html) Projects vertical vorticity onto $$A_0$$.
+  + [`NA0`](/classes/transforms/wvtransformstratifiedqg/na0.html) Reconstructs density displacement from $$A_0$$.
+  + [`PA0`](/classes/transforms/wvtransformstratifiedqg/pa0.html) Reconstructs pressure height from $$A_0$$.
+  + [`UA0`](/classes/transforms/wvtransformstratifiedqg/ua0.html) Reconstructs $$u$$ from $$A_0$$.
+  + [`VA0`](/classes/transforms/wvtransformstratifiedqg/va0.html) Reconstructs $$v$$ from $$A_0$$.
 + Geometry and mode indexing
-  + [`conjugateDimension`](/classes/transforms/wvtransformstratifiedqg/conjugatedimension.html) assumed conjugate dimension
-  + [`indexFromKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
-  + [`indexFromModeNumber`](/classes/transforms/wvtransformstratifiedqg/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
-  + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformstratifiedqg/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
-  + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformstratifiedqg/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
-  + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
-  + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
-  + [`isValidKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
-  + [`isValidModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
-  + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
-  + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
-  + [`kMode_dft`](/classes/transforms/wvtransformstratifiedqg/kmode_dft.html) k mode-number on the DFT grid
-  + [`kMode_wv`](/classes/transforms/wvtransformstratifiedqg/kmode_wv.html) k mode number on the WV grid
-  + [`klModeNumberFromIndex`](/classes/transforms/wvtransformstratifiedqg/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
-  + [`lMode_dft`](/classes/transforms/wvtransformstratifiedqg/lmode_dft.html) l mode-number on the DFT grid
-  + [`lMode_wv`](/classes/transforms/wvtransformstratifiedqg/lmode_wv.html) l mode number on the WV grid
-  + [`maskForAliasedModes`](/classes/transforms/wvtransformstratifiedqg/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
-  + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformstratifiedqg/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
-  + [`maskForNyquistModes`](/classes/transforms/wvtransformstratifiedqg/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
-  + [`modeNumberFromIndex`](/classes/transforms/wvtransformstratifiedqg/modenumberfromindex.html) Return mode numbers for spectral linear indices.
-  + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
-  + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformstratifiedqg/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
-  + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformstratifiedqg/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
-  + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformstratifiedqg/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
-  + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
-  + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Mode numbers and validity
+    + [`isValidConjugateKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidconjugateklmodenumber.html) return a boolean indicating whether (k,l) is a valid conjugate WV mode number
+    + [`isValidConjugateModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidconjugatemodenumber.html) returns a boolean indicating whether (k,l,j) is a valid conjugate mode number
+    + [`isValidKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidklmodenumber.html) return a boolean indicating whether (k,l) is a valid WV mode number
+    + [`isValidModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidmodenumber.html) returns a boolean indicating whether (k,l,j) is a valid mode number
+    + [`isValidPrimaryKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidprimaryklmodenumber.html) return a boolean indicating whether (k,l) is a valid primary (non-conjugate) WV mode number
+    + [`isValidPrimaryModeNumber`](/classes/transforms/wvtransformstratifiedqg/isvalidprimarymodenumber.html) returns a boolean indicating whether (k,l,j) is a valid primary (non-conjugate) mode number
+    + [`kMode_dft`](/classes/transforms/wvtransformstratifiedqg/kmode_dft.html) k mode-number on the DFT grid
+    + [`kMode_wv`](/classes/transforms/wvtransformstratifiedqg/kmode_wv.html) k mode number on the WV grid
+    + [`lMode_dft`](/classes/transforms/wvtransformstratifiedqg/lmode_dft.html) l mode-number on the DFT grid
+    + [`lMode_wv`](/classes/transforms/wvtransformstratifiedqg/lmode_wv.html) l mode number on the WV grid
+    + [`primaryKLModeNumberFromKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/primaryklmodenumberfromklmodenumber.html) takes any valid WV mode number and returns the primary mode number
+  + Linear-index conversion
+    + [`indexFromKLModeNumber`](/classes/transforms/wvtransformstratifiedqg/indexfromklmodenumber.html) return the linear index into k_wv and l_wv from a mode number
+    + [`indexFromModeNumber`](/classes/transforms/wvtransformstratifiedqg/indexfrommodenumber.html) return the linear index into a spectral matrix given (k,l,j)
+    + [`klModeNumberFromIndex`](/classes/transforms/wvtransformstratifiedqg/klmodenumberfromindex.html) return mode number from a linear index into a WV matrix
+    + [`modeNumberFromIndex`](/classes/transforms/wvtransformstratifiedqg/modenumberfromindex.html) Return mode numbers for spectral linear indices.
+  + DFT and WV layout metadata
+    + [`Nk_dft`](/classes/transforms/wvtransformstratifiedqg/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
+    + [`Nl_dft`](/classes/transforms/wvtransformstratifiedqg/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
+    + [`conjugateDimension`](/classes/transforms/wvtransformstratifiedqg/conjugatedimension.html) assumed conjugate dimension
+    + [`dftConjugateIndices2D`](/classes/transforms/wvtransformstratifiedqg/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
+    + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformstratifiedqg/dftprimaryindices2d.html) index into the DFT grid of each WV mode
+    + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformstratifiedqg/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
+    + [`k_dft`](/classes/transforms/wvtransformstratifiedqg/k_dft.html) k wavenumber dimension on the DFT grid
+    + [`kl`](/classes/transforms/wvtransformstratifiedqg/kl.html) wavenumber dimension
+    + [`l_dft`](/classes/transforms/wvtransformstratifiedqg/l_dft.html) l wavenumber dimension on the DFT grid
+    + [`shouldExcludeConjugates`](/classes/transforms/wvtransformstratifiedqg/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
+    + [`shouldExcludeNyquist`](/classes/transforms/wvtransformstratifiedqg/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
+  + Layout conversion
+    + [`indicesFromDFTGridToWVGrid`](/classes/transforms/wvtransformstratifiedqg/indicesfromdftgridtowvgrid.html) indices to convert from DFT to WV grid
+    + [`indicesFromWVGridToDFTGrid`](/classes/transforms/wvtransformstratifiedqg/indicesfromwvgridtodftgrid.html) indices to convert from WV to DFT grid
+    + [`transformFromDFTGridToWVGrid`](/classes/transforms/wvtransformstratifiedqg/transformfromdftgridtowvgrid.html) convert from DFT to WV grid
+    + [`transformFromSpatialDomainToDFTGrid`](/classes/transforms/wvtransformstratifiedqg/transformfromspatialdomaintodftgrid.html) transform from $$(x,y,z)$$ to $$(k,l,z)$$ on the DFT grid
+    + [`transformFromWVGridToDFTGrid`](/classes/transforms/wvtransformstratifiedqg/transformfromwvgridtodftgrid.html) convert from a WV to DFT grid
+    + [`transformToSpatialDomainFromDFTGrid`](/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgrid.html) transform from $$(k,l,z)$$ on the DFT grid to $$(x,y,z)$$
+    + [`transformToSpatialDomainFromDFTGridAtPosition`](/classes/transforms/wvtransformstratifiedqg/transformtospatialdomainfromdftgridatposition.html) transform from $$(k,l)$$ on the DFT grid to $$(x,y)$$ at any position
+  + Masks and Hermitian bookkeeping
+    + [`isHermitian`](/classes/transforms/wvtransformstratifiedqg/ishermitian.html) Check if the matrix is Hermitian. Report errors.
+    + [`maskForAliasedModes`](/classes/transforms/wvtransformstratifiedqg/maskforaliasedmodes.html) returns a mask with locations of modes that will alias with a quadratic multiplication.
+    + [`maskForConjugateFourierCoefficients`](/classes/transforms/wvtransformstratifiedqg/maskforconjugatefouriercoefficients.html) a mask indicate the components that are redundant conjugates
+    + [`maskForNyquistModes`](/classes/transforms/wvtransformstratifiedqg/maskfornyquistmodes.html) returns a mask with locations of modes that are not fully resolved
+    + [`setConjugateToUnity`](/classes/transforms/wvtransformstratifiedqg/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
 + Spectral transforms and operators
-  + [`FMatrix`](/classes/transforms/wvtransformstratifiedqg/fmatrix.html) transformation matrix $$F_g$$
-  + [`FinvMatrix`](/classes/transforms/wvtransformstratifiedqg/finvmatrix.html) transformation matrix $$F_g^{-1}$$
-  + [`GMatrix`](/classes/transforms/wvtransformstratifiedqg/gmatrix.html) transformation matrix $$G_g$$
-  + [`GinvMatrix`](/classes/transforms/wvtransformstratifiedqg/ginvmatrix.html) transformation matrix $$G_g^{-1}$$
+  + [`P0`](/classes/transforms/wvtransformstratifiedqg/p0.html) Preconditioner for F, size(P)=[Nj 1]. F*u = uhat, (PF)*u = P*uhat, so ubar==P*uhat
   + [`PF0`](/classes/transforms/wvtransformstratifiedqg/pf0.html) size(PF,PG)=[Nj x Nz]
   + [`PF0inv`](/classes/transforms/wvtransformstratifiedqg/pf0inv.html) Transformation matrices
+  + [`Q0`](/classes/transforms/wvtransformstratifiedqg/q0.html) Preconditioner for G, size(Q)=[Nj 1]. G*eta = etahat, (QG)*eta = Q*etahat, so etabar==Q*etahat.
   + [`QG0`](/classes/transforms/wvtransformstratifiedqg/qg0.html) Preconditioned G-mode forward transformation
   + [`QG0inv`](/classes/transforms/wvtransformstratifiedqg/qg0inv.html) Preconditioned G-mode inverse transformation
   + [`degreesOfFreedomForComplexMatrix`](/classes/transforms/wvtransformstratifiedqg/degreesoffreedomforcomplexmatrix.html) a matrix with the number of degrees-of-freedom at each entry
@@ -328,22 +356,10 @@ These items document internal implementation details and are not part of the pri
   + [`propertyAnnotationsForGeometry`](/classes/transforms/wvtransformstratifiedqg/propertyannotationsforgeometry.html) return array of CAPropertyAnnotations initialized by default
   + [`propertyAnnotationsForRotatingFPlane`](/classes/transforms/wvtransformstratifiedqg/propertyannotationsforrotatingfplane.html)
 + Class internals
-  + [`Nk_dft`](/classes/transforms/wvtransformstratifiedqg/nk_dft.html) length of the k-wavenumber dimension on the DFT grid
-  + [`Nl_dft`](/classes/transforms/wvtransformstratifiedqg/nl_dft.html) length of the l-wavenumber dimension on the DFT grid
   + [`chebfunForZArray`](/classes/transforms/wvtransformstratifiedqg/chebfunforzarray.html)
-  + [`dftConjugateIndices2D`](/classes/transforms/wvtransformstratifiedqg/dftconjugateindices2d.html) index into the DFT grid of the conjugate of each WV mode
-  + [`dftPrimaryIndices2D`](/classes/transforms/wvtransformstratifiedqg/dftprimaryindices2d.html) index into the DFT grid of each WV mode
-  + [`indicesOfFourierConjugates`](/classes/transforms/wvtransformstratifiedqg/indicesoffourierconjugates.html) a matrix of linear indices of the conjugate
-  + [`isHermitian`](/classes/transforms/wvtransformstratifiedqg/ishermitian.html) Check if the matrix is Hermitian. Report errors.
-  + [`k_dft`](/classes/transforms/wvtransformstratifiedqg/k_dft.html) k wavenumber dimension on the DFT grid
-  + [`kl`](/classes/transforms/wvtransformstratifiedqg/kl.html) wavenumber dimension
-  + [`l_dft`](/classes/transforms/wvtransformstratifiedqg/l_dft.html) l wavenumber dimension on the DFT grid
   + [`maxFg`](/classes/transforms/wvtransformstratifiedqg/maxfg.html)
   + [`maxFw`](/classes/transforms/wvtransformstratifiedqg/maxfw.html)
   + [`quadraturePointsForStratifiedFlow`](/classes/transforms/wvtransformstratifiedqg/quadraturepointsforstratifiedflow.html) return the quadrature points for a given stratification
-  + [`setConjugateToUnity`](/classes/transforms/wvtransformstratifiedqg/setconjugatetounity.html) set the conjugate of the wavenumber (iK,iL) to 1
-  + [`shouldExcludeConjugates`](/classes/transforms/wvtransformstratifiedqg/shouldexcludeconjugates.html) whether the WV grid excludes redundant Hermitian-conjugate wavenumbers
-  + [`shouldExcludeNyquist`](/classes/transforms/wvtransformstratifiedqg/shouldexcludenyquist.html) whether the WV grid includes Nyquist wavenumbers
   + [`throwErrorIfDensityViolation`](/classes/transforms/wvtransformstratifiedqg/throwerrorifdensityviolation.html) checks if the proposed coefficients are a valid adiabatic re-arrangement of the base state
   + [`verticalProjectionOperatorsWithRigidLid`](/classes/transforms/wvtransformstratifiedqg/verticalprojectionoperatorswithrigidlid.html) return the normalized projection operators with prefactors
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/j.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/j.md
@@ -9,13 +9,13 @@ mathjax: true
 
 #  j
 
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 
 ---
 
 ## Discussion
-Vertical-mode index axis.
+Dimensionless `Nj`-by-1 vertical-mode index vector.
 
 `j` is an `Nj`-by-1 column vector of dimensionless nonnegative mode numbers. Three-dimensional rigid-lid transforms include the barotropic index `j=0`; wave motions occupy internal modes with `j>0`.
 

--- a/docs/classes/transforms/wvtransformstratifiedqg/k.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/k.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  k
 
-Stored x-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 x-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformstratifiedqg/kaxis.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/kaxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  kAxis
 
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered x-direction angular-wavenumber axis.
+Centered `Nx`-by-1 x-wavenumber axis in rad/m.
 
 `kAxis` is an `Nx`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dk`.

--- a/docs/classes/transforms/wvtransformstratifiedqg/l.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/l.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  l
 
-Stored y-direction angular wavenumbers on the compact WV grid.
+Compact `Nkl`-by-1 y-wavenumber vector in rad/m.
 
 
 ---

--- a/docs/classes/transforms/wvtransformstratifiedqg/laxis.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/laxis.md
@@ -9,12 +9,12 @@ mathjax: true
 
 #  lAxis
 
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 
 ---
 
 ## Discussion
-Centered y-direction angular-wavenumber axis.
+Centered `Ny`-by-1 y-wavenumber axis in rad/m.
 
 `lAxis` is an `Ny`-by-1 vector in radians per meter, ordered from negative to positive wavenumbers with zero centered as by `fftshift`. Adjacent entries are separated by `dl`.

--- a/docs/classes/transforms/wvtransformstratifiedqg/na0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/na0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  NA0
 
-These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs density displacement from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the density-displacement stat
 Real valued property with dimensions $$(j,kl)$$ and no units.
 
 ## Discussion
+Reconstructs density displacement from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the density-displacement state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 3, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformstratifiedqg/pa0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/pa0.md
@@ -9,9 +9,14 @@ mathjax: true
 
 #  PA0
 
-
+Reconstructs pressure height from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
 
 ---
+
+## Discussion
+Reconstructs pressure height from $$A_0$$.
+
+`PA0` maps the zero-frequency coefficient array onto the pressure-height anomaly used to evaluate `pi` and pressure.

--- a/docs/classes/transforms/wvtransformstratifiedqg/rho_nm0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/rho_nm0.md
@@ -9,10 +9,15 @@ mathjax: true
 
 #  rho_nm0
 
-No-motion density profile sampled on the vertical grid.
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
 
 
 ---
 
 ## Description
 Real valued property with dimension $$z$$ and units of $$kg m^{-3}$$.
+
+## Discussion
+Reference no-motion density profile, `[Nz 1]`, in kg/m³.
+
+`rho_nm0` is the fixed profile supplied when constructing the transform and sampled on the vertical grid.

--- a/docs/classes/transforms/wvtransformstratifiedqg/totalenergy.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/totalenergy.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergy
 
-% - Topic: Energetics
+Total energy computed from wave-vortex coefficients.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from wave-vortex coefficients.
+
 The horizontally-averaged depth-integrated energy computed from the wave-vortex coefficients
 
 $$

--- a/docs/classes/transforms/wvtransformstratifiedqg/totalenergyspatiallyintegrated.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/totalenergyspatiallyintegrated.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  totalEnergySpatiallyIntegrated
 
-% - Topic: Energetics
+Total energy computed from physical-space fields.
 
 
 ---
@@ -18,7 +18,8 @@ mathjax: true
 Real valued property with no dimensions and units of $$m3/s2$$.
 
 ## Discussion
-%
+Total energy computed from physical-space fields.
+
 The horizontally-averaged depth-integrated energy computed in the spatial domain is defined as,
 
 $$

--- a/docs/classes/transforms/wvtransformstratifiedqg/ua0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/ua0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  UA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$u$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$u$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$u$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 1, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/classes/transforms/wvtransformstratifiedqg/va0.md
+++ b/docs/classes/transforms/wvtransformstratifiedqg/va0.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  VA0
 
-These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
+Reconstructs $$v$$ from $$A_0$$.
 
 > Developer documentation: this item describes internal implementation details.
 
@@ -20,6 +20,8 @@ These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In 
 Complex valued property with dimensions $$(j,kl)$$ and units of $$s^{-1}$$.
 
 ## Discussion
+Reconstructs $$v$$ from $$A_0$$.
+
 These reconstruction coefficients map $$A_0$$ onto the $$v$$ state variable. In the historical notation of [Early et al. (2021)](https://doi.org/10.1017/jfm.2020.995), they are the row 2, column 3 entries of $$S$$ for the primary internal-gravity-wave and geostrophic solutions in equation C4.
 
 For $$k^2+l^2>0, j>0$$ this is written as,

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -13,7 +13,7 @@ nav_order: 100
 - Updated Fourier-at-position reconstruction to use compact `WVFourierStorageLayout` mappings.
 - Removed obsolete pseudo-radial and frequency-binning APIs whose maintained equivalents live in `WVDiagnostics`.
 - Added backend-neutral transform-storage accounting and fresh-process RSS benchmarks.
-- Completed and reorganized transform and forcing documentation, corrected API metadata, and improved nonlinear-integration examples.
+- Completed and reorganized transform and forcing documentation, clarified spectral grids, energy, forcing, flow components, geometry indexing, density profiles, and projection/reconstruction summaries, corrected API metadata, and improved nonlinear-integration examples.
 - Verified and documented the mathematical contracts for pseudo-topographic wave generation, beta-plane QGPV advection, and vertical diffusivity, and restored the variable-stratification mean-density-anomaly source disabled by an obsolete class-name check.
 
 ## [4.2.1] - 2026-08-09

--- a/tools/applyDocumentationTaxonomy.m
+++ b/tools/applyDocumentationTaxonomy.m
@@ -144,21 +144,26 @@ elseif ismember(name,["Nx","Ny","Nz","spatialMatrixSize"])
     topicPath = "Inspect the domain — Spatial grid — Resolution and shape";
 elseif ismember(name,["z_int","volumeIntegral"])
     topicPath = "Inspect the domain — Spatial grid — Quadrature and integration";
-elseif ismember(name,["kAxis","lAxis","j","dk","dl"])
-    topicPath = "Inspect the domain — Spectral grid — Axes and spacing";
-elseif ismember(name,["k","l","K","L","J","klGrid","kljGrid"])
-    topicPath = "Inspect the domain — Spectral grid — Coordinate arrays";
+elseif ismember(name,["k","l","j"])
+    topicPath = "Inspect the domain — Spectral grid — Compact grid vectors";
+elseif ismember(name,["K","L","J","klGrid","kljGrid"])
+    topicPath = "Inspect the domain — Spectral grid — Compact grid arrays";
+elseif ismember(name,["dk","dl"])
+    topicPath = "Inspect the domain — Spectral grid — Wavenumber spacing";
 elseif ismember(name,["Kh","K2"])
     topicPath = "Inspect the domain — Spectral grid — Horizontal wavenumber geometry";
 elseif ismember(name,["Nj","Nkl","spectralMatrixSize", ...
         "effectiveHorizontalGridResolution", ...
-        "effectiveVerticalGridResolution","effectiveJMax"])
+        "effectiveVerticalGridResolution","effectiveJMax", ...
+        "summarizeDegreesOfFreedom"])
     topicPath = "Inspect the domain — Spectral grid — Resolution and shape";
 elseif className == "WVTransformBarotropicQG" && ismember(name,["h","h_0","Lr2"])
     topicPath = "Inspect the domain — Spectral grid — Equivalent depth and deformation scale";
 elseif ismember(name,["verticalModes","h","h_0","h_pm","Lr2", ...
         "waveModeVerticalStructureAtIndex"])
     topicPath = "Inspect the domain — Spectral grid — Vertical modes and scaling";
+elseif ismember(name,["FMatrix","FinvMatrix","GMatrix","GinvMatrix"])
+    topicPath = "Inspect the domain — Spectral grid — Vertical-mode transformation matrices";
 elseif ismember(name,["isHydrostatic","shouldAntialias"])
     topicPath = "Inspect the domain — Transform configuration";
 elseif ismember(name,["diffX","diffY","diffZF","diffZG","intZF","intZG"])
@@ -166,11 +171,17 @@ elseif ismember(name,["diffX","diffY","diffZF","diffZG","intZF","intZG"])
 elseif ismember(name,["transformUVEtaToWaveVortex","transformUVWEtaToWaveVortex", ...
         "transformWaveVortexToUVWEta","transformQGPVToWaveVortex"])
     topicPath = "Convert representations — Physical fields and coefficients";
-elseif name == "hasMeanPressureDifference" || startsWith(name,"summarizeEnergy") || ...
-        name == "summarizeModeEnergy" || name == "summarizeDegreesOfFreedom" || ...
-        ismember(name,energyNames())
-    topicPath = "Analyze the flow — Energy and summaries";
-elseif ismember(name,["uvMax","wMax"])
+elseif ismember(name,["geostrophicEnergy","waveEnergy","inertialEnergy", ...
+        "mdaEnergy","meanDensityAnomalyEnergy", ...
+        "geostrophicKineticEnergy","geostrophicPotentialEnergy", ...
+        "totalEnergyOfFlowComponent"])
+    topicPath = "Analyze energy — Component energy";
+elseif ismember(name,["totalEnergy","totalEnergySpatiallyIntegrated", ...
+        "exactTotalEnergy"])
+    topicPath = "Analyze energy — Total energy";
+elseif startsWith(name,"summarizeEnergy") || name == "summarizeModeEnergy"
+    topicPath = "Analyze energy — Energy summaries";
+elseif ismember(name,["uvMax","wMax","hasMeanPressureDifference"])
     topicPath = "Analyze the flow — Flow diagnostics";
 elseif name == "isDensityInValidRange"
     topicPath = "Analyze the flow — Density validity";
@@ -178,22 +189,29 @@ elseif contains(lower(name),"enstrophy") && ~contains(lower(name),"flux")
     topicPath = "Analyze the flow — Potential vorticity and enstrophy";
 elseif ismember(name,["spectrumWithFgTransform","spectrumWithGgTransform", ...
         "crossSpectrumWithFgTransform","crossSpectrumWithGgTransform", ...
-        "transformToKLAxes"])
+        "transformToKLAxes","kAxis","lAxis"])
     topicPath = "Analyze the flow — Spectra — Spectral fields";
 elseif name == "kRadial" || name == "transformToRadialWavenumber"
     topicPath = "Analyze the flow — Spectra — Radial wavenumber";
 elseif name == "convertFromWavenumberToFrequency"
     topicPath = "Analyze the flow — Spectra — Frequency";
-elseif ismember(name,["addForcing","setForcing","removeForcing", ...
-        "removeAllForcing","forcingNames","forcingWithName", ...
-        "hasForcingWithName","summarizeForcing","forcing","hasClosure"])
-    topicPath = "Manage forcing and closures";
+elseif ismember(name,["addForcing","setForcing","removeForcing","removeAllForcing"])
+    topicPath = "Manage forcing and closures — Configure forcing";
+elseif ismember(name,["forcingNames","forcingWithName", ...
+        "hasForcingWithName","forcing","hasClosure"])
+    topicPath = "Manage forcing and closures — Inspect forcing and closures";
+elseif name == "summarizeForcing"
+    topicPath = "Manage forcing and closures — Summarize forcing";
 elseif ismember(name,["waveComponent","inertialComponent", ...
-        "geostrophicComponent","mdaComponent","flowComponentNames", ...
-        "flowComponentWithName","flowComponents", ...
+        "geostrophicComponent","mdaComponent", ...
         "primaryFlowComponentNames","primaryFlowComponentWithName", ...
-        "primaryFlowComponents","totalFlowComponent","summarizeFlowComponents"])
-    topicPath = "Inspect flow components";
+        "primaryFlowComponents"])
+    topicPath = "Inspect flow components — Primary flow components";
+elseif ismember(name,["flowComponentNames","flowComponentWithName", ...
+        "flowComponents","totalFlowComponent"])
+    topicPath = "Inspect flow components — Registered and combined components";
+elseif name == "summarizeFlowComponents"
+    topicPath = "Inspect flow components — Summarize flow components";
 elseif ismember(name,["addFlowComponent","addPrimaryFlowComponent"])
     topicPath = "Extend a transform — Flow components";
 elseif ismember(name,["addOperation","removeOperation","operationWithName", ...
@@ -221,15 +239,23 @@ orderedGroups = {
     ["Lx","Ly","Lz"]
     ["Nx","Ny","Nz","spatialMatrixSize"]
     ["z_int","volumeIntegral"]
-    ["kAxis","lAxis","j","dk","dl"]
-    ["k","l","K","L","J","klGrid","kljGrid"]
+    ["k","l","j"]
+    ["K","L","J","klGrid","kljGrid"]
+    ["dk","dl"]
     ["Kh","K2"]
     ["Nj","Nkl","spectralMatrixSize","effectiveHorizontalGridResolution", ...
-        "effectiveVerticalGridResolution","effectiveJMax"]
+        "effectiveVerticalGridResolution","effectiveJMax","summarizeDegreesOfFreedom"]
     ["verticalModes","h","h_0","h_pm","Lr2","waveModeVerticalStructureAtIndex"]
+    ["FMatrix","FinvMatrix","GMatrix","GinvMatrix"]
+    ["addForcing","setForcing","removeForcing","removeAllForcing"]
+    ["forcing","forcingNames","forcingWithName","hasForcingWithName","hasClosure"]
+    ["waveComponent","inertialComponent","geostrophicComponent","mdaComponent", ...
+        "primaryFlowComponents","primaryFlowComponentNames","primaryFlowComponentWithName"]
+    ["flowComponents","flowComponentNames","flowComponentWithName","totalFlowComponent"]
     ["Ap","Am","A0"]
     ["Apt","Amt","A0t","waveCoefficientsAtTimeT"]
     ["t0","t","Omega","iOmega","phase","conjPhase"]
+    ["kAxis","lAxis","transformToKLAxes"]
     ["kRadial","transformToRadialWavenumber"]
     };
 
@@ -247,25 +273,51 @@ function topicPath = transformDeveloperTopic(name)
 lowerName = lower(name);
 if name == "WVTransform"
     topicPath = "Construction internals";
+elseif ismember(name,["kMode_dft","lMode_dft","kMode_wv","lMode_wv", ...
+        "isValidConjugateKLModeNumber","isValidConjugateModeNumber", ...
+        "isValidKLModeNumber","isValidModeNumber", ...
+        "isValidPrimaryKLModeNumber","isValidPrimaryModeNumber", ...
+        "primaryKLModeNumberFromKLModeNumber"])
+    topicPath = "Geometry and mode indexing — Mode numbers and validity";
+elseif ismember(name,["indexFromKLModeNumber","indexFromModeNumber", ...
+        "klModeNumberFromIndex","modeNumberFromIndex"])
+    topicPath = "Geometry and mode indexing — Linear-index conversion";
+elseif ismember(name,["conjugateDimension","Nk_dft","Nl_dft", ...
+        "k_dft","l_dft","kl","dftConjugateIndices2D", ...
+        "dftPrimaryIndices2D","indicesOfFourierConjugates", ...
+        "shouldExcludeConjugates","shouldExcludeNyquist"])
+    topicPath = "Geometry and mode indexing — DFT and WV layout metadata";
+elseif ismember(name,["indicesFromDFTGridToWVGrid", ...
+        "indicesFromWVGridToDFTGrid","transformFromDFTGridToWVGrid", ...
+        "transformFromWVGridToDFTGrid", ...
+        "transformFromSpatialDomainToDFTGrid", ...
+        "transformToSpatialDomainFromDFTGrid", ...
+        "transformToSpatialDomainFromDFTGridAtPosition"])
+    topicPath = "Geometry and mode indexing — Layout conversion";
+elseif ismember(name,["maskForAliasedModes", ...
+        "maskForConjugateFourierCoefficients","maskForNyquistModes", ...
+        "isHermitian","setConjugateToUnity"])
+    topicPath = "Geometry and mode indexing — Masks and Hermitian bookkeeping";
 elseif contains(lowerName,"cache") || contains(lowerName,"namemap") || ...
         contains(lowerName,"annotation") || contains(lowerName,"operation")
     topicPath = "Caches and registries";
 elseif contains(lowerName,"group") || contains(lowerName,"requiredpropert") || ...
         contains(lowerName,"netcdf") || startsWith(name,"restore") || startsWith(name,"namesOf")
     topicPath = "Persistence internals";
-elseif contains(lowerName,"flux") || contains(lowerName,"forcing") || startsWith(name,"rk4")
+elseif contains(lowerName,"flux") || contains(lowerName,"forcing") || ...
+        startsWith(name,"rk4") || ismember(name,["Fu","Fv","Feta","F0","Fpv"])
     topicPath = "Nonlinear flux and forcing internals";
 elseif contains(lowerName,"index") || contains(lowerName,"mode") || ...
         contains(lowerName,"grid") || contains(lowerName,"mask") || ...
         contains(lowerName,"axis") || contains(lowerName,"dimension") || ...
         contains(lowerName,"matrixsize") || startsWith(name,"isValid")
-    topicPath = "Geometry and mode indexing";
+    topicPath = "Geometry and mode indexing — Additional geometry utilities";
 elseif contains(lowerName,"transform") || contains(lowerName,"matrix") || ...
         contains(lowerName,"dct") || contains(lowerName,"dst") || ...
-        startsWith(name,"PF") || startsWith(name,"QG")
+        startsWith(name,"PF") || startsWith(name,"QG") || ismember(name,["P0","Q0"])
     topicPath = "Spectral transforms and operators";
 elseif contains(name,"Ap") || contains(name,"Am") || contains(name,"A0") || ...
-        ismember(name,["Fu","Fv","Feta","F0","Fpv","PA0","P0","Q0"])
+        name == "PA0"
     topicPath = "Projection and reconstruction coefficients";
 else
     topicPath = "Class internals";
@@ -485,12 +537,4 @@ end
 if numel(parts) >= 3
     metadata.subsubtopic = parts(3);
 end
-end
-
-function names = energyNames()
-names = ["totalEnergy","totalEnergySpatiallyIntegrated","exactTotalEnergy", ...
-    "geostrophicEnergy","waveEnergy","inertialEnergy", ...
-    "mdaEnergy","meanDensityAnomalyEnergy", ...
-    "geostrophicKineticEnergy","geostrophicPotentialEnergy", ...
-    "totalEnergyOfFlowComponent"];
 end


### PR DESCRIPTION
## Summary

- reorganize concrete WVTransform topics around user workflows and geometry
- harmonize coefficient, density, grid, and projection/reconstruction summaries
- restore F/G transformation-matrix notation and simplify forcing selection tables

## Verification

- focused API documentation tests
- documentation build and deterministic check
- internal-route validation
- Code Analyzer and lightweight repository checks

This is the documentation prerequisite for #134.