### PR TITLE
Define the published benchmark contract

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -21,9 +21,31 @@ The registered suites are:
 
 The runner accepts more than one suite and a subset of case IDs. Suite definitions are versioned in `waveVortexBenchmarkSuites`; changing a case matrix or score definition requires a new suite version. Backends are selected independently from transform families through `waveVortexBenchmarkBackends`.
 
-Every scored case is normalized against its matching committed builtin reference. Case score 100 matches the reference. Family and suite scores use geometric means, with transform families weighted equally. Same-host builtin-to-candidate speedups are reported separately.
+Every scored case is normalized against the builtin reference registered for its suite in `results/catalog.json`. The runner reads the catalog entry directly; it does not infer a reference from a machine model, MATLAB release, or backend name. Case score 100 matches the reference. Family and suite scores use geometric means, with transform families weighted equally. Same-host builtin-to-candidate speedups are reported separately.
 
 Ordinary artifacts are written beneath the ignored `results/runs` directory. Immutable reference artifacts live beneath `results/reference`. Memory measurements use a fresh MATLAB process and report baseline, persistent, and peak-observed resident memory; these process measurements include MATLAB runtime and allocator behavior.
+
+Reference generation is an explicit authoring operation. Supply `shouldCreateReference=true` together with a temporary or candidate `referenceDirectory`; the runner writes `<referenceDirectory>/<suiteId>` and never edits the catalog automatically. Review and catalog approval are separate steps.
+
+## Raw and published benchmark data
+
+The detailed MATLAB runner artifact is implementation-specific. It retains construction time, cache diagnostics, scoring fields, failures, and other information useful to benchmark authors. Future raw artifacts use schema `1.1.0`, which adds the WaveVortexModel package version and a human-readable processor name without changing the measured operation.
+
+Public results use the language-neutral schema in `schemas/published-benchmark-v1.schema.json`. One published dataset represents one suite, implementation, backend, platform, and run. It contains the timing samples, median runtime, correctness result, and process-memory measurements needed by the benchmark website without requiring consumers to understand MATLAB runner internals. Missing implementation coverage is recorded as `unavailable`; it is never treated as failed or zero performance.
+
+Normalize a MATLAB artifact with explicit platform identity and repository-relative provenance:
+
+```matlab
+dataset = publishedWaveVortexBenchmarkFromMatlabArtifact(rawPath,suiteId="scaling-standard-v1",platformId="m5-max",platformName="Apple M5 Max",provenancePath="Benchmarks/results/reference/example/benchmark.json");
+```
+
+Legacy `1.0.0` artifacts do not contain a package version or useful processor name, so normalization also requires `implementationVersion` and `processorName`. The original raw artifact is read-only and is never rewritten.
+
+The normalizer returns an ordinary MATLAB structure in canonical field order. Authors can inspect it or encode it with `jsonencode`; Issue #140 owns the reviewed process for writing and registering public datasets.
+
+Published dataset IDs use `<suite>--<implementation>-<backend>--<platform>--<UTC timestamp>`. Approved datasets are listed in `results/catalog.json`; the catalog entry points to the dataset instead of duplicating its machine or implementation metadata. The benchmark website work in Issue #139 owns the comparison rules needed for its plots and tables.
+
+The catalog intentionally excludes transform-layout, storage, retirement, and other engineering gates. Those artifacts continue to support implementation decisions but are not public performance datasets.
 
 The large suites can require substantial time and memory. A partial result is valid, but a family or suite receives no aggregate score unless every required case completes.
 

--- a/Benchmarks/publishedWaveVortexBenchmarkFromMatlabArtifact.m
+++ b/Benchmarks/publishedWaveVortexBenchmarkFromMatlabArtifact.m
@@ -1,0 +1,159 @@
+function dataset = publishedWaveVortexBenchmarkFromMatlabArtifact(rawArtifactPath,options)
+% Normalize one MATLAB suite and backend for public benchmark use.
+arguments
+    rawArtifactPath (1,1) string
+    options.suiteId (1,1) string
+    options.platformId (1,1) string
+    options.platformName (1,1) string
+    options.provenancePath (1,1) string
+    options.backendId (1,1) string = "builtin"
+    options.processorName (1,1) string = ""
+    options.implementationVersion (1,1) string = ""
+    options.implementationRepository (1,1) string = "https://github.com/JeffreyEarly/wave-vortex-model"
+end
+
+if ~isfile(rawArtifactPath)
+    error("WaveVortexBenchmark:MissingRawArtifact","Raw benchmark artifact does not exist: %s.",rawArtifactPath);
+end
+raw = jsondecode(fileread(rawArtifactPath));
+if ~isfield(raw,"schemaVersion")
+    error("WaveVortexBenchmark:InvalidRawArtifact","Raw benchmark artifact is missing schemaVersion.");
+end
+rawSchemaVersion = string(raw.schemaVersion);
+if ~ismember(rawSchemaVersion,["1.0.0" "1.1.0"])
+    error("WaveVortexBenchmark:UnsupportedRawSchema","Unsupported raw benchmark schema: %s.",rawSchemaVersion);
+end
+suite = selectedSuite(raw.suites,options.suiteId);
+if ~isfield(suite,"operation") || ~ismember(string(suite.operation),["nonlinearAdvection" "nonlinearFlux"])
+    error("WaveVortexBenchmark:UnsupportedPublishedOperation","Published benchmark v1 supports only the state-advanced nonlinearFlux contract.");
+end
+environment = raw.environment;
+configuration = raw.configuration;
+if ~isfield(environment,"sourceDirty") || logical(environment.sourceDirty)
+    error("WaveVortexBenchmark:DirtyPublishedSource","Published benchmark artifacts require a clean source commit.");
+end
+
+processorName = options.processorName;
+if processorName == "" && isfield(environment,"processorName")
+    processorName = string(environment.processorName);
+end
+if processorName == "" && isfield(environment,"processor")
+    processorName = string(environment.processor);
+end
+if processorName == ""
+    error("WaveVortexBenchmark:MissingProcessorName","A human-readable processor name is required.");
+end
+
+implementationVersion = options.implementationVersion;
+if implementationVersion == "" && isfield(environment,"packageVersion")
+    implementationVersion = string(environment.packageVersion);
+end
+if implementationVersion == ""
+    error("WaveVortexBenchmark:MissingImplementationVersion","An implementation version is required for this raw artifact.");
+end
+
+[collectedAt,timestamp] = collectionTime(raw.runId);
+datasetId = options.suiteId + "--matlab-" + options.backendId + "--" + options.platformId + "--" + timestamp;
+benchmark = struct("suiteId",string(suite.id),"suiteVersion",double(suite.version),"operation","nonlinearFlux","correctnessTolerance",double(configuration.correctnessTolerance));
+displayName = "WaveVortexModel MATLAB";
+if isfield(environment,"packageName")
+    displayName = string(environment.packageName) + " MATLAB";
+end
+implementation = struct("id","matlab","displayName",displayName,"version",implementationVersion,"repository",options.implementationRepository,"commit",string(environment.sourceCommit),"backend",options.backendId,"sourceDirty",logical(environment.sourceDirty));
+platform = struct("id",options.platformId,"displayName",options.platformName,"processor",processorName,"physicalMemoryBytes",double(environment.physicalMemoryBytes),"os",string(environment.os),"architecture",string(environment.architecture),"threadCount",double(environment.requestedThreads));
+details = struct("matlabRelease",string(environment.matlabRelease));
+toolchain = struct("kind","matlab","name","MATLAB","version",string(environment.matlabVersion),"details",details);
+provenance = struct("rawArtifact",options.provenancePath,"rawSchemaVersion",rawSchemaVersion);
+
+rawCases = suite.cases;
+cases = cell(1,numel(rawCases));
+for iCase = 1:numel(rawCases)
+    if iscell(rawCases)
+        rawCase = rawCases{iCase};
+    else
+        rawCase = rawCases(iCase);
+    end
+    cases{iCase} = normalizeCase(rawCase,options.backendId);
+end
+dataset = struct("schemaVersion","published-benchmark-v1","datasetId",datasetId,"collectedAt",collectedAt,"benchmark",benchmark,"implementation",implementation,"platform",platform,"toolchain",toolchain,"provenance",provenance,"cases",{cases});
+end
+
+function benchmarkCase = normalizeCase(rawCase,backendId)
+if ~isfield(rawCase,"operation") || ~ismember(string(rawCase.operation),["nonlinearAdvection" "nonlinearFlux"])
+    error("WaveVortexBenchmark:UnsupportedPublishedOperation","Raw cases must measure the state-advanced nonlinearFlux contract.");
+end
+configuration = struct("Lxyz",double(rawCase.Lxyz(:)'),"Nxyz",double(rawCase.Nxyz(:)'),"isHydrostatic",logical(rawCase.isHydrostatic),"shouldAntialias",logical(rawCase.shouldAntialias),"seed",double(rawCase.seed),"warmupCount",double(rawCase.warmupCount),"sampleCount",double(rawCase.sampleCount));
+common = {"id",string(rawCase.id),"transformId",string(rawCase.transformId),"scoreFamily",string(rawCase.scoreFamily),"configuration",configuration};
+if string(rawCase.status) ~= "complete"
+    error("WaveVortexBenchmark:UnpublishableRawCase","Raw case %s did not complete and cannot be published.",string(rawCase.id));
+end
+backends = rawCase.backends;
+backendIndex = 0;
+for iBackend = 1:numel(backends)
+    if iscell(backends)
+        backend = backends{iBackend};
+    else
+        backend = backends(iBackend);
+    end
+    if string(backend.id) == backendId
+        backendIndex = iBackend;
+        break
+    end
+end
+if backendIndex == 0
+    benchmarkCase = struct(common{:},"status","unavailable","unavailableReason","Backend " + backendId + " was not recorded in the raw artifact.");
+    return
+end
+if iscell(backends)
+    backend = backends{backendIndex};
+else
+    backend = backends(backendIndex);
+end
+if string(backend.status) ~= "complete" || ~logical(backend.correctnessPassed)
+    error("WaveVortexBenchmark:UnpublishableRawCase","Raw backend %s for case %s did not pass.",backendId,string(rawCase.id));
+end
+samples = double(backend.rawSeconds(:)');
+timing = struct("medianSeconds",double(backend.medianSeconds),"samplesSeconds",samples);
+correctness = struct("passed",logical(backend.correctnessPassed),"relativeError",double(backend.relativeError));
+memory = normalizeMemory(backend.memory);
+benchmarkCase = struct(common{:},"status","complete","timing",timing,"correctness",correctness,"memory",memory);
+end
+
+function memory = normalizeMemory(rawMemory)
+if isfield(rawMemory,"status") && string(rawMemory.status) == "complete"
+    memory = struct("status","complete","provider",string(rawMemory.provider),"baselineProcessBytes",double(rawMemory.baselineBytes),"peakProcessBytes",double(rawMemory.peakBytes),"peakIncrementBytes",double(rawMemory.peakIncrementBytes));
+    return
+end
+reason = "Memory measurement was unavailable in the raw artifact.";
+if isfield(rawMemory,"status") && string(rawMemory.status) == "not-requested"
+    reason = "Memory measurement was not requested.";
+elseif isfield(rawMemory,"failure") && isfield(rawMemory.failure,"message") && strlength(string(rawMemory.failure.message)) > 0
+    reason = string(rawMemory.failure.message);
+end
+memory = struct("status","unavailable","reason",reason);
+end
+
+function suite = selectedSuite(suites,suiteId)
+for iSuite = 1:numel(suites)
+    if iscell(suites)
+        candidate = suites{iSuite};
+    else
+        candidate = suites(iSuite);
+    end
+    if string(candidate.id) == suiteId
+        suite = candidate;
+        return
+    end
+end
+error("WaveVortexBenchmark:MissingRawSuite","Raw benchmark artifact does not contain suite %s.",suiteId);
+end
+
+function [collectedAt,timestamp] = collectionTime(runId)
+runId = string(runId);
+if isempty(regexp(runId,"^\d{8}T\d{6}Z$","once"))
+    error("WaveVortexBenchmark:InvalidCollectionTime","Raw benchmark runId must use UTC YYYYMMDDTHHmmssZ format.");
+end
+instant = datetime(runId,"InputFormat","yyyyMMdd'T'HHmmss'Z'","TimeZone","UTC");
+collectedAt = string(instant,"yyyy-MM-dd'T'HH:mm:ss'Z'");
+timestamp = string(instant,"yyyyMMdd'T'HHmmss'Z'");
+end

--- a/Benchmarks/results/catalog.json
+++ b/Benchmarks/results/catalog.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "benchmark-catalog-v1",
+  "scoringReferences": [
+    {
+      "suiteId": "core-v1",
+      "backendId": "builtin",
+      "rawArtifact": "Benchmarks/results/reference/core-v1-m5-max-r2026a-builtin/benchmark.json"
+    },
+    {
+      "suiteId": "scaling-standard-v1",
+      "backendId": "builtin",
+      "rawArtifact": "Benchmarks/results/reference/scaling-standard-v1-m5-max-r2026a-builtin/benchmark.json"
+    },
+    {
+      "suiteId": "scaling-large-v1",
+      "backendId": "builtin",
+      "rawArtifact": "Benchmarks/results/reference/scaling-large-v1-m5-max-r2026a-builtin/benchmark.json"
+    }
+  ],
+  "publishedDatasets": []
+}

--- a/Benchmarks/runWaveVortexBenchmark.m
+++ b/Benchmarks/runWaveVortexBenchmark.m
@@ -10,6 +10,7 @@ arguments
     options.caseIds (1,:) string = strings(1,0)
     options.outputDirectory (1,1) string = ""
     options.referenceDirectory (1,1) string = ""
+    options.catalogPath (1,1) string = ""
     options.shouldMeasureMemory (1,1) logical = true
     options.shouldWriteArtifacts (1,1) logical = true
     options.shouldCreateReference (1,1) logical = false
@@ -33,14 +34,19 @@ backends = waveVortexBenchmarkBackends(options.backends);
 if options.runId == ""
     options.runId = string(datetime("now","TimeZone","UTC","Format","yyyyMMdd'T'HHmmss'Z'"));
 end
-if options.referenceDirectory == ""
-    options.referenceDirectory = fullfile(benchmarkFolder,"results","reference");
+if options.catalogPath == ""
+    options.catalogPath = fullfile(benchmarkFolder,"results","catalog.json");
+end
+if options.shouldCreateReference && options.referenceDirectory == ""
+    error("WaveVortexBenchmark:ReferenceDirectoryRequired","referenceDirectory is required when shouldCreateReference is true.");
+elseif ~options.shouldCreateReference && options.referenceDirectory ~= ""
+    error("WaveVortexBenchmark:ReferenceDirectoryNotApplicable","referenceDirectory is used only when shouldCreateReference is true.");
 end
 if options.outputDirectory == ""
     options.outputDirectory = fullfile(benchmarkFolder,"results","runs",options.runId + "-" + computer("arch") + "-" + version("-release"));
 end
 
-results = struct("schemaVersion","1.0.0","status","complete","runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",options.suites,"backendIds",options.backends,"caseIds",options.caseIds,"correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",options.shouldMeasureMemory),"suites",emptySuiteResults());
+results = struct("schemaVersion","1.1.0","status","complete","runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",options.suites,"backendIds",options.backends,"caseIds",options.caseIds,"correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",options.shouldMeasureMemory),"suites",emptySuiteResults());
 for iSuite = 1:numel(suites)
     suiteResult = runSuite(suites(iSuite),backends,options,benchmarkFolder,repositoryRoot);
     results.suites(end+1) = suiteResult;
@@ -56,13 +62,13 @@ clear stateCleanup
 end
 
 function suiteResult = runSuite(suite,backends,options,benchmarkFolder,repositoryRoot)
-referencePath = referenceArtifactPath(options.referenceDirectory,suite.id);
+[referenceFile,referenceArtifact,referenceOutputDirectory] = referenceLocations(suite,options,repositoryRoot);
 if suite.kind == "transform-layout"
     suiteResult = runWaveVortexTransformLayoutSuite(suite,options.correctnessTolerance,repositoryRoot);
-    suiteResult.referenceArtifact = referencePath;
+    suiteResult.referenceArtifact = referenceArtifact;
     if options.shouldCreateReference
-        referenceResults = struct("schemaVersion","1.0.0","status",suiteResult.status,"runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",suite.id,"backendIds","builtin","correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",false),"suites",suiteResult);
-        writeRunArtifacts(referenceResults,referencePath);
+        referenceResults = struct("schemaVersion","1.1.0","status",suiteResult.status,"runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",suite.id,"backendIds","builtin","correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",false),"suites",suiteResult);
+        writeRunArtifacts(referenceResults,referenceOutputDirectory);
     end
     return
 end
@@ -80,17 +86,58 @@ if ~suite.selectionIsComplete
     suiteResult.status = "partial";
 end
 
-suiteResult.referenceArtifact = referencePath;
+suiteResult.referenceArtifact = referenceArtifact;
 if options.shouldCreateReference
     suiteResult = applySelfReferenceScores(suiteResult);
 else
-    suiteResult = applyReferenceScores(suiteResult,referencePath);
+    suiteResult = applyReferenceScores(suiteResult,referenceFile);
 end
 suiteResult = calculateAggregateScores(suiteResult);
 
 if options.shouldCreateReference
-    referenceResults = struct("schemaVersion","1.0.0","status",suiteResult.status,"runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",suite.id,"backendIds","builtin","correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",options.shouldMeasureMemory),"suites",suiteResult);
-    writeRunArtifacts(referenceResults,referencePath);
+    referenceResults = struct("schemaVersion","1.1.0","status",suiteResult.status,"runId",options.runId,"environment",benchmarkEnvironment(repositoryRoot),"configuration",struct("suiteIds",suite.id,"backendIds","builtin","correctnessTolerance",options.correctnessTolerance,"shouldMeasureMemory",options.shouldMeasureMemory),"suites",suiteResult);
+    writeRunArtifacts(referenceResults,referenceOutputDirectory);
+end
+end
+
+function [referenceFile,referenceArtifact,referenceOutputDirectory] = referenceLocations(suite,options,repositoryRoot)
+referenceFile = "";
+referenceArtifact = "";
+referenceOutputDirectory = "";
+if options.shouldCreateReference
+    referenceOutputDirectory = fullfile(options.referenceDirectory,suite.id);
+    referenceFile = fullfile(referenceOutputDirectory,"benchmark.json");
+    referenceArtifact = referenceOutputDirectory;
+elseif suite.isScored
+    [referenceFile,referenceArtifact] = scoringReferenceFromCatalog(options.catalogPath,suite.id,repositoryRoot);
+end
+end
+
+function [absolutePath,relativePath] = scoringReferenceFromCatalog(catalogPath,suiteId,repositoryRoot)
+if ~isfile(catalogPath)
+    error("WaveVortexBenchmark:MissingCatalog","Benchmark catalog does not exist: %s.",catalogPath);
+end
+catalog = jsondecode(fileread(catalogPath));
+if ~isfield(catalog,"schemaVersion") || string(catalog.schemaVersion) ~= "benchmark-catalog-v1" || ~isfield(catalog,"scoringReferences")
+    error("WaveVortexBenchmark:InvalidCatalog","Benchmark catalog must use schema benchmark-catalog-v1 and contain scoringReferences.");
+end
+references = catalog.scoringReferences;
+matches = string({references.suiteId}) == suiteId;
+if nnz(matches) ~= 1
+    error("WaveVortexBenchmark:MissingScoringReference","Benchmark catalog must contain exactly one scoring reference for suite %s.",suiteId);
+end
+reference = references(matches);
+if string(reference.backendId) ~= "builtin"
+    error("WaveVortexBenchmark:InvalidCatalog","Scoring reference for suite %s must use the builtin backend.",suiteId);
+end
+relativePath = string(reference.rawArtifact);
+parts = split(relativePath,"/");
+if startsWith(relativePath,["/" "\\"]) || ~isempty(regexp(relativePath,"^[A-Za-z]:","once")) || contains(relativePath,"\\") || any(parts == "..") || any(parts == "")
+    error("WaveVortexBenchmark:InvalidCatalog","Scoring reference paths must be repository-relative and cannot contain traversal.");
+end
+absolutePath = fullfile(repositoryRoot,relativePath);
+if ~isfile(absolutePath)
+    error("WaveVortexBenchmark:MissingScoringReference","Scoring reference does not exist: %s.",relativePath);
 end
 end
 
@@ -170,9 +217,8 @@ for iCase = 1:numel(suiteResult.cases)
 end
 end
 
-function suiteResult = applyReferenceScores(suiteResult,referencePath)
-referenceFile = fullfile(referencePath,"benchmark.json");
-if ~isfile(referenceFile)
+function suiteResult = applyReferenceScores(suiteResult,referenceFile)
+if referenceFile == "" || ~isfile(referenceFile)
     return
 end
 reference = jsondecode(fileread(referenceFile));
@@ -268,7 +314,29 @@ end
 function environment = benchmarkEnvironment(repositoryRoot)
 [~,commit] = system(sprintf('git -C "%s" rev-parse HEAD',repositoryRoot));
 [~,dirty] = system(sprintf('git -C "%s" status --porcelain',repositoryRoot));
-environment = struct("os",string(system_dependent("getos")),"processor",string(system_dependent("getcpu")),"physicalMemoryBytes",physicalMemoryBytes(),"matlabVersion",string(version),"matlabRelease",string(version("-release")),"architecture",string(computer("arch")),"requestedThreads",maxNumCompThreads,"sourceCommit",strtrim(string(commit)),"sourceDirty",strlength(strtrim(string(dirty))) > 0);
+metadata = jsondecode(fileread(fullfile(repositoryRoot,"resources","mpackage.json")));
+environment = struct("os",string(system_dependent("getos")),"processor",string(system_dependent("getcpu")),"processorName",processorName(),"physicalMemoryBytes",physicalMemoryBytes(),"matlabVersion",string(version),"matlabRelease",string(version("-release")),"architecture",string(computer("arch")),"requestedThreads",maxNumCompThreads,"sourceCommit",strtrim(string(commit)),"sourceDirty",strlength(strtrim(string(dirty))) > 0,"packageName",string(metadata.name),"packageVersion",string(metadata.version));
+end
+
+function name = processorName()
+name = "";
+if ismac
+    [status,output] = system("sysctl -n machdep.cpu.brand_string");
+    if status == 0
+        name = strtrim(string(output));
+    end
+elseif isunix && isfile("/proc/cpuinfo")
+    text = fileread("/proc/cpuinfo");
+    token = regexp(text,"(?:model name|Hardware)\s*:\s*([^\r\n]+)","tokens","once");
+    if ~isempty(token)
+        name = strtrim(string(token{1}));
+    end
+elseif ispc
+    name = strtrim(string(getenv("PROCESSOR_IDENTIFIER")));
+end
+if name == ""
+    name = string(system_dependent("getcpu"));
+end
 end
 
 function bytes = physicalMemoryBytes()
@@ -288,10 +356,6 @@ elseif isunix && isfile("/proc/meminfo")
         bytes = 1024*str2double(token{1});
     end
 end
-end
-
-function path = referenceArtifactPath(referenceDirectory,suiteId)
-path = fullfile(referenceDirectory,suiteId + "-m5-max-r2026a-builtin");
 end
 
 function addRepositoryPaths(repositoryRoot,benchmarkFolder)

--- a/Benchmarks/schemas/benchmark-catalog-v1.schema.json
+++ b/Benchmarks/schemas/benchmark-catalog-v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wavevortexmodel.org/schemas/benchmark-catalog-v1.schema.json",
+  "title": "WaveVortexModel benchmark catalog v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "scoringReferences", "publishedDatasets"],
+  "properties": {
+    "schemaVersion": {"const": "benchmark-catalog-v1"},
+    "scoringReferences": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["suiteId", "backendId", "rawArtifact"],
+        "properties": {
+          "suiteId": {"enum": ["core-v1", "scaling-standard-v1", "scaling-large-v1"]},
+          "backendId": {"const": "builtin"},
+          "rawArtifact": {"$ref": "#/$defs/repositoryPath"}
+        }
+      }
+    },
+    "publishedDatasets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["datasetId", "artifact"],
+        "properties": {
+          "datasetId": {"type": "string", "minLength": 1},
+          "artifact": {"$ref": "#/$defs/repositoryPath"}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "repositoryPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*//).+$"
+    }
+  }
+}

--- a/Benchmarks/schemas/published-benchmark-v1.schema.json
+++ b/Benchmarks/schemas/published-benchmark-v1.schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wavevortexmodel.org/schemas/published-benchmark-v1.schema.json",
+  "title": "WaveVortexModel published benchmark v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "datasetId",
+    "collectedAt",
+    "benchmark",
+    "implementation",
+    "platform",
+    "toolchain",
+    "provenance",
+    "cases"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "published-benchmark-v1"},
+    "datasetId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*--(?:matlab|cpp)-[a-z0-9][a-z0-9-]*--[a-z0-9][a-z0-9-]*--[0-9]{8}T[0-9]{6}Z$"},
+    "collectedAt": {"type": "string", "format": "date-time", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"},
+    "benchmark": {"$ref": "#/$defs/benchmark"},
+    "implementation": {"$ref": "#/$defs/implementation"},
+    "platform": {"$ref": "#/$defs/platform"},
+    "toolchain": {"$ref": "#/$defs/toolchain"},
+    "provenance": {"$ref": "#/$defs/provenance"},
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/case"}
+    }
+  },
+  "$defs": {
+    "slug": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "positiveInteger": {"type": "integer", "minimum": 1},
+    "nonnegativeNumber": {"type": "number", "minimum": 0},
+    "positiveNumber": {"type": "number", "exclusiveMinimum": 0},
+    "benchmark": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suiteId", "suiteVersion", "operation", "correctnessTolerance"],
+      "properties": {
+        "suiteId": {"$ref": "#/$defs/slug"},
+        "suiteVersion": {"$ref": "#/$defs/positiveInteger"},
+        "operation": {"const": "nonlinearFlux"},
+        "correctnessTolerance": {"$ref": "#/$defs/positiveNumber"}
+      }
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "displayName", "version", "repository", "commit", "backend", "sourceDirty"],
+      "properties": {
+        "id": {"enum": ["matlab", "cpp"]},
+        "displayName": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "repository": {"type": "string", "format": "uri"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "backend": {"$ref": "#/$defs/slug"},
+        "sourceDirty": {"const": false}
+      }
+    },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "displayName", "processor", "physicalMemoryBytes", "os", "architecture", "threadCount"],
+      "properties": {
+        "id": {"$ref": "#/$defs/slug"},
+        "displayName": {"type": "string", "minLength": 1},
+        "processor": {"type": "string", "minLength": 1},
+        "physicalMemoryBytes": {"$ref": "#/$defs/positiveInteger"},
+        "os": {"type": "string", "minLength": 1},
+        "architecture": {"type": "string", "minLength": 1},
+        "threadCount": {"$ref": "#/$defs/positiveInteger"}
+      }
+    },
+    "toolchain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "name", "version", "details"],
+      "properties": {
+        "kind": {"enum": ["matlab", "cpp"]},
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "details": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rawArtifact", "rawSchemaVersion"],
+      "properties": {
+        "rawArtifact": {"type": "string", "minLength": 1, "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*//).+$"},
+        "rawSchemaVersion": {"type": "string", "minLength": 1}
+      }
+    },
+    "configuration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["Lxyz", "Nxyz", "isHydrostatic", "shouldAntialias", "seed", "warmupCount", "sampleCount"],
+      "properties": {
+        "Lxyz": {"type": "array", "minItems": 2, "maxItems": 3, "items": {"$ref": "#/$defs/positiveNumber"}},
+        "Nxyz": {"type": "array", "minItems": 2, "maxItems": 3, "items": {"$ref": "#/$defs/positiveInteger"}},
+        "isHydrostatic": {"type": "boolean"},
+        "shouldAntialias": {"type": "boolean"},
+        "seed": {"type": "integer", "minimum": 0},
+        "warmupCount": {"type": "integer", "minimum": 0},
+        "sampleCount": {"$ref": "#/$defs/positiveInteger"}
+      }
+    },
+    "timing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["medianSeconds", "samplesSeconds"],
+      "properties": {
+        "medianSeconds": {"$ref": "#/$defs/positiveNumber"},
+        "samplesSeconds": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/positiveNumber"}}
+      }
+    },
+    "correctness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed", "relativeError"],
+      "properties": {
+        "passed": {"const": true},
+        "relativeError": {"$ref": "#/$defs/nonnegativeNumber"}
+      }
+    },
+    "memory": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "provider", "baselineProcessBytes", "peakProcessBytes", "peakIncrementBytes"],
+          "properties": {
+            "status": {"const": "complete"},
+            "provider": {"type": "string", "minLength": 1},
+            "baselineProcessBytes": {"$ref": "#/$defs/nonnegativeNumber"},
+            "peakProcessBytes": {"$ref": "#/$defs/nonnegativeNumber"},
+            "peakIncrementBytes": {"$ref": "#/$defs/nonnegativeNumber"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "reason"],
+          "properties": {
+            "status": {"const": "unavailable"},
+            "reason": {"type": "string", "minLength": 1}
+          }
+        }
+      ]
+    },
+    "case": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "transformId", "scoreFamily", "configuration", "status", "timing", "correctness", "memory"],
+          "properties": {
+            "id": {"$ref": "#/$defs/slug"},
+            "transformId": {"$ref": "#/$defs/slug"},
+            "scoreFamily": {"$ref": "#/$defs/slug"},
+            "configuration": {"$ref": "#/$defs/configuration"},
+            "status": {"const": "complete"},
+            "timing": {"$ref": "#/$defs/timing"},
+            "correctness": {"$ref": "#/$defs/correctness"},
+            "memory": {"$ref": "#/$defs/memory"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "transformId", "scoreFamily", "configuration", "status", "unavailableReason"],
+          "properties": {
+            "id": {"$ref": "#/$defs/slug"},
+            "transformId": {"$ref": "#/$defs/slug"},
+            "scoreFamily": {"$ref": "#/$defs/slug"},
+            "configuration": {"$ref": "#/$defs/configuration"},
+            "status": {"const": "unavailable"},
+            "unavailableReason": {"type": "string", "minLength": 1}
+          }
+        }
+      ]
+    }
+  }
+}

--- a/UnitTests/TestPublishedWaveVortexBenchmark.m
+++ b/UnitTests/TestPublishedWaveVortexBenchmark.m
@@ -1,0 +1,128 @@
+classdef TestPublishedWaveVortexBenchmark < matlab.unittest.TestCase
+    properties
+        repositoryRoot
+        benchmarkFolder
+        temporaryFolder
+    end
+
+    methods (TestClassSetup)
+        function addBenchmarkPath(testCase)
+            testCase.repositoryRoot = string(fileparts(fileparts(mfilename("fullpath"))));
+            testCase.benchmarkFolder = fullfile(testCase.repositoryRoot,"Benchmarks");
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(testCase.benchmarkFolder));
+        end
+    end
+
+    methods (TestMethodSetup)
+        function createTemporaryFolder(testCase)
+            fixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+            testCase.temporaryFolder = string(fixture.Folder);
+        end
+    end
+
+    methods (Test,TestTags="full")
+        function schemasAndCatalogDefineThePublishedBoundary(testCase)
+            publishedSchema = jsondecode(fileread(fullfile(testCase.benchmarkFolder,"schemas","published-benchmark-v1.schema.json")));
+            catalogSchema = jsondecode(fileread(fullfile(testCase.benchmarkFolder,"schemas","benchmark-catalog-v1.schema.json")));
+            catalog = jsondecode(fileread(fullfile(testCase.benchmarkFolder,"results","catalog.json")));
+
+            testCase.verifyEqual(string(publishedSchema.title),"WaveVortexModel published benchmark v1");
+            testCase.verifyEqual(string(catalogSchema.title),"WaveVortexModel benchmark catalog v1");
+            testCase.verifyEqual(string(catalog.schemaVersion),"benchmark-catalog-v1");
+            testCase.verifyEqual(string({catalog.scoringReferences.suiteId}),["core-v1" "scaling-standard-v1" "scaling-large-v1"]);
+            testCase.verifyEqual(string({catalog.scoringReferences.backendId}),repmat("builtin",1,3));
+            testCase.verifyEmpty(catalog.publishedDatasets);
+            for iReference = 1:numel(catalog.scoringReferences)
+                reference = catalog.scoringReferences(iReference);
+                relativePath = string(reference.rawArtifact);
+                testCase.verifyTrue(isfile(fullfile(testCase.repositoryRoot,relativePath)));
+                testCase.verifyTrue(startsWith(relativePath,"Benchmarks/results/reference/"));
+                testCase.verifyFalse(contains(relativePath,["transform-layout" "retirement" "storage"]));
+                testCase.verifyFalse(startsWith(relativePath,["/" "\\"]));
+                testCase.verifyFalse(contains(relativePath,[".." "\\"]));
+            end
+        end
+
+        function legacyArtifactNormalizesWithoutMutation(testCase)
+            rawRelativePath = "Benchmarks/results/reference/scaling-standard-v1-m5-max-r2026a-builtin/benchmark.json";
+            rawPath = fullfile(testCase.repositoryRoot,rawRelativePath);
+            originalBytes = fileread(rawPath);
+            dataset = publishedWaveVortexBenchmarkFromMatlabArtifact(rawPath,suiteId="scaling-standard-v1",platformId="m5-max",platformName="Apple M5 Max",provenancePath=rawRelativePath,processorName="Apple M5 Max",implementationVersion="4.2.1");
+
+            expectedFields = ["schemaVersion" "datasetId" "collectedAt" "benchmark" "implementation" "platform" "toolchain" "provenance" "cases"];
+            testCase.verifyEqual(string(fieldnames(dataset))',expectedFields);
+            testCase.verifyEqual(dataset.datasetId,"scaling-standard-v1--matlab-builtin--m5-max--20260808T180708Z");
+            testCase.verifyEqual(dataset.benchmark.operation,"nonlinearFlux");
+            testCase.verifyEqual(dataset.implementation.version,"4.2.1");
+            testCase.verifyEqual(dataset.platform.processor,"Apple M5 Max");
+            testCase.verifyNumElements(dataset.cases,34);
+            testCase.verifyEqual(fileread(rawPath),originalBytes);
+
+            first = dataset.cases{1};
+            testCase.verifyEqual(first.status,"complete");
+            testCase.verifyEqual(first.timing.medianSeconds,median(first.timing.samplesSeconds),AbsTol=1e-15);
+            testCase.verifyEqual(first.memory.peakIncrementBytes,first.memory.peakProcessBytes-first.memory.baselineProcessBytes);
+        end
+
+        function futureArtifactUsesAddedMetadataAndMarksMissingBackend(testCase)
+            rawPath = fullfile(testCase.repositoryRoot,"Benchmarks","results","reference","scaling-standard-v1-m5-max-r2026a-builtin","benchmark.json");
+            raw = jsondecode(fileread(rawPath));
+            raw.schemaVersion = "1.1.0";
+            raw.environment.packageName = "WaveVortexModel";
+            raw.environment.packageVersion = "4.2.1";
+            raw.environment.processorName = "Future Reference CPU";
+            raw.suites.cases(1).backends = struct([]);
+            fixturePath = fullfile(testCase.temporaryFolder,"raw.json");
+            writeJson(fixturePath,raw);
+
+            dataset = publishedWaveVortexBenchmarkFromMatlabArtifact(fixturePath,suiteId="scaling-standard-v1",platformId="future-host",platformName="Future host",provenancePath="Benchmarks/results/runs/future/benchmark.json");
+            testCase.verifyEqual(dataset.implementation.displayName,"WaveVortexModel MATLAB");
+            testCase.verifyEqual(dataset.implementation.version,"4.2.1");
+            testCase.verifyEqual(dataset.platform.processor,"Future Reference CPU");
+            testCase.verifyEqual(dataset.provenance.rawSchemaVersion,"1.1.0");
+            testCase.verifyEqual(dataset.cases{1}.status,"unavailable");
+            testCase.verifySubstring(dataset.cases{1}.unavailableReason,"builtin");
+            testCase.verifyEqual(dataset.cases{2}.status,"complete");
+        end
+
+        function cppDocumentUsesTheSameLanguageNeutralVocabulary(testCase)
+            cpp = exampleCppDataset;
+            encoded = jsonencode(cpp);
+            decoded = jsondecode(encoded);
+            expectedFields = ["schemaVersion" "datasetId" "collectedAt" "benchmark" "implementation" "platform" "toolchain" "provenance" "cases"];
+
+            testCase.verifyEqual(string(fieldnames(decoded))',expectedFields);
+            testCase.verifyEqual(string(decoded.schemaVersion),"published-benchmark-v1");
+            testCase.verifyEqual(string(decoded.implementation.id),"cpp");
+            testCase.verifyEqual(string(decoded.toolchain.kind),"cpp");
+            testCase.verifyFalse(isfield(decoded.toolchain.details,"matlabRelease"));
+            testCase.verifyEqual(string(decoded.cases.status),"unavailable");
+        end
+
+        function runnerContainsNoMachineSpecificReferenceSelection(testCase)
+            source = lower(string(fileread(fullfile(testCase.benchmarkFolder,"runWaveVortexBenchmark.m"))));
+            testCase.verifySubstring(source,"scoringreferencefromcatalog");
+            testCase.verifyFalse(contains(source,"m5-max"));
+            testCase.verifyFalse(contains(source,"r2026a"));
+            testCase.verifyFalse(contains(source,"referenceartifactpath"));
+        end
+    end
+end
+
+function dataset = exampleCppDataset
+benchmark = struct("suiteId","scaling-standard-v1","suiteVersion",1,"operation","nonlinearFlux","correctnessTolerance",1e-12);
+implementation = struct("id","cpp","displayName","WaveVortexModel C++","version","0.1.0","repository","https://github.com/JeffreyEarly/wave-vortex-model-cpp","commit",repmat('a',1,40),"backend","fftw","sourceDirty",false);
+platform = struct("id","example-host","displayName","Example host","processor","Example CPU","physicalMemoryBytes",16*2^30,"os","Example OS","architecture","example64","threadCount",8);
+toolchain = struct("kind","cpp","name","Clang","version","18.0.0","details",struct("buildType","Release"));
+provenance = struct("rawArtifact","Benchmarks/results/cpp/example.json","rawSchemaVersion","cpp-v1");
+configuration = struct("Lxyz",[15e3 15e3 1300],"Nxyz",[64 64 65],"isHydrostatic",false,"shouldAntialias",true,"seed",1,"warmupCount",2,"sampleCount",3);
+benchmarkCase = struct("id","boussinesq-64x64x65","transformId","boussinesq","scoreFamily","boussinesq","configuration",configuration,"status","unavailable","unavailableReason","Transform not implemented by this backend.");
+dataset = struct("schemaVersion","published-benchmark-v1","datasetId","scaling-standard-v1--cpp-fftw--example-host--20260810T123456Z","collectedAt","2026-08-10T12:34:56Z","benchmark",benchmark,"implementation",implementation,"platform",platform,"toolchain",toolchain,"provenance",provenance,"cases",{{benchmarkCase}});
+end
+
+function writeJson(pathname,value)
+fileId = fopen(pathname,"w");
+cleanup = onCleanup(@()fclose(fileId));
+fprintf(fileId,"%s\n",jsonencode(value,PrettyPrint=true));
+clear cleanup
+end

--- a/UnitTests/TestWaveVortexBenchmark.m
+++ b/UnitTests/TestWaveVortexBenchmark.m
@@ -71,10 +71,13 @@ classdef TestWaveVortexBenchmark < matlab.unittest.TestCase
             results = runWaveVortexBenchmark(suites="smoke-v1",caseIds="smoke-constant-hydrostatic",outputDirectory=runFolder,referenceDirectory=referenceFolder,shouldMeasureMemory=false,shouldCreateReference=true,runId="test-run");
             testCase.verifyTrue(isfile(fullfile(runFolder,"benchmark.json")));
             testCase.verifyTrue(isfile(fullfile(runFolder,"summary.md")));
-            referencePath = fullfile(referenceFolder,"smoke-v1-m5-max-r2026a-builtin");
+            referencePath = fullfile(referenceFolder,"smoke-v1");
             testCase.verifyTrue(isfile(fullfile(referencePath,"benchmark.json")));
             decoded = jsondecode(fileread(fullfile(runFolder,"benchmark.json")));
-            testCase.verifyEqual(string(decoded.schemaVersion),"1.0.0");
+            testCase.verifyEqual(string(decoded.schemaVersion),"1.1.0");
+            testCase.verifyEqual(string(decoded.environment.packageName),"WaveVortexModel");
+            testCase.verifyEqual(string(decoded.environment.packageVersion),"4.2.1");
+            testCase.verifyNotEmpty(string(decoded.environment.processorName));
             testCase.verifyEqual(decoded.suites.cases.backends.caseScore,100);
             summary = fileread(fullfile(runFolder,"summary.md"));
             testCase.verifySubstring(summary,"## Suite scores");
@@ -85,6 +88,29 @@ classdef TestWaveVortexBenchmark < matlab.unittest.TestCase
             testCase.verifyEqual(results.runId,"test-run");
             testCase.verifyEqual(results.status,"partial");
             testCase.verifyFalse(results.suites.selectionIsComplete);
+        end
+
+        function referenceCreationRequiresExplicitGenericDirectory(testCase)
+            testCase.verifyError(@()runWaveVortexBenchmark(suites="smoke-v1",shouldMeasureMemory=false,shouldWriteArtifacts=false,shouldCreateReference=true),"WaveVortexBenchmark:ReferenceDirectoryRequired");
+            testCase.verifyError(@()runWaveVortexBenchmark(suites="smoke-v1",referenceDirectory=testCase.temporaryFolder,shouldMeasureMemory=false,shouldWriteArtifacts=false),"WaveVortexBenchmark:ReferenceDirectoryNotApplicable");
+        end
+
+        function catalogScoringPreservesReferenceCalculation(testCase)
+            caseId = "barotropic-qg-128x128";
+            results = runWaveVortexBenchmark(suites="scaling-standard-v1",caseIds=caseId,shouldMeasureMemory=false,shouldWriteArtifacts=false);
+            backend = results.suites.cases.backends;
+            catalog = jsondecode(fileread(fullfile(testCase.benchmarkFolder,"results","catalog.json")));
+            reference = catalog.scoringReferences(string({catalog.scoringReferences.suiteId}) == "scaling-standard-v1");
+            relativePath = string(reference.rawArtifact);
+            referencePath = fullfile(testCase.repositoryRoot,relativePath);
+            reference = jsondecode(fileread(referencePath));
+            referenceIndex = find(string({reference.suites.cases.id}) == caseId,1);
+            referenceMedian = reference.suites.cases(referenceIndex).backends.medianSeconds;
+
+            testCase.verifyEqual(results.suites.referenceArtifact,relativePath);
+            testCase.verifyEqual(backend.referenceMedianSeconds,referenceMedian);
+            testCase.verifyEqual(backend.caseScore,100*referenceMedian/backend.medianSeconds,RelTol=1e-14);
+            testCase.verifyTrue(isfinite(backend.caseScore));
         end
 
         function freshProcessMemoryIsRecorded(testCase)


### PR DESCRIPTION
## Summary

- define the language-neutral published benchmark and catalog schemas
- normalize MATLAB benchmark artifacts through one focused production function
- select scored-suite references from the catalog instead of machine-specific paths
- add raw schema 1.1 package and processor metadata
- keep comparison, publication, and C++ producer work assigned to Issues #139–#141

## Verification

- `TestPublishedWaveVortexBenchmark` (5 tests)
- affected `TestWaveVortexBenchmark` methods (3 tests)
- MATLAB Code Analyzer on changed MATLAB files (zero findings)
- JSON parsing, whitespace, manifest, immutable-reference, artifact, and repository-scope checks

Broad benchmark and MATLAB suites were intentionally deferred under the Issue #138 verification plan.

Closes #138
